### PR TITLE
feat(build): defer live stats fetch to runtime systemd timer

### DIFF
--- a/build_files/base/00-image-info.sh
+++ b/build_files/base/00-image-info.sh
@@ -62,12 +62,8 @@ echo "IMAGE_VERSION=\"${VERSION}\"" >> /usr/lib/os-release
 # Fix issues caused by ID no longer being fedora
 sed -i "s|^EFIDIR=.*|EFIDIR=\"fedora\"|" /usr/sbin/grub2-switch-to-blscfg
 
-# Weekly user count for fastfetch
-ghcurl https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json | jq -r ".message" > /usr/share/ublue-os/fastfetch-user-count
-
-# bazaar weekly downloads used for fastfetch
-curl -X 'GET' \
-'https://flathub.org/api/v2/stats/io.github.kolunmi.Bazaar?all=false&days=1' \
--H 'accept: application/json' | jq -r ".installs_last_7_days" | numfmt --to=si --round=nearest > /usr/share/ublue-os/bazaar-install-count
+# Ship placeholder values — refreshed at runtime by bluefin-stats-refresh.timer
+echo "…" > /usr/share/ublue-os/fastfetch-user-count
+echo "…" > /usr/share/ublue-os/bazaar-install-count
 
 echo "::endgroup::"

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -28,6 +28,9 @@ systemctl enable bootc-unified-storage.service
 # Updater
 systemctl enable uupd.timer
 
+# Refresh community stats (user count, Bazaar downloads) for fastfetch
+systemctl enable bluefin-stats-refresh.timer
+
 #disable the old rpm-ostreed-automatic.timer
 systemctl disable rpm-ostreed-automatic.timer
 

--- a/system_files/shared/usr/lib/systemd/system/bluefin-stats-refresh.service
+++ b/system_files/shared/usr/lib/systemd/system/bluefin-stats-refresh.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Refresh Bluefin community stats for fastfetch
+Documentation=https://projectbluefin.io
+After=network-online.target
+Wants=network-online.target
+ConditionPathIsReadWrite=/var/cache/bluefin
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/mkdir -p /var/cache/bluefin
+ExecStart=/usr/libexec/bluefin-refresh-stats
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/shared/usr/lib/systemd/system/bluefin-stats-refresh.timer
+++ b/system_files/shared/usr/lib/systemd/system/bluefin-stats-refresh.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodically refresh Bluefin community stats for fastfetch
+Documentation=https://projectbluefin.io
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1d
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/system_files/shared/usr/libexec/bluefin-refresh-stats
+++ b/system_files/shared/usr/libexec/bluefin-refresh-stats
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+# Refresh Bluefin community stats used by fastfetch.
+# Writes to /var/cache/bluefin/ so updates survive across reboots
+# without requiring changes to the immutable /usr layer.
+
+set -euo pipefail
+
+CACHE_DIR=/var/cache/bluefin
+mkdir -p "${CACHE_DIR}"
+
+# User count from ublue-os/countme
+if count=$(curl -sf --retry 3 --max-time 10 \
+    https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json \
+    | jq -r '.message'); then
+    echo "${count}" > "${CACHE_DIR}/fastfetch-user-count"
+fi
+
+# Bazaar weekly downloads from Flathub
+if installs=$(curl -sf --retry 3 --max-time 10 \
+    'https://flathub.org/api/v2/stats/io.github.kolunmi.Bazaar?all=false&days=1' \
+    | jq -r '.installs_last_7_days' \
+    | numfmt --to=si --round=nearest); then
+    echo "${installs}" > "${CACHE_DIR}/bazaar-install-count"
+fi


### PR DESCRIPTION
## Summary

Removes live API calls from `00-image-info.sh` that fetched user count and Bazaar download stats on every build. These calls added 3-6s of latency, created network dependencies, and made builds non-reproducible (same commit → different rootfs depending on when built).

### Changes

- **`00-image-info.sh`**: Replace live API calls with static `…` placeholder
- **`bluefin-stats-refresh.service`**: Oneshot systemd service that fetches fresh stats from GitHub/Flathub and writes to `/var/cache/bluefin/` (writable, persistent)
- **`bluefin-stats-refresh.timer`**: Triggers 2min after boot, then daily. Uses `Persistent=true` so missed runs are caught on next boot.
- **`/usr/libexec/bluefin-refresh-stats`**: Fetch script with retries and graceful failure (never breaks boot)
- **`17-cleanup.sh`**: Enable the timer at build time

### Why /var/cache/bluefin/
The `/usr` layer is immutable at runtime in bootc. Writing to `/var/cache/bluefin/` allows the stats to be updated without requiring a new image build.

Closes #125
Part of Epic #104 (Build Efficiency)