### PR TITLE
fix(ci): remove merge_group trigger; update Syft to v1.44.0

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,6 +1,5 @@
 name: Latest Images
 on:
-  merge_group:
   pull_request:
     branches:
       - latest

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -184,7 +184,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          syft-version: v1.39.0
+          syft-version: v1.44.0
 
       - name: Generate SBOM
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

Two small CI fixes:

### 1. Remove `merge_group:` from Latest Images workflow (#71)
The unfiltered `merge_group:` trigger caused merge queue temporary branches to publish to `:latest` because `reusable-build.yml` pushes for any non-`pull_request` event. Removed the trigger entirely — latest builds should only run on direct pushes to the `latest` branch.

### 2. Update Syft from v1.39.0 → v1.44.0 (#98)
5 minor releases of bug fixes, new package catalogers, and improved OS detection for SBOM generation.

Closes #71
Closes #98

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot