### PR TITLE
feat(ci): skopeo copy for alias tags and per-variant cache keys

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -139,6 +139,8 @@ jobs:
         with:
           path: /var/tmp/buildah-cache-*
           key: ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.architecture }}-buildah-
 
       - name: Build Image
         id: build-image
@@ -268,48 +270,38 @@ jobs:
           command: |
             set -euox pipefail
 
+            REGISTRY="${{ steps.registry_case.outputs.lowercase }}"
+            IMAGE="${{ env.IMAGE_NAME }}"
+            DEFAULT_TAG="${{ env.DEFAULT_TAG }}"
+
             rm -f "${{ env.DIGEST_FILE }}"
+
+            # Push default tag with full upload (two-push pattern for annotation stability)
+            # Workaround for https://github.com/containers/podman/issues/27796
+            sudo -E podman push \
+              --compression-format zstd:chunked \
+              --compression-level 3 \
+              --force-compression \
+              --retry 5 \
+              --retry-delay 30s \
+              "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
+
+            sudo -E podman push \
+              --compression-format zstd:chunked \
+              --compression-level 3 \
+              --force-compression \
+              --retry 5 \
+              --retry-delay 30s \
+              --digestfile "${{ env.DIGEST_FILE }}" \
+              "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
+
+            # Server-side tag copies — no re-upload of image data
             # shellcheck disable=SC2086 - word splitting on alias_tags is intentional
             for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
-              dest=${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
-              if [[ "${tag}" == "${{ env.DEFAULT_TAG }}" ]]; then
-                # First push: compress and upload layers
-                # --force-compression: re-compress even if registry already has a
-                # differently-compressed variant (required for gzip→zstd:chunked migration)
-                sudo -E podman push \
-                  --compression-format zstd:chunked \
-                  --compression-level 3 \
-                  --force-compression \
-                  --retry 5 \
-                  --retry-delay 30s \
-                  ${{ env.IMAGE_NAME }}:${tag} "${dest}"
-                # Second push: layers already in registry so manifest digest is stable
-                # Workaround for https://github.com/containers/podman/issues/27796
-                sudo -E podman push \
-                  --compression-format zstd:chunked \
-                  --compression-level 3 \
-                  --force-compression \
-                  --retry 5 \
-                  --retry-delay 30s \
-                  --digestfile "${{ env.DIGEST_FILE }}" \
-                  ${{ env.IMAGE_NAME }}:${tag} "${dest}"
-              else
-                # Push twice for annotation stability
-                # Workaround for https://github.com/containers/podman/issues/27796
-                sudo -E podman push \
-                  --compression-format zstd:chunked \
-                  --compression-level 3 \
-                  --force-compression \
-                  --retry 5 \
-                  --retry-delay 30s \
-                  ${{ env.IMAGE_NAME }}:${tag} "${dest}"
-                sudo -E podman push \
-                  --compression-format zstd:chunked \
-                  --compression-level 3 \
-                  --force-compression \
-                  --retry 5 \
-                  --retry-delay 30s \
-                  ${{ env.IMAGE_NAME }}:${tag} "${dest}"
+              if [[ "${tag}" != "${DEFAULT_TAG}" ]]; then
+                skopeo copy \
+                  "docker://${REGISTRY}/${IMAGE}:${DEFAULT_TAG}" \
+                  "docker://${REGISTRY}/${IMAGE}:${tag}"
               fi
             done
 

--- a/Justfile
+++ b/Justfile
@@ -670,15 +670,13 @@ setup-cache $image="bluefin" $tag="latest" $ghcr="0" $github_event="0":
 
     ALLOW_CACHE_WRITE="false"
 
-    BLESSED_IMAGE=bluefin-dx
-
-    if [[ "${image_name}" == "${BLESSED_IMAGE}" ]] && \
-       [[ "{{ ghcr }}" == "1" ]] && \
+    # Allow cache write for any image on schedule/workflow_dispatch pushes
+    if [[ "{{ ghcr }}" == "1" ]] && \
        [[ "${github_event}" == "workflow_dispatch" || "${github_event}" == "schedule" ]]; then
         ALLOW_CACHE_WRITE="true"
     fi
 
-    CACHE_NAME="${BLESSED_IMAGE}-${fedora_version}"
+    CACHE_NAME="${image_name}-${fedora_version}"
 
     echo "${CACHE_NAME}" "${ALLOW_CACHE_WRITE}"
 


### PR DESCRIPTION
## Summary

Two independent CI efficiency improvements:

### 1. Skopeo server-side tag copies (Refs #124)

Replace repeated `podman push` for alias tags with `skopeo copy` between registry paths. Avoids re-uploading layer data for each alias — layers are already in GHCR after the first push of `DEFAULT_TAG`. Only the manifest is transferred.

**Before:** Each alias tag triggered a full `podman push` (two-push pattern) — re-compressed and re-uploaded all layers.  
**After:** `DEFAULT_TAG` gets the two-push pattern once; all other alias tags use `skopeo copy docker:// → docker://` (manifest-only, no layer upload).

### 2. Per-variant fallback cache keys (Refs #122)

- `restore-keys` fallback added to the buildah cache — allows a partial cache hit when an exact key is missing (e.g. first build of a new Fedora version)
- Cache name is now `${image_name}-${fedora_version}` (was always `bluefin-dx-${fedora_version}`), so each variant gets its own cache slot

### Bug fix

Restores the `Update Podman` step that was accidentally removed in the original commit. Ubuntu 24.04 runners need podman from the resolute repo for zstd:chunked push and rechunker layer annotations.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify alias tags appear in GHCR after a non-PR push
- [ ] Cache restore-keys provide a warm cache on the first build after a Fedora version bump

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot