### PR TITLE
chore(ci): update testsuite pin to b542be5 (round-4 GNOME 50 fixes)

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@7329430675ff6dda52ae4dd980fa2ef11acbab7a # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@b542be5b9350ac721212329433e224879d3e6d6d # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke


### PR DESCRIPTION
## Summary

Bumps testsuite SHA from `7329430` to `b542be5` (PR [projectbluefin/testsuite#143](https://github.com/projectbluefin/testsuite/pull/143)).

Round-4 GNOME 50 e2e smoke test compatibility fixes:
- **Nautilus sidebar** — roles changed from `list item` → `button` in GNOME 50
- **Location check** — new custom step replacing toggle-button breadcrumb checks (now path labels)
- **Extensions** — multi-pattern `pgrep` fallback for headless environments
- **Notification banner** — demote hard assertion to warning in headless GNOME 50 QEMU

## Test plan

CI will run e2e smoke suite automatically after build.