### PR TITLE
fix: correct stale refs in github config files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://docs.projectbluefin.io
     about: "User documentation, FAQ, and feature guides."
   - name: "Contribution guide"
-    url: https://github.com/projectbluefin/bluefin/blob/testing/CONTRIBUTING.md
+    url: https://github.com/projectbluefin/bluefin/blob/main/CONTRIBUTING.md
     about: "Build, validation, and workflow rules — read before opening a PR."
   - name: "Project Bluefin website"
     url: https://projectbluefin.io

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - .github/workflows/copilot-setup-steps.yml
+      - .github/copilot-setup-steps.yml
   pull_request:
     paths:
-      - .github/workflows/copilot-setup-steps.yml
+      - .github/copilot-setup-steps.yml
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.


### PR DESCRIPTION
## Summary

Two stale refs in GitHub config files:

- **`.github/ISSUE_TEMPLATE/config.yml`**: CONTRIBUTING.md contact link was pointing to `blob/testing/CONTRIBUTING.md` (old default branch). Updated to `blob/main/CONTRIBUTING.md`.
- **`.github/copilot-setup-steps.yml`**: `on.push.paths` / `on.pull_request.paths` were watching `.github/workflows/copilot-setup-steps.yml` (which doesn't exist). Corrected to the actual file path `.github/copilot-setup-steps.yml`.

## Test plan
- `just check` ✅
- `pre-commit run --all-files` ✅
- No functional code changes — config refs only