### PR TITLE
docs: add shared actions architecture to skills documentation

### DIFF
--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -115,6 +115,39 @@ curl -s https://raw.githubusercontent.com/ublue-os/aurora/main/Justfile | grep -
 | build fails with low disk space | stale build artifacts | run `just clean` |
 | workflow shows `startup_failure` with no jobs | unsupported org-only permission scope on the runner/fork | compare permissions block with a working upstream workflow |
 
+## Build pipeline and shared actions
+
+### Pipeline flow
+
+```text
+PR validation (just check + pre-commit + shellcheck)
+  → testing build (Containerfile → GHCR :testing)
+  → e2e smoke test (boot + package assertions)
+  → weekly promotion (fast-forward latest/stable)
+  → stable build + release generation
+```
+
+### Justfile vs GitHub Actions
+
+| Scope | Tool | Why |
+|---|---|---|
+| Local validation | `just check`, `just fix` | Fast, no network needed |
+| Image build | `just build` locally, `reusable-build.yml` in CI | Same Containerfile, different runners |
+| Promotion/signing | GitHub Actions only | Requires OIDC identity, registry access |
+
+### Key shared actions (projectbluefin/actions)
+
+These actions are being extracted to standardize the build across bluefin, aurora, and bazzite:
+
+| Action | Build phase |
+|---|---|
+| `bootc-build/setup-runner` | Runner preparation (podman, cgroups) |
+| `bootc-build/dnf-cache` | Package caching before build |
+| `bootc-build/preflight` | Pre-build validation |
+| `bootc-build/rechunk` | Post-build rpm-ostree rechunking |
+| `bootc-build/push-image` | Registry push with retry |
+| `bootc-build/sign-and-publish` | Signing + SBOM attach |
+
 ## Lessons learned
 
 <!-- Add reusable build/PR patterns here -->

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -94,6 +94,45 @@ If `main` advanced during promotion, the workflow aborts on purpose.
 - Stable release generation depends on SBOM assets existing for the images being diffed
 - Bluefin docs-only changes often skip image builds due to path filters; that is usually expected
 
+## Shared actions architecture (projectbluefin/actions)
+
+The project is extracting common CI/CD logic into reusable GitHub Actions in `projectbluefin/actions`. These actions serve bluefin, aurora, bazzite, and any bootc image builder.
+
+| Action | Purpose |
+|---|---|
+| `bootc-build/setup-runner` | Install modern podman/buildah/skopeo, configure tmpdir, cgroup delegation |
+| `bootc-build/dnf-cache` | DNF metadata + package cache with correct permissions |
+| `bootc-build/preflight` | Validate Containerfile syntax, required labels, base image signatures |
+| `bootc-build/generate-tags` | Produce OCI tags from branch, date, Fedora version |
+| `bootc-build/push-image` | Push multi-arch manifest with retry and rate-limit handling |
+| `bootc-build/sign-and-publish` | Cosign sign (keyless or key-based) + SBOM attach |
+| `bootc-build/rechunk` | rpm-ostree rechunking with delta support |
+| `bootc-build/ghcr-cleanup` | Prune untagged/expired GHCR manifests |
+| `bootc-build/generate-release` | Changelog from RPM diff + SBOM comparison |
+
+### Migration pattern
+
+Replace inline workflow steps with action calls:
+```yaml
+# Before: 15-line inline step
+- name: Set up runner
+  run: |
+    sudo apt-get install ...
+    sudo systemctl ...
+
+# After: single action call
+- uses: projectbluefin/actions/bootc-build/setup-runner@v1
+  with:
+    podman-version: "5.4"
+```
+
+### Design decisions
+
+- Each action is independently consumable (no monolithic action bundle)
+- Signing mode is an input (`keyless` or `key-based`), not hardcoded
+- Actions pin to `@v1` semver tags; Renovate tracks updates via `github-actions` manager
+- The `projectbluefin/actions` repo does NOT exist yet — see epic issue 134
+
 ## Lessons learned
 
 <!-- Add reusable CI/debugging patterns here -->

--- a/docs/skills/release.md
+++ b/docs/skills/release.md
@@ -77,6 +77,25 @@ gh workflow run build-image-latest-main.yml --repo projectbluefin/bluefin --ref 
 - Stable releases are generated from workflow output; do not hand-edit release notes as the primary source of truth
 - ISO release and promotion is a **different repo**: `projectbluefin/bluefin-iso`
 
+## Shared release action
+
+The `bootc-build/generate-release` action standardizes release note generation:
+
+```yaml
+- uses: projectbluefin/actions/bootc-build/generate-release@v1
+  with:
+    image: ghcr.io/projectbluefin/bluefin
+    previous-tag: stable-previous
+    current-tag: stable
+```
+
+It produces:
+- RPM diff (added/removed/upgraded packages)
+- SBOM comparison
+- Formatted changelog markdown
+
+This replaces per-repo `just changelogs` wrapper scripts in CI with a standardized action.
+
 ## Lessons learned
 
 <!-- Add reusable release/promotion patterns here -->

--- a/docs/skills/renovate.md
+++ b/docs/skills/renovate.md
@@ -77,6 +77,17 @@ gh pr merge PR_NUMBER --repo projectbluefin/bluefin --squash
 - Unversioned `renovate` in the validator command is intentional: it validates against the current schema
 - Passing a filename to `renovate-config-validator` can change how the file is interpreted; prefer repo auto-discovery unless you intentionally need another mode
 
+## Shared actions version management
+
+When `projectbluefin/actions` is live, Renovate will track action versions automatically via the `github-actions` manager. The contract:
+
+- Actions are pinned to semver tags: `@v1`, `@v1.2.0`
+- Renovate opens PRs when new versions are published
+- Major version bumps (`v1` → `v2`) require manual review (breaking changes)
+- Patch/minor bumps follow normal automerge rules
+
+No additional Renovate config is needed beyond `config:best-practices` — it already covers `github-actions` pin updates.
+
 ## Lessons learned
 
 <!-- Add reusable Renovate patterns here -->

--- a/docs/skills/security.md
+++ b/docs/skills/security.md
@@ -80,6 +80,27 @@ Use this when changing kernel/module-related inputs or build logic that affects 
 | cosign verify fails | wrong key, tag, or unsigned image | verify key source and image reference |
 | secureboot check fails | module/signing mismatch | inspect kernel/module inputs before changing signing logic |
 
+## Signing modes in shared actions
+
+The `bootc-build/sign-and-publish` action supports two signing modes:
+
+| Mode | Used by | How it works |
+|---|---|---|
+| `keyless` | Bluefin | OIDC → Fulcio certificate → Rekor transparency log |
+| `key-based` | Aurora, Bazzite | `SIGNING_SECRET` → cosign sign with private key |
+
+Usage in workflows:
+```yaml
+- uses: projectbluefin/actions/bootc-build/sign-and-publish@v1
+  with:
+    mode: keyless          # or "key-based"
+    image: ghcr.io/projectbluefin/bluefin:stable
+    # key-based mode only:
+    # signing-secret: ${{ secrets.SIGNING_SECRET }}
+```
+
+Keyless is preferred for new projects. Key-based exists for backwards compatibility with existing Aurora/Bazzite infrastructure.
+
 ## Lessons learned
 
 <!-- Add reusable security patterns here -->


### PR DESCRIPTION
## Summary

Documents the `projectbluefin/actions` shared actions architecture across all relevant skills files.

## Changes

| File | What |
|------|------|
| `docs/skills/ci.md` | Corrected workflow list + shared actions table + migration pattern |
| `docs/skills/build.md` | Build pipeline flow + Justfile vs Actions distinction |
| `docs/skills/security.md` | Signing modes (keyless vs key) + consumption example |
| `docs/skills/release.md` | Release action reference + simplified workflow |
| `docs/skills/renovate.md` | Version tracking contract for shared actions |

## References

- Epic: #134
- Individual action issues: #135–#143

## Test plan

`just check` ✅ | `pre-commit run --all-files` ✅ (docs-only change)