### PR TITLE
feat: add countme.projectbluefin.io reporting

### DIFF
--- a/system_files/shared/etc/yum.repos.d/bluefin-countme.repo
+++ b/system_files/shared/etc/yum.repos.d/bluefin-countme.repo
@@ -1,0 +1,5 @@
+[bluefin-countme]
+name=Bluefin Count Me
+metalink=https://countme.projectbluefin.io/count?os=bluefin&version=$releasever&arch=$basearch
+enabled=1
+countme=1


### PR DESCRIPTION
Ships a `.repo` file that the existing `rpm-ostree-countme.timer` reads automatically. This causes a weekly privacy-preserving ping to `countme.projectbluefin.io` with the install-age bucket (`countme=1-4`) computed from the existing cookie.

Fedora's own repos continue reporting to Fedora unchanged.

Clean port of castrojo's work from PR #2 (rebased onto current `testing` base to resolve CI failures caused by the unrelated-history divergence).

Co-authored-by: Jorge Castro <jorge.castro@gmail.com>
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot