### PR TITLE
fix(ci): add packages:write to weekly-promotion e2e job

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -109,6 +109,9 @@ jobs:
 
   e2e:
     needs: [verify-e2e]
+    permissions:
+      packages: write
+      contents: read
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@12bd892e476ef930ae3240eff71402390bba8da9 # main
     with:
       image: ${{ needs.verify-e2e.outputs.image }}


### PR DESCRIPTION
Same fix as PR #19 — the reusable testsuite e2e.yml requires `packages: write` to push screenshots to GHCR. Missed in the initial sweep.