### PR TITLE
fix: update stale ublue-os org references to projectbluefin

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -195,12 +195,12 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     LABELS+=("--label" "org.opencontainers.image.title=${image_name}")
     LABELS+=("--label" "org.opencontainers.image.version=${ver}")
     LABELS+=("--label" "ostree.linux=${kernel_release}")
-    LABELS+=("--label" "io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/bluefin/refs/heads/main/README.md")
+    LABELS+=("--label" "io.artifacthub.package.readme-url=https://raw.githubusercontent.com/projectbluefin/bluefin/refs/heads/main/README.md")
     LABELS+=("--label" "io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4")
     LABELS+=("--label" "org.opencontainers.image.description=The next generation Linux workstation, designed for reliability, performance, and sustainability.")
     LABELS+=("--label" "containers.bootc=1")
     LABELS+=("--label" "org.opencontainers.image.created=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)")
-    LABELS+=("--label" "org.opencontainers.image.source=https://raw.githubusercontent.com/ublue-os/bluefin/refs/heads/main/Containerfile")
+    LABELS+=("--label" "org.opencontainers.image.source=https://raw.githubusercontent.com/projectbluefin/bluefin/refs/heads/main/Containerfile")
     LABELS+=("--label" "org.opencontainers.image.url=https://projectbluefin.io")
     LABELS+=("--label" "org.opencontainers.image.vendor={{ repo_organization }}")
     LABELS+=("--label" "io.artifacthub.package.deprecated=false")
@@ -704,5 +704,5 @@ retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
         skopeo="skopeo"
     fi
     for image in bluefin-nvidia-open bluefin-dx-nvidia-open; do
-      $skopeo copy docker://ghcr.io/ublue-os/${image}:{{ working_tag }} docker://ghcr.io/ublue-os/${image}:{{ stream }}
+      $skopeo copy docker://ghcr.io/projectbluefin/${image}:{{ working_tag }} docker://ghcr.io/projectbluefin/${image}:{{ stream }}
     done


### PR DESCRIPTION
Update OCI labels and admin recipe that still pointed to the old upstream `ublue-os/bluefin` repository after the migration to `projectbluefin/bluefin`.

**Changes:**
- `io.artifacthub.package.readme-url`: `ublue-os` → `projectbluefin`
- `org.opencontainers.image.source`: `ublue-os` → `projectbluefin`
- `retag-nvidia-on-ghcr` admin recipe: uses `projectbluefin` GHCR org instead of `ublue-os`

**Not changed** (intentional upstream deps):
- `BREW_IMAGE` in Containerfile — brew is an ublue-os upstream image
- `verify-container` recipe default — default registry for ublue-os container verification
- `base-main` skopeo inspects — upstream manifest lookup for Fedora version detection

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot