### PR TITLE
chore: remove stale silverblue-main entry from image-versions.yml

### DIFF
--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,8 +1,4 @@
 images:
-  - name: silverblue-main
-    image: ghcr.io/ublue-os/silverblue-main
-    tag: latest
-    digest: sha256:7a0a6155e368390fe8acc583565cdb38849422960183724aa5fdba950a5e536e
   - name: common
     image: ghcr.io/projectbluefin/common
     tag: latest


### PR DESCRIPTION
PR #17 moved the base image from `ghcr.io/ublue-os/silverblue-main` to `quay.io/fedora-ostree-desktops/silverblue`. The Justfile only reads `common` and `brew` entries from `image-versions.yml`; the `silverblue-main` entry is dead config that may cause unnecessary Renovate PRs.

## Test plan
- Validate passes ✅
- No Justfile or workflow references `silverblue-main` in `image-versions.yml`

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot