### PR TITLE
fix(ci): bump upload-artifact to v7 (Node.js 24)

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -266,7 +266,7 @@ jobs:
 
       - name: Upload digest artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image-digest-${{ inputs.stream_name }}-${{ matrix.base_name }}-${{ matrix.image_flavor }}
           path: /tmp/digests/


### PR DESCRIPTION
## Summary

Bumps `actions/upload-artifact` from v4 (Node.js 20) to v7.0.1 (Node.js 24).

GitHub will force Node.js 24 as default starting **June 16, 2026** — this prevents build warnings becoming failures.

- Old SHA: `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4, Node 20)
- New SHA: `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1, Node 24)