### PR TITLE
fix: ship rechunker-group-fix service for legacy-rechunk→chunkah migration

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -16,6 +16,10 @@ systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service
 systemctl enable ublue-system-setup.service
 
+# see /usr/bin/rechunker-group-fix
+# DO NOT REMOVE THIS
+systemctl enable rechunker-group-fix.service
+
 systemctl enable flatpak-preinstall.service
 
 # Updater

--- a/system_files/shared/usr/bin/rechunker-group-fix
+++ b/system_files/shared/usr/bin/rechunker-group-fix
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# To use this script, you'll want to put this in your systemd service:
+# rm /etc/gshadow
+# systemd-sysusers
+# (run this script)
+# systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
+# This will populate /etc/group successfully, and then populate /etc/gshadow
+# with any missing groups that we nuked when we removed /etc/gshadow
+
+GSHADOW_FILE="/etc/gshadow"
+GROUP_FILE="/etc/group"
+
+for f in $(cat $GROUP_FILE); do
+   cut -f1 -d':' <(echo $f) | xargs -I{} grep ^"{}" $GSHADOW_FILE &>/dev/null || \
+     echo $(cut -f1 -d':' <(echo $f)):'!*::' >> $GSHADOW_FILE
+done

--- a/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
+++ b/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
@@ -1,0 +1,32 @@
+# We have this script so that people using images with `nss-altfiles` (`/usr/lib/g{roup,shadow}`)
+# do not break their systems when rebasing to an image without that
+# This usually happens when using https://github.com/hhd-dev/rechunk then rebasing to an image without it.
+# Please DO NOT remove this unless this is fully, completely obsolete.
+# This is exactly what is making it break: https://github.com/ublue-os/legacy-rechunk/blob/1d2b0c2e99afbdc2eb06788ae28e157a88b03d70/1_prune.sh#L41-L47
+# Users WILL experience black screens and systems will NOT boot if this script malfunctions. Please test this properly and always make sure this works
+# Relevant issues:
+# - https://github.com/bootc-dev/bootc/issues/1179#issuecomment-2708305926
+# - https://github.com/ublue-os/main/issues/759
+# - https://github.com/ublue-os/bluefin-lts/issues/918
+# - https://github.com/ublue-os/image-template/issues/177
+# - https://github.com/ublue-os/aurora/issues/1468
+# - https://github.com/ublue-os/bluefin/issues/3852
+# This got created on Tue, 16 Dec 2025 00:44:58 -0300
+[Unit]
+Description=Fix groups for Legacy rechunker
+ConditionPathExists=/run/ostree-booted
+Wants=local-fs.target
+After=local-fs.target
+Before=systemd-user-sessions.service
+# Before=systemd-sysusers.service
+
+[Service]
+Type=oneshot
+ExecStart=bash -c 'touch /etc/gshadow && chmod 600 /etc/gshadow'
+ExecStart=bash -c 'rm /etc/gshadow'
+ExecStart=systemd-sysusers
+ExecStart=rechunker-group-fix
+ExecStart=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
+
+[Install]
+WantedBy=default.target multi-user.target


### PR DESCRIPTION
## Summary

Ships the `rechunker-group-fix` service and script (copied verbatim from [ublue-os/aurora](https://github.com/ublue-os/aurora/tree/main/system_files/shared)) to fix a critical boot failure when users `bootc switch` from `ghcr.io/ublue-os/bluefin` (legacy-rechunk) to `ghcr.io/projectbluefin/bluefin` (chunkah / `rpm-ostree compose build-chunked-oci`).

## The Bug

Legacy-rechunk's [`1_prune.sh:L41-L47`](https://github.com/ublue-os/legacy-rechunk/blob/1d2b0c2e99afbdc2eb06788ae28e157a88b03d70/1_prune.sh#L41-L47) moves `/etc/group` entries into `/usr/lib/group` for `nss-altfiles`. When the user switches to a chunkah image (which does **not** use `nss-altfiles`), `/etc/gshadow` becomes desynced. On first boot, `systemd-sysusers` fails:

```
systemd-sysusers[1022]: /etc/gshadow: Group "plocate" already exists.
```

Result: **black screen, no GDM** on first boot. Second boot succeeds, but users assume the image is broken and rollback.

Renner0e tested and documented this in [bluefin-lts#918](https://github.com/ublue-os/bluefin-lts/issues/918):
> "I just tested the migration off of the hdd/rechunker which causes a desync of systemd-sysusers. The first boot into the non-hdd-rechunked image will fail and won't be able to reach GDM. However if you shutdown again and then boot the same image everything will be fine afterwards. Rolling back to hdd-rechunk images also still works."

## The Fix

A `Type=oneshot` systemd service that runs on every boot and repairs `/etc/gshadow` from `/etc/group`. Idempotent — no-op once gshadow is clean.

Boot sequence:
1. Ensure `/etc/gshadow` exists with mode 600
2. Delete the desynced `/etc/gshadow`
3. `systemd-sysusers` — recreate from sysusers.d
4. `rechunker-group-fix` — sync remaining groups from `/etc/group`
5. `systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev`

## Files Changed

| File | Change |
|------|--------|
| `system_files/shared/usr/bin/rechunker-group-fix` | New — script (verbatim from Aurora) |
| `system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service` | New — service (verbatim from Aurora) |
| `build_files/base/17-cleanup.sh` | `systemctl enable rechunker-group-fix.service` |

## Test Plan

Being validated via k8s homelab migration test matrix — 4 VMs in parallel:
- **VM-1/2**: default ostree storage — `ghcr.io/ublue-os/bluefin:latest/stable` → `bootc switch → ghcr.io/projectbluefin/bluefin` → reboot → verify GDM + rechunker-group-fix.service → `bootc switch` back → verify
- **VM-3/4**: unified experimental storage — same matrix with `bootc image set-unified` pre-enabled

Evidence collected at each step: `bootc status --json`, `ostree admin status`, journal, group/gshadow counts, `systemctl is-active gdm`.

## References

- [bluefin-lts#918](https://github.com/ublue-os/bluefin-lts/issues/918) — renner0e manual test (**primary evidence**)
- [bluefin#3852](https://github.com/ublue-os/bluefin/issues/3852) — Bluefin instance
- [bootc#1179](https://github.com/bootc-dev/bootc/issues/1179) — bootc upstream
- [aurora#1468](https://github.com/ublue-os/aurora/issues/1468) — Aurora instance
- [legacy-rechunk root cause](https://github.com/ublue-os/legacy-rechunk/blob/1d2b0c2e99afbdc2eb06788ae28e157a88b03d70/1_prune.sh#L41-L47)

> ⚠️ Aurora's service file: "Users WILL experience black screens and systems will NOT boot if this script malfunctions. Please test this properly and always make sure this works"

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot