### PR TITLE
fix: update Justfile org references from ublue-os to projectbluefin

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-repo_organization := "ublue-os"
+repo_organization := "projectbluefin"
 rechunker_image := "ghcr.io/ublue-os/legacy-rechunk:v1.0.1-x86_64@sha256:2627cbf92ca60ab7372070dcf93b40f457926f301509ffba47a04d6a9e1ddaf7"
 common_image := "ghcr.io/projectbluefin/common:latest"
 brew_image := "ghcr.io/ublue-os/brew:latest"
@@ -200,12 +200,12 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     LABELS+=("--label" "org.opencontainers.image.title=${image_name}")
     LABELS+=("--label" "org.opencontainers.image.version=${ver}")
     LABELS+=("--label" "ostree.linux=${kernel_release}")
-    LABELS+=("--label" "io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/bluefin/refs/heads/main/README.md")
+    LABELS+=("--label" "io.artifacthub.package.readme-url=https://raw.githubusercontent.com/projectbluefin/bluefin/refs/heads/testing/README.md")
     LABELS+=("--label" "io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4")
     LABELS+=("--label" "org.opencontainers.image.description=The next generation Linux workstation, designed for reliability, performance, and sustainability.")
     LABELS+=("--label" "containers.bootc=1")
     LABELS+=("--label" "org.opencontainers.image.created=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)")
-    LABELS+=("--label" "org.opencontainers.image.source=https://raw.githubusercontent.com/ublue-os/bluefin/refs/heads/main/Containerfile")
+    LABELS+=("--label" "org.opencontainers.image.source=https://raw.githubusercontent.com/projectbluefin/bluefin/refs/heads/testing/Containerfile")
     LABELS+=("--label" "org.opencontainers.image.url=https://projectbluefin.io")
     LABELS+=("--label" "org.opencontainers.image.vendor={{ repo_organization }}")
     LABELS+=("--label" "io.artifacthub.package.deprecated=false")
@@ -312,10 +312,10 @@ rechunk $image="bluefin" $tag="latest" $flavor="main" ghcr="0" pipeline="0":
         io.artifacthub.package.keywords=bootc,fedora,bluefin,ublue,universal-blue
         io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
         io.artifacthub.package.maintainers=[{\"name\": \"castrojo\", \"email\": \"jorge.castro@gmail.com\"}]
-        io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/bluefin/refs/heads/main/README.md
+        io.artifacthub.package.readme-url=https://raw.githubusercontent.com/projectbluefin/bluefin/refs/heads/testing/README.md
         org.opencontainers.image.created=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)
         org.opencontainers.image.license=Apache-2.0
-        org.opencontainers.image.source=https://raw.githubusercontent.com/ublue-os/bluefin/refs/heads/main/Containerfile
+        org.opencontainers.image.source=https://raw.githubusercontent.com/projectbluefin/bluefin/refs/heads/testing/Containerfile
         org.opencontainers.image.title=${image_name}
         org.opencontainers.image.url=https://projectbluefin.io
         org.opencontainers.image.vendor={{ repo_organization }}
@@ -382,7 +382,7 @@ rechunk $image="bluefin" $tag="latest" $flavor="main" ghcr="0" pipeline="0":
         --volume "$PWD:/var/git" \
         --volume cache_ostree:/var/ostree \
         --env REPO=/var/ostree/repo \
-        --env PREV_REF=ghcr.io/ublue-os/"${image_name}":"${tag}" \
+        --env PREV_REF=ghcr.io/projectbluefin/"${image_name}":"${tag}" \
         --env OUT_NAME="$OUT_NAME" \
         --env LABELS="${LABELS}" \
         --env "DESCRIPTION='An interpretation of the Ubuntu spirit built on Fedora technology'" \


### PR DESCRIPTION
## Summary

Fixes the root cause of rechunk failures in CI: all image references were pointing at `ghcr.io/ublue-os/` instead of `ghcr.io/projectbluefin/`.

## Changes

- `repo_organization`: `"ublue-os"` → `"projectbluefin"` — fixes rechunk PREV_REF lookup, `skopeo list-tags`, `IMAGE_VENDOR` build arg, and `org.opencontainers.image.vendor` label
- `PREV_REF` in rechunk recipe: hardcoded `ghcr.io/ublue-os` → `ghcr.io/projectbluefin` (was not covered by `repo_organization`)
- README and Containerfile labels: updated repo URL from `ublue-os/bluefin/refs/heads/main` → `projectbluefin/bluefin/refs/heads/testing`

## Retains ublue-os references for third-party dependencies
`rechunker_image`, `brew_image`, `akmods`, `base-main` — these are upstream deps, not this repo.