### PR TITLE
feat(build): skip weak dependencies in dnf installs

### DIFF
--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -7,6 +7,9 @@ echo "::group:: Copy Files"
 # Speeds up local builds
 dnf config-manager setopt keepcache=1
 
+# Skip weak dependencies for a smaller, faster image
+dnf config-manager setopt install_weak_deps=0
+
 # Keep *-logos in RPM DB for downstream package installations
 # We are not allowed to ship an empty fedora-logos package
 dnf -y swap fedora-logos generic-logos


### PR DESCRIPTION
## Summary

Add `install_weak_deps=0` to the global dnf config in `build_files/shared/build.sh`.

Weak dependencies (`Recommends:`/`Suggests:`) are typically documentation, optional language packs, and debug tooling — not needed in an immutable container image.

Any package that genuinely requires a formerly-weak dep will have it declared as a hard `Requires:` — if it doesn't, the dep is optional by design.

### Expected impact
- 50–150 MB reduction in install footprint (varies per distro release)
- Faster DNF transactions (fewer packages to resolve and install)
- Smaller final image layer

Closes #128

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot