### PR TITLE
docs: update LTS variant link to projectbluefin/bluefin-lts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,5 +49,5 @@ just/                  # Extra just recipes
 ## Related projects
 
 - Documentation: [projectbluefin/bluefin-docs](https://github.com/projectbluefin/bluefin-docs) / [docs.projectbluefin.io](https://docs.projectbluefin.io)
-- LTS variant: [ublue-os/bluefin-lts](https://github.com/ublue-os/bluefin-lts)
+- LTS variant: [projectbluefin/bluefin-lts](https://github.com/projectbluefin/bluefin-lts)
 - Common layer: [projectbluefin/common](https://github.com/projectbluefin/common)


### PR DESCRIPTION
## Summary

Update the Copilot instructions LTS reference from `ublue-os/bluefin-lts` to `projectbluefin/bluefin-lts` — the LTS variant has moved to the projectbluefin org.

> Docs-only change — will not trigger a container image build.