### PR TITLE
fix(ci): add cosign signing retry and post-push verification

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -450,10 +450,24 @@ jobs:
 
       - name: Sign container image
         if: github.event_name != 'pull_request'
-        run: |
-          cosign sign -y "${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}"
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cosign sign -y "${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}"
         env:
           TAGS: ${{ steps.digest.outputs.digest }}
+
+      - name: Verify signature
+        if: github.event_name != 'pull_request'
+        run: |
+          cosign verify \
+            --certificate-identity-regexp="https://github.com/${{ github.repository }}/" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            "${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${{ steps.digest.outputs.digest }}"
+        env:
+          COSIGN_EXPERIMENTAL: "1"
 
       - name: Install ORAS
         if: github.event_name != 'pull_request'
@@ -487,12 +501,16 @@ jobs:
 
       - name: Sign SBOM OCI Artifact
         if: github.event_name != 'pull_request'
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cosign sign -y "${LOWERCASE}/${IMAGE_NAME}@${SBOM_DIGEST}"
         env:
           LOWERCASE: ${{ steps.registry_case.outputs.lowercase }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
-        run: |
-          cosign sign -y "${LOWERCASE}/${IMAGE_NAME}@${SBOM_DIGEST}"
 
       - name: Attestation
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

Two cosign reliability improvements:

### 1. Retry cosign sign on transient Rekor failures (#60)
Wraps both `cosign sign` calls (image + SBOM) in `nick-fields/retry@v3`:
- 3 attempts
- 30s wait between retries  
- 5-minute timeout

Prevents the `getLogEntryByUuidNotFound` 404 transient failure that leaves images pushed-but-unsigned, breaking `ujust update` for all users on the affected stream.

### 2. Verify signature after signing (#97)
Adds a `cosign verify` step after the image is signed using keyless OIDC identity, confirming the signature is accessible in the registry before proceeding to SBOM and attestation.

Closes #60
Closes #97

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot