### PR TITLE
fix(ci): add packages:write to e2e reusable workflow callers

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -131,6 +131,9 @@ jobs:
   e2e:
     if: needs.dispatch.outputs.authorized == 'true'
     needs: [dispatch]
+    permissions:
+      packages: write
+      contents: read
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@12bd892e476ef930ae3240eff71402390bba8da9 # main
     with:
       image: ${{ needs.dispatch.outputs.image }}

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -43,6 +43,9 @@ jobs:
 
   run-e2e:
     needs: [e2e]
+    permissions:
+      packages: write
+      contents: read
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@12bd892e476ef930ae3240eff71402390bba8da9 # main
     with:
       image: ${{ needs.e2e.outputs.image }}


### PR DESCRIPTION
## Problem

The `e2e-dispatch.yml` workflow's `e2e` job calls the `projectbluefin/testsuite` reusable e2e workflow, which requires `packages: write` permission to push test screenshots to GHCR. The calling job only inherited `contents: read` from the workflow-level permissions, causing `startup_failure` before any jobs ran.

Same issue affected `nightly.yml` (previously fixed) and `post-testing-e2e.yml` (fixed here too).

## Fix

Added explicit `permissions: packages: write / contents: read` to the `e2e`/`run-e2e` jobs that call the reusable testsuite workflow.

## References
- Failed run: https://github.com/projectbluefin/bluefin/actions/runs/26696954501