### PR TITLE
fix: update ublue-os org references in changelogs.py to projectbluefin

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -8,7 +8,7 @@ from typing import Any
 import re
 from collections import defaultdict
 
-REGISTRY = "ghcr.io/ublue-os/"
+REGISTRY = "ghcr.io/projectbluefin/"
 
 IMAGE_MATRIX_LATEST = {
     "experience": ["base", "dx"],
@@ -41,7 +41,7 @@ OTHER_NAMES = {
 }
 
 COMMITS_FORMAT = "### Commits\n| Hash | Subject | Author |\n| --- | --- | --- |{commits}\n\n"
-COMMIT_FORMAT = "\n| **[{short}](https://github.com/ublue-os/bluefin/commit/{githash})** | {subject} | {author} |"
+COMMIT_FORMAT = "\n| **[{short}](https://github.com/projectbluefin/bluefin/commit/{githash})** | {subject} | {author} |"
 
 CHANGELOG_TITLE = "{tag}: {pretty}"
 CHANGELOG_FORMAT = """\
@@ -73,10 +73,10 @@ For current users, type the following to rebase to this version:
 IMAGE_NAME=$(jq -r '.["image-name"]' < /usr/share/ublue-os/image-info.json)
 
 # For this Stream
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:{target}
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/$IMAGE_NAME:{target}
 
 # For this Specific Image:
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:{curr}
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/$IMAGE_NAME:{curr}
 ```
 
 ### Documentation


### PR DESCRIPTION
## Summary

Update the changelog generation script to use correct `projectbluefin` org references:

- `REGISTRY`: `ghcr.io/ublue-os/` → `ghcr.io/projectbluefin/`
- Commit links: `github.com/ublue-os/bluefin/commit/` → `github.com/projectbluefin/bluefin/commit/`
- `bootc switch` rebase instructions: `ghcr.io/ublue-os/` → `ghcr.io/projectbluefin/`

The `/usr/share/ublue-os/image-info.json` path is a filesystem standard shared across all ublue-based images and is intentionally left unchanged.

## Test plan

- `just check` ✅
- `pre-commit run --all-files` ✅