### PR TITLE
feat(build): use bootc container lint --fatal-warnings

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,4 +45,4 @@ RUN rm -rf /opt && ln -s /var/opt /opt
 
 CMD ["/sbin/init"]
 
-RUN bootc container lint
+RUN bootc container lint --fatal-warnings


### PR DESCRIPTION
## Summary

Upgrade `bootc container lint` to `bootc container lint --fatal-warnings` so any warning-class issue fails the build instead of silently shipping.

This catches regressions around:
- `baseimage-composefs`: composefs not properly configured
- `sysusers`: missing sysusers.d entries for system users
- `var-tmpfiles`: /var content that should use tmpfiles.d

## Why Now
PR validation now includes hadolint (#157). Adding fatal lint as the next safety layer ensures warnings can't accumulate without explicit acknowledgment.

Closes #115

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot