### PR TITLE
fix(ci): update testsuite pin to include summary error_message fix

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@97be5c766ec4d71ae4e0773b7b1c65d0db596408 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e4dd0345f1b26339046cb88cbd10609bbd932583 # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke


### PR DESCRIPTION
## Summary

Pins testsuite to `e4dd0345` (latest main), which fixes `AttributeError: 'list' object has no attribute 'strip'` in the Write job summary step.

**Root cause:** `behave`'s JSON formatter emits `error_message` as a list when a step has multi-line errors. Fixed in projectbluefin/testsuite#137.

Previous pin `97be5c76` already had the `boot.1.1` ostree fix. This adds the summary write fix on top.

## Test plan
- `just check` ✅
- `pre-commit run --all-files` ✅
- Workflow file only — no image rebuild