### PR TITLE
chore(ci): update testsuite pin to 6721f614 (GNOME 50 smoke fixes)

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e4dd0345f1b26339046cb88cbd10609bbd932583 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@6721f614cf98bc3949578c51cb9a08a2d6e3a8b9 # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke


### PR DESCRIPTION
## Summary

Updates testsuite pin in `post-testing-e2e.yml` from `e4dd0345` → `6721f614`.

Picks up testsuite PRs #138 + #139 — comprehensive GNOME 50 smoke test fixes:

**PR #138:**
- Conditional `open()` instead of `toggle()` for Quick Settings + Date Menu
- qecore key mapping patch (`leftctrl`/`leftalt`/`leftshift` evdev names)
- Multi-method app launch (`gtk-launch` → `gio launch .desktop` → fallback)
- Notification banner regex for GNOME 50 extra double-quoted results
- `bootloader-update.service` in `IGNORED_FAILED_UNITS_IN_VM`
- Wi-Fi scenario skip when no wireless interface present

**PR #139:**
- Ptyxis window title `'Terminal'` accepted (GNOME 50 renamed it)
- `nautilus --quit` after Alt+F4 to close background daemon
- Notification banner JS updated for GNOME 50 `_bannerBin` API; 10s timeout
- Extensions app launched with `GTK_A11Y=atk-bridge` for AT-SPI
- About page falls back to all-roles scan for system info text
- `context` attrs initialized before early-return paths in `before_scenario`

## Test plan

Both testsuite PRs passed lint, behave dry-run, and pytest CI before merge.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI