### PR TITLE
feat(ci): add Containerfile lint via hadolint to PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -39,6 +39,12 @@ jobs:
           shopt -s globstar nullglob
           shellcheck build_files/**/*.sh
 
+      - name: Lint Containerfile
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: Containerfile
+          config: .hadolint.yaml
+
       - name: Run pre-commit
         shell: bash
         run: pre-commit run --all-files

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,6 @@
+# Hadolint configuration for Bluefin Containerfile
+# https://github.com/hadolint/hadolint
+ignore:
+  - DL3006  # Always tag the version of an image explicitly — images use ARG for dynamic tags
+  - DL3059  # Multiple consecutive RUN instructions — intentional single-RUN design until #112
+  - SC2312  # Consider invoking this command separately — style preference


### PR DESCRIPTION
Adds hadolint to `pr-validation.yml` for fast Containerfile linting (~5s). Includes `.hadolint.yaml` ignoring rules that don't apply to bootc images (DL3006 dynamic ARG tags, DL3059 single-RUN design). Closes #116