### PR TITLE
feat(ci): allow cache writes on trusted-branch push events

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -670,9 +670,10 @@ setup-cache $image="bluefin" $tag="latest" $ghcr="0" $github_event="0":
 
     ALLOW_CACHE_WRITE="false"
 
-    # Allow cache write for any image on schedule/workflow_dispatch pushes
+    # Allow cache write on trusted-branch builds (push, schedule, workflow_dispatch).
+    # PR builds use the "pull_request" event and are excluded to prevent cache poisoning.
     if [[ "{{ ghcr }}" == "1" ]] && \
-       [[ "${github_event}" == "workflow_dispatch" || "${github_event}" == "schedule" ]]; then
+       [[ "${github_event}" == "push" || "${github_event}" == "workflow_dispatch" || "${github_event}" == "schedule" ]]; then
         ALLOW_CACHE_WRITE="true"
     fi
 


### PR DESCRIPTION
Expands cache write policy to include push events (trusted branch merges). PR builds (pull_request event) still excluded for security. Closes #109