### PR TITLE
fix: update offline docs PDF URL to projectbluefin/documentation

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -12,7 +12,7 @@ rpm --erase --nodeps kernel-devel
 
 mkdir -p /usr/share/doc/bluefin
 # Offline Bluefin documentation
-ghcurl "https://github.com/ublue-os/bluefin-docs/releases/download/0.1/bluefin.pdf" --retry 3 -o /tmp/bluefin.pdf
+ghcurl "https://github.com/projectbluefin/documentation/releases/download/0.1/bluefin.pdf" --retry 3 -o /tmp/bluefin.pdf
 install -Dm0644 -t /usr/share/doc/bluefin/ /tmp/bluefin.pdf
 
 # Footgun, See: https://github.com/ublue-os/main/issues/598


### PR DESCRIPTION
## Summary

Updates the bundled offline documentation PDF URL from the old `ublue-os/bluefin-docs` repo to the canonical `projectbluefin/documentation` location.

The old URL currently redirects (HTTP 301), so this is not breaking — but it's cleaner to use the direct URL and avoids an unnecessary redirect hop during image builds.

## Test plan

- `just check` ✅
- `shellcheck build_files/**/*.sh` ✅
- `pre-commit run --all-files` ✅
- PDF exists at new URL: `curl -I https://github.com/projectbluefin/documentation/releases/download/0.1/bluefin.pdf` → HTTP 302 (GitHub release redirect to CDN) ✅