### PR TITLE
feat(build): mount tmpfs at /tmp for faster build I/O

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,6 +35,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=cache,dst=/var/cache/rpm-ostree \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=secret,id=GITHUB_TOKEN \
+    --mount=type=tmpfs,target=/tmp \
     /ctx/build_files/shared/build.sh
 
 # Makes `/opt` writeable by default


### PR DESCRIPTION
## Summary

Adds `--mount=type=tmpfs,target=/tmp` to the main `RUN` step in the Containerfile.

Build scripts write heavily to `/tmp` on every build:
- `04-install-kernel-akmods.sh`: downloads akmods/nvidia/zfs OCI layers, extracts tarballs (~200–500MB peak)
- `05-override-install.sh`: downloads starship binary and PDF docs

Without tmpfs, these writes go through the container overlay filesystem (hitting the runner's disk). With tmpfs, they use RAM — no disk I/O overhead, no overlay layers to unwind.

`/tmp` is not used for any bind mounts in this Containerfile (`ctx` is mounted at `/ctx`), so there is no conflict.

GitHub Actions runners have 14GB RAM; peak /tmp usage is ~500MB.

## Test plan

- [ ] CI passes
- [ ] Build completes without errors (all build scripts that use /tmp still work correctly since they run within the same RUN step)
- [ ] No files expected to persist from /tmp across RUN steps

Closes #133

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot