### PR TITLE
refactor: create shared package-lib.sh for common install patterns

### DIFF
--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -44,6 +44,8 @@ dnf5 versionlock add "${OVERRIDES[@]}"
 
 # shellcheck source=build_files/shared/copr-helpers.sh
 source /ctx/build_files/shared/copr-helpers.sh
+# shellcheck source=build_files/shared/package-lib.sh
+source /ctx/build_files/shared/package-lib.sh
 
 # NOTE:
 # Packages are split into FEDORA_PACKAGES and COPR_PACKAGES to prevent
@@ -207,14 +209,7 @@ EXCLUDED_PACKAGES=(
 )
 
 # Remove excluded packages if they are installed
-if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    readarray -t INSTALLED_EXCLUDED < <(rpm -qa --queryformat='%{NAME}\n' "${EXCLUDED_PACKAGES[@]}" 2>/dev/null || true)
-    if [[ "${#INSTALLED_EXCLUDED[@]}" -gt 0 ]]; then
-        dnf -y remove "${INSTALLED_EXCLUDED[@]}"
-    else
-        echo "No excluded packages found to remove."
-    fi
-fi
+remove_excluded_packages EXCLUDED_PACKAGES
 
 ## Pins and Overrides
 ## Use this section to pin packages in order to avoid regressions

--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -189,6 +189,7 @@ copr_install_isolated "ublue-os/packages" \
     "oversteer-udev"
 
 # Packages to exclude - common to all versions
+# shellcheck disable=SC2034  # passed by name to remove_excluded_packages
 EXCLUDED_PACKAGES=(
     default-fonts-cjk-sans
     fedora-bookmarks

--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -7,6 +7,8 @@ set -ouex pipefail
 # Load secure COPR helpers
 # shellcheck source=build_files/shared/copr-helpers.sh
 source /ctx/build_files/shared/copr-helpers.sh
+# shellcheck source=build_files/shared/package-lib.sh
+source /ctx/build_files/shared/package-lib.sh
 
 # DX packages from Fedora repos - common to all versions
 FEDORA_PACKAGES=(
@@ -64,8 +66,7 @@ FEDORA_PACKAGES=(
     ydotool
 )
 
-echo "Installing ${#FEDORA_PACKAGES[@]} DX packages from Fedora repos..."
-dnf5 -y install "${FEDORA_PACKAGES[@]}"
+install_fedora_packages FEDORA_PACKAGES
 
 # rocm doesn't work well on nvidia
 if [[ ! "${IMAGE_NAME}" =~ nvidia ]]; then
@@ -110,14 +111,7 @@ case "$FEDORA_MAJOR_VERSION" in
 esac
 
 # Remove excluded packages if they are installed
-if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    readarray -t INSTALLED_EXCLUDED < <(rpm -qa --queryformat='%{NAME}\n' "${EXCLUDED_PACKAGES[@]}" 2>/dev/null || true)
-    if [[ "${#INSTALLED_EXCLUDED[@]}" -gt 0 ]]; then
-        dnf5 -y remove "${INSTALLED_EXCLUDED[@]}"
-    else
-        echo "No excluded packages found to remove."
-    fi
-fi
+remove_excluded_packages EXCLUDED_PACKAGES
 
 systemctl enable docker.socket
 systemctl enable podman.socket

--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -11,6 +11,7 @@ source /ctx/build_files/shared/copr-helpers.sh
 source /ctx/build_files/shared/package-lib.sh
 
 # DX packages from Fedora repos - common to all versions
+# shellcheck disable=SC2034  # passed by name to install_fedora_packages
 FEDORA_PACKAGES=(
     android-tools
     bcc
@@ -101,6 +102,7 @@ dnf -y install --enablerepo=code \
 
 
 # DX packages to exclude - common to all versions
+# shellcheck disable=SC2034  # passed by name to remove_excluded_packages
 EXCLUDED_PACKAGES=()
 
 # Version-specific package exclusions for DX

--- a/build_files/shared/package-lib.sh
+++ b/build_files/shared/package-lib.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/bash
+# Shared package management helpers for build scripts.
+# Source this file to use the helpers.
+# Note: COPR-specific helpers stay in copr-helpers.sh (security boundary).
+
+# Install packages from Fedora (or other already-enabled) repos.
+# Usage: install_fedora_packages PACKAGES_ARRAY_NAME
+install_fedora_packages() {
+    local -n _packages=$1
+    if [[ ${#_packages[@]} -eq 0 ]]; then
+        echo "install_fedora_packages: no packages to install"
+        return 0
+    fi
+    echo "Installing ${#_packages[@]} packages from Fedora repos..."
+    dnf5 -y install "${_packages[@]}"
+}
+
+# Remove packages that conflict with or are replaced by image content.
+# Silently skips any packages that are not installed.
+# Usage: remove_excluded_packages PACKAGES_ARRAY_NAME
+remove_excluded_packages() {
+    local -n _packages=$1
+    if [[ ${#_packages[@]} -eq 0 ]]; then
+        return 0
+    fi
+    readarray -t _installed < <(rpm -qa --queryformat='%{NAME}\n' "${_packages[@]}" 2>/dev/null || true)
+    if [[ ${#_installed[@]} -gt 0 ]]; then
+        echo "Removing ${#_installed[@]} excluded packages: ${_installed[*]}"
+        dnf5 -y remove "${_installed[@]}"
+    else
+        echo "No excluded packages found to remove."
+    fi
+}
+
+# Assert that every package in the list is installed; exit 1 if any are missing.
+# Usage: assert_packages_present PACKAGES_ARRAY_NAME
+assert_packages_present() {
+    local -n _packages=$1
+    local -a missing=()
+    for pkg in "${_packages[@]}"; do
+        if ! rpm -q "$pkg" &>/dev/null; then
+            missing+=("$pkg")
+        fi
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: Required packages not installed: ${missing[*]}"
+        exit 1
+    fi
+    echo "✅ All ${#_packages[@]} required packages are present."
+}


### PR DESCRIPTION
## Summary

Create `build_files/shared/package-lib.sh` with three shared helpers:

| Helper | Purpose |
|---|---|
| `install_fedora_packages` | Bulk install from repos with count logging |
| `remove_excluded_packages` | Safe removal of conflict packages (RPM-presence check first) |
| `assert_packages_present` | Fail-fast validation for required packages |

### Refactored callers
- `03-packages.sh`: exclusion removal now calls `remove_excluded_packages EXCLUDED_PACKAGES`
- `00-dx.sh`: Fedora DX install now calls `install_fedora_packages FEDORA_PACKAGES`; exclusion removal uses shared helper

### Not changed
The complex `03-packages.sh` transaction (Fedora + Tailscale + multimedia in one dnf5 call) stays as-is — preserving the consolidation from PR #150. COPR isolation stays in `copr-helpers.sh` (security boundary maintained per issue).

Closes #95

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot