### PR TITLE
fix: ship rechunker-group-fix service for legacy-rechunk→chunkah migration

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -16,6 +16,10 @@ systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service
 systemctl enable ublue-system-setup.service
 
+# see /usr/bin/rechunker-group-fix
+# DO NOT REMOVE THIS
+systemctl enable rechunker-group-fix.service
+
 systemctl enable flatpak-preinstall.service
 
 # Updater

--- a/system_files/shared/usr/bin/rechunker-group-fix
+++ b/system_files/shared/usr/bin/rechunker-group-fix
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# To use this script, you'll want to put this in your systemd service:
+# rm /etc/gshadow
+# systemd-sysusers
+# (run this script)
+# systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
+# This will populate /etc/group successfully, and then populate /etc/gshadow
+# with any missing groups that we nuked when we removed /etc/gshadow
+
+GSHADOW_FILE="/etc/gshadow"
+GROUP_FILE="/etc/group"
+
+for f in $(cat $GROUP_FILE); do
+   cut -f1 -d':' <(echo $f) | xargs -I{} grep ^"{}" $GSHADOW_FILE &>/dev/null || \
+     echo $(cut -f1 -d':' <(echo $f)):'!*::' >> $GSHADOW_FILE
+done

--- a/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
+++ b/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
@@ -1,0 +1,32 @@
+# We have this script so that people using images with `nss-altfiles` (`/usr/lib/g{roup,shadow}`)
+# do not break their systems when rebasing to an image without that
+# This usually happens when using https://github.com/hhd-dev/rechunk then rebasing to an image without it.
+# Please DO NOT remove this unless this is fully, completely obsolete.
+# This is exactly what is making it break: https://github.com/ublue-os/legacy-rechunk/blob/1d2b0c2e99afbdc2eb06788ae28e157a88b03d70/1_prune.sh#L41-L47
+# Users WILL experience black screens and systems will NOT boot if this script malfunctions. Please test this properly and always make sure this works
+# Relevant issues:
+# - https://github.com/bootc-dev/bootc/issues/1179#issuecomment-2708305926
+# - https://github.com/ublue-os/main/issues/759
+# - https://github.com/ublue-os/bluefin-lts/issues/918
+# - https://github.com/ublue-os/image-template/issues/177
+# - https://github.com/ublue-os/aurora/issues/1468
+# - https://github.com/ublue-os/bluefin/issues/3852
+# This got created on Tue, 16 Dec 2025 00:44:58 -0300
+[Unit]
+Description=Fix groups for Legacy rechunker
+ConditionPathExists=/run/ostree-booted
+Wants=local-fs.target
+After=local-fs.target
+Before=systemd-user-sessions.service
+# Before=systemd-sysusers.service
+
+[Service]
+Type=oneshot
+ExecStart=bash -c 'touch /etc/gshadow && chmod 600 /etc/gshadow'
+ExecStart=bash -c 'rm /etc/gshadow'
+ExecStart=systemd-sysusers
+ExecStart=rechunker-group-fix
+ExecStart=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
+
+[Install]
+WantedBy=default.target multi-user.target


### PR DESCRIPTION
## Summary

Ships a one-time migration service for users rebasing from images that used `hhd-dev/rechunk` (legacy rechunker with `nss-altfiles`) to images using `chunkah` (rpm-ostree `build-chunked-oci`).

The legacy rechunker stored groups in `/usr/lib/group` and `/usr/lib/gshadow` via `nss-altfiles`. When rebasing to an image without `nss-altfiles`, the standard `/etc/gshadow` falls out of sync with `/etc/group`, causing login failures and black screens.

## What this does

- Ships `/usr/bin/rechunker-group-fix` script that repopulates any missing entries in `/etc/gshadow`
- Ships `rechunker-group-fix.service` — a `oneshot` systemd unit that runs early on boot (before `systemd-user-sessions.service`)
- Enables the service via `17-cleanup.sh`

## References
- https://github.com/ublue-os/legacy-rechunk/blob/1d2b0c2e99afbdc2eb06788ae28e157a88b03d70/1_prune.sh#L41-L47
- https://github.com/bootc-dev/bootc/issues/1179#issuecomment-2708305926
- https://github.com/ublue-os/main/issues/759
- https://github.com/ublue-os/bluefin-lts/issues/918
- https://github.com/ublue-os/bluefin/issues/3852

## Testing
PR Validation CI passed. This is a migration path fix — systems that never used the legacy rechunker are unaffected (service exits cleanly when `/etc/gshadow` already has all groups).