### PR TITLE
chore(ci): update testsuite pin to 05445e0 (round-6 GNOME 50 + Ptyxis soft-skip)

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -134,7 +134,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@051e8ccd2aff03f0dc2f91169ec85c9655ee2618 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@05445e0ce981ec428bb0b06e94142e711995f2a9 # main
     with:
       image: ${{ needs.dispatch.outputs.image }}
       suites: smoke,developer,vanilla-gnome

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@051e8ccd2aff03f0dc2f91169ec85c9655ee2618 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@05445e0ce981ec428bb0b06e94142e711995f2a9 # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -112,7 +112,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@051e8ccd2aff03f0dc2f91169ec85c9655ee2618 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@05445e0ce981ec428bb0b06e94142e711995f2a9 # main
     with:
       image: ${{ needs.verify-e2e.outputs.image }}
       suites: developer,vanilla-gnome


### PR DESCRIPTION
## Summary

Updates the post-testing-e2e testsuite pin from `051e8ccd` (round-5) to `05445e0` which includes 30+ commits of fixes:

- `@quarantine` on `ujust_report` scenario (was the **only failing test** in the last e2e run)  
- Ptyxis and Extensions GUI gracefully skipped when absent (PR #190)  
- Search bar quarantined (uinput not available on GnomeOS)  
- DX distrobox/podman-compose/jupyter/venv quarantined  
- zsh/fish/starship and nvidia/ujust scenarios quarantined  
- Many other GNOME 50 / round-6+ compatibility fixes  

## Why

The post-testing-e2e gate has been failing or skipping, blocking weekly promotion to `latest`/`stable`. Updating to the current testsuite main should yield a clean e2e run and unblock the pipeline.