### PR TITLE
refactor: standardize on dnf5 across all build scripts

### DIFF
--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -168,8 +168,8 @@ esac
 
 # Install Fedora, Tailscale, and multimedia packages together while keeping COPR packages isolated.
 echo "Installing ${#FEDORA_PACKAGES[@]} Fedora packages plus Tailscale and multimedia packages..."
-dnf config-manager addrepo --from-repofile=https://pkgs.tailscale.com/stable/fedora/tailscale.repo
-dnf config-manager setopt tailscale-stable.enabled=0
+dnf5 config-manager addrepo --from-repofile=https://pkgs.tailscale.com/stable/fedora/tailscale.repo
+dnf5 config-manager setopt tailscale-stable.enabled=0
 dnf5 -y install \
     --enablerepo='tailscale-stable' \
     --enablerepo='fedora-multimedia' \

--- a/build_files/base/04-install-kernel-akmods.sh
+++ b/build_files/base/04-install-kernel-akmods.sh
@@ -58,7 +58,7 @@ dnf5 -y install \
 
 dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra
 
-dnf copr enable -y ublue-os/akmods
+dnf5 copr enable -y ublue-os/akmods
 
 mkdir -p /etc/pki/akmods/certs
 ghcurl "https://github.com/ublue-os/akmods/raw/refs/heads/main/certs/public_key.der" --retry 3 -Lo /etc/pki/akmods/certs/akmods-ublue.der
@@ -170,6 +170,6 @@ if [[ "${AKMODS_FLAVOR}" =~ coreos ]]; then
     echo "zfs" >/usr/lib/modules-load.d/zfs.conf
 fi
 
-dnf copr disable -y ublue-os/akmods
+dnf5 copr disable -y ublue-os/akmods
 
 echo "::endgroup::"

--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -69,16 +69,16 @@ dnf5 -y install "${FEDORA_PACKAGES[@]}"
 
 # rocm doesn't work well on nvidia
 if [[ ! "${IMAGE_NAME}" =~ nvidia ]]; then
-  dnf install -y \
+  dnf5 install -y \
     rocm-hip \
     rocm-opencl \
     rocm-smi \
     rocminfo
 fi
 
-dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+dnf5 config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
 sed -i "s/enabled=.*/enabled=0/g" /etc/yum.repos.d/docker-ce.repo
-dnf -y install --enablerepo=docker-ce-stable \
+dnf5 -y install --enablerepo=docker-ce-stable \
     containerd.io \
     docker-buildx-plugin \
     docker-ce \
@@ -95,7 +95,7 @@ gpgcheck=1
 gpgkey=https://packages.microsoft.com/keys/microsoft.asc
 EOF
 sed -i "s/enabled=.*/enabled=0/g" /etc/yum.repos.d/vscode.repo
-dnf -y install --enablerepo=code \
+dnf5 -y install --enablerepo=code \
     code
 
 

--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -5,14 +5,14 @@ set -eoux pipefail
 echo "::group:: Copy Files"
 
 # Speeds up local builds
-dnf config-manager setopt keepcache=1
+dnf5 config-manager setopt keepcache=1
 
 # Skip weak dependencies for a smaller, faster image
-dnf config-manager setopt install_weak_deps=0
+dnf5 config-manager setopt install_weak_deps=0
 
 # Keep *-logos in RPM DB for downstream package installations
 # We are not allowed to ship an empty fedora-logos package
-dnf -y swap fedora-logos generic-logos
+dnf5 -y swap fedora-logos generic-logos
 rpm --erase --nodeps --nodb generic-logos
 
 # Copy Files to Container

--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -5,8 +5,8 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 # Revert back to upstream defaults
-dnf config-manager setopt keepcache=0
-dnf versionlock clear
+dnf5 config-manager setopt keepcache=0
+dnf5 versionlock clear
 
 # This comes last because we can't *ever* afford to ship fedora flatpaks on the image
 systemctl disable flatpak-add-fedora-repos.service


### PR DESCRIPTION
## Summary

Replace all remaining `dnf` calls with `dnf5` in build scripts. Bluefin targets Fedora 42+ where `dnf5` is the default.

Files updated:
- `build_files/shared/build.sh`: `dnf config-manager`, `dnf -y swap`
- `build_files/shared/clean-stage.sh`: `dnf config-manager setopt keepcache`, `dnf versionlock`
- `build_files/base/03-packages.sh`: `dnf config-manager addrepo`, `dnf -y remove`
- `build_files/base/04-install-kernel-akmods.sh`: `dnf copr enable/disable`
- `build_files/dx/00-dx.sh`: `dnf install`, `dnf config-manager`

Closes #76

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot