### PR TITLE
fix(ci): target testing branch for PRs and Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   "extends": [
     "config:best-practices",
   ],
-  "baseBranchPatterns": ["main"],
+  "baseBranchPatterns": ["testing"],
 
   "git-submodules": {
     "enabled": true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,7 +3,7 @@ name: PR Validation — testsuite
 on:
   pull_request:
     branches:
-      - main
+      - testing
   merge_group:
 
 concurrency:


### PR DESCRIPTION
## What

Corrects CI and Renovate to land all work on `testing` (not `main`).

- `pr-validation.yml`: trigger on PRs targeting `testing`
- `renovate.json5`: `baseBranchPatterns` set to `["testing"]`

## Context

Renovate was opening dependency PRs against `main`, and the validate workflow was only running for PRs to `main`. All active development lands on `testing`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI