### PR TITLE
fix(ci): validate ref on manual workflow dispatches

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   build-image-latest:
     name: Build Latest Images
+    if: github.event_name != 'workflow_dispatch' || github.ref_name == 'latest'
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     strategy:

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   build-image-stable:
     name: Build Stable Images
+    if: github.event_name != 'workflow_dispatch' || github.ref_name == 'stable'
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     strategy:

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -61,6 +61,7 @@ jobs:
     needs: [detect-changes]
     if: |
       always() &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
     uses: ./.github/workflows/reusable-build.yml


### PR DESCRIPTION
## Summary

Prevent accidental publishes from wrong branches when using `workflow_dispatch`.

| Workflow | Allowed dispatch ref |
|---|---|
| `build-image-testing.yml` | `main` only |
| `build-image-stable.yml` | `stable` only |
| `build-image-latest-main.yml` | `latest` only |

### Implementation
Added `if: github.event_name != 'workflow_dispatch' || github.ref_name == 'BRANCH'` to each build job. All other triggers (push, pull_request, workflow_call, schedule) are unaffected.

Closes #85

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot