### PR TITLE
fix(ci): update testsuite pin to include boot.1.1 ostree fix

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@12bd892e476ef930ae3240eff71402390bba8da9 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@97be5c766ec4d71ae4e0773b7b1c65d0db596408 # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke


### PR DESCRIPTION
## Summary

The pinned testsuite commit (`12bd892e`) predates the canonical boot.N symlink fix (`7bcdf965`). This caused the e2e smoke test to fail with `ostree-system-generator failed with exit status 1`.

**Root cause:** bootc 1.1.x on Fedora 44 installs deployments under `boot.1.1` (versioned). The `ostree-system-generator` regex only accepts `/ostree/boot.[01]/...`. The kernel cmdline was passed `ostree=/ostree/boot.1.1/...` which the generator couldn't parse → `/var` never bind-mounted → dbus-broker / NetworkManager / sshd cascade failure → SSH never came up → Wait for SSH timeout.

The fix in the testsuite (`7bcdf965`) creates a canonical `boot.1` symlink pointing to `boot.1.1` and rewrites OSTREE_PATH before constructing KERNEL_ARGS.

Updated pin to `97be5c76` (latest main) which includes all subsequent fixes.

## Test plan
- `just check` ✅
- `pre-commit run --all-files` ✅
- Workflow file change only — no image rebuild triggered