### PR TITLE
feat(build): pin starship version for deterministic builds

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,19 @@
       ],
       datasourceTemplate: 'docker',
     },
+    // Track pinned binary download versions in image-versions.yml.
+    // Each pinned entry is preceded by a:
+    //   # renovate: datasource=github-releases depName=owner/repo
+    // comment so Renovate can discover and update the version string.
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^image-versions\\.yml$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+\\w+: "(?<currentValue>[^"]+)"',
+      ],
+    },
     // Track GNOME extension submodules that pin to a release tag via the
     // `branch =` field in .gitmodules. Renovate's git-submodules manager
     // alone can't see new tags because tags don't move; this rewrites the

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -32,7 +32,8 @@ ghcurl "https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads
 chmod +x /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 
 # Starship Shell Prompt
-ghcurl "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz" --retry 3 -o /tmp/starship.tar.gz
+STARSHIP_VERSION="$(grep -A1 'datasource=github-releases depName=starship/starship' /ctx/image-versions.yml | grep 'starship:' | awk '{print $2}' | tr -d '"')"
+ghcurl "https://github.com/starship/starship/releases/download/v${STARSHIP_VERSION}/starship-x86_64-unknown-linux-gnu.tar.gz" --retry 3 -o /tmp/starship.tar.gz
 tar -xzf /tmp/starship.tar.gz -C /tmp
 install -c -m 0755 /tmp/starship /usr/bin
 

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -7,3 +7,8 @@ images:
     image: ghcr.io/ublue-os/brew
     tag: latest
     digest: sha256:48be52bde586f6637ce83f128bf9ba1580b7e4de4d093fed94bec587082850ce
+
+# Pinned versions for direct binary downloads (managed by Renovate)
+downloads:
+  # renovate: datasource=github-releases depName=starship/starship
+  starship: "1.25.1"


### PR DESCRIPTION
## Summary

Replaces the floating `releases/latest` starship download with a pinned version (`1.25.1`) tracked in `image-versions.yml`.

### What changes
- `image-versions.yml`: new `downloads:` section with pinned starship version + Renovate comment annotation
- `05-override-install.sh`: reads version from `image-versions.yml` at build time; uses `/download/v${VERSION}/` URL
- `.github/renovate.json5`: new custom regex manager that picks up `# renovate: datasource=... depName=...` annotations in `image-versions.yml`

### Why
Two builds from the same commit could install different starship versions if a release landed between builds. This was the last floating download URL in the build scripts (live GitHub/Flathub stats were addressed in PR #156).

Renovate will now open a PR automatically whenever a new starship release is published.

Closes #107

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot