### PR TITLE
fix(ci): extend automerge to cover app/mergeraptor PRs

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -26,14 +26,14 @@ jobs:
             --base main \
             --state open \
             --json number,headRefOid,author \
-            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\") | .number" \
+            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\" or .author.login == \"app/mergeraptor\") | .number" \
             | head -1)
 
           if [ -z "$PR_NUMBER" ]; then
-            echo "No open Renovate PR found for SHA $HEAD_SHA — skipping"
+            echo "No open Renovate/Mergeraptor PR found for SHA $HEAD_SHA — skipping"
             echo "pr_number=" >> "$GITHUB_OUTPUT"
           else
-            echo "Found Renovate PR #$PR_NUMBER"
+            echo "Found Renovate/Mergeraptor PR #$PR_NUMBER"
             echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Problem

The `renovate-automerge.yml` workflow only matched `author.login == "renovate[bot]"` but mergeraptor PRs use `app/mergeraptor`. This meant all incoming mergeraptor dependency-update PRs were silently skipped — the automerge workflow would log "No open Renovate PR found for SHA ... — skipping" even when CI passed.

## Fix

Update the jq filter to accept both bot logins:
```jq
select(.author.login == "renovate[bot]" or .author.login == "app/mergeraptor")
```

## Verification

PRs from both `renovate[bot]` and `app/mergeraptor` will now have auto-merge enabled once `PR Validation — testsuite` passes.