### PR TITLE
feat: add countme.projectbluefin.io weekly user count reporting

### DIFF
--- a/system_files/shared/etc/yum.repos.d/bluefin-countme.repo
+++ b/system_files/shared/etc/yum.repos.d/bluefin-countme.repo
@@ -1,0 +1,5 @@
+[bluefin-countme]
+name=Bluefin Count Me
+metalink=https://countme.projectbluefin.io/count?os=bluefin&version=$releasever&arch=$basearch
+enabled=1
+countme=1


### PR DESCRIPTION
## Summary

Ship a single `.repo` file that the **existing** `rpm-ostree-countme.timer` reads automatically — no new services, no new binaries.

The timer appends `&countme=N` (1–4 install-age bucket from the existing cookie at `/var/lib/rpm-ostree-countme/countme`) and sends a weekly GET to `countme.projectbluefin.io`.

Fedora's own repos continue reporting to Fedora unchanged — this is additive only.

### What gets sent (once per week maximum)
```
GET https://countme.projectbluefin.io/count?os=bluefin&version=42&arch=x86_64&countme=3
User-Agent: rpm-ostree (Bluefin 42; bluefin; Linux.x86_64)
```

### Infrastructure
- Worker: https://countme.projectbluefin.io (Cloudflare Workers + D1, free tier at current scale)
- Badge: `https://img.shields.io/endpoint?url=https://countme.projectbluefin.io/badge/bluefin.json`
- Source: https://github.com/castrojo/copilot-config/tree/main/countme-worker

### Opt-out
Users can opt out by setting `countme=0` in the repo file or removing it — same as Fedora countme opt-out.

- [ ] I am using an agent and I take responsibility for this PR