### PR TITLE
chore(ci): update testsuite pin to 6721f614 (GNOME 50 round-2 smoke fixes)

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@74c86f1a967f51cb0c7adf3732036ae2f7b89b4c # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@6721f614cf98bc3949578c51cb9a08a2d6e3a8b9 # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke


### PR DESCRIPTION
## Summary

Updates testsuite pin in `post-testing-e2e.yml` from `74c86f1a` → `6721f614`.

Picks up testsuite PR #139 (second round of GNOME 50 compat fixes):
- Ptyxis window title `'Terminal'` accepted (GNOME 50 renamed from `'Ptyxis'`)
- `nautilus --quit` after Alt+F4 to close Nautilus background daemon
- Notification banner JS updated for GNOME 50 `_bannerBin` API; timeout 4s→10s
- Extensions app launched with `GTK_A11Y=atk-bridge` so it registers with AT-SPI
- About page falls back to all-roles scan when TEXT_ROLES find nothing
- `html_formatter`/command attrs initialized before early-return paths

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI