### PR TITLE
feat: add .dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Exclude files that are not needed in the container build context.
+# This reduces the context size sent to the container daemon on each build.
+
+# Version control
+.git
+
+# GitHub configuration and CI workflows
+.github
+
+# Documentation
+docs
+*.md
+LICENSE
+
+# Tooling configuration
+.hadolint.yaml
+.pre-commit-config.yaml
+.devcontainer.json
+.editorconfig


### PR DESCRIPTION
## Summary

Add `.dockerignore` to exclude files not needed inside the container at build time:
- `.git/` — VCS history (~10-100 MB, entirely useless in container)
- `.github/` — CI workflows, issue templates
- `docs/`, `*.md`, `LICENSE` — documentation
- Tooling configs (`.hadolint.yaml`, `.pre-commit-config.yaml`, etc.)

The `build_files/`, `system_files/`, `Containerfile`, `Justfile`, and `image-versions.yml` are all still included.

Closes #93

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot