### PR TITLE
chore(ci): update testsuite pin to 051e8cc (round-5 GNOME 50 fixes)

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@b542be5b9350ac721212329433e224879d3e6d6d # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@051e8ccd2aff03f0dc2f91169ec85c9655ee2618 # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke


### PR DESCRIPTION
## Summary

Bumps testsuite SHA from `b542be5` to `051e8cc` ([PR #146](https://github.com/projectbluefin/testsuite/pull/146)).

Round-5 GNOME 50 e2e fixes:
- **Downloads sidebar** — revert to `list item` role (it IS still list item in this GNOME 50 build)
- **Extensions** — remove pgrep fallback; AT-SPI app presence is sufficient for soft-pass
- **New folder / search bar** — demote to soft warnings in headless GNOME 50 QEMU