### PR TITLE
docs: add SECURITY.md and fix stale ublue-os references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Bluefin's mission is to provide a robust, cloud-native desktop operating system 
 - **💬 [Discussions](https://community.projectbluefin.io/)** - Community forum (strongly recommended!)
 - **📖 [Documentation](https://docs.projectbluefin.io/)** - Documentation and User Guides
 - **🔧 [Contributing Guide](https://docs.projectbluefin.io/contributing)** - How to contribute to the project
+- **🔒 [Security Policy](SECURITY.md)** - Reporting vulnerabilities
 
 ## Getting Started
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+| Branch | Supported |
+|---|---|
+| `testing` (main) | ✅ Active development |
+| `stable` | ✅ Security fixes |
+| `latest` | ✅ Security fixes |
+| `gts` | ✅ Security fixes |
+| Older releases | ❌ |
+
+## Reporting a Vulnerability
+
+**Please use [GitHub Private Vulnerability Reporting](https://github.com/projectbluefin/bluefin/security/advisories/new) to report security issues.**
+
+This ensures your report is handled confidentially before public disclosure.
+
+> Do **not** open a public GitHub issue for security vulnerabilities.
+
+### What to include
+
+- Description of the vulnerability and its potential impact
+- Steps to reproduce or proof-of-concept
+- Affected versions/streams
+- Any suggested mitigations (optional)
+
+## Response Timeline
+
+| Stage | Target |
+|---|---|
+| Initial acknowledgment | 48 hours |
+| Assessment complete | 7 days |
+| Fix/mitigation delivered | 30 days (critical), 90 days (high/medium) |
+| Public disclosure | After fix ships to stable/latest |
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Reporters are credited in the release notes unless they request anonymity. We will not take legal action against researchers who follow this policy.
+
+## Scope
+
+This policy covers the `projectbluefin/bluefin` OCI image build pipeline, including:
+
+- `Containerfile` and build scripts in `build_files/`
+- GitHub Actions workflows in `.github/workflows/`
+- Supply chain: base image pinning, COPR repos, binary downloads
+- cosign signing and image integrity
+
+**Out of scope:** Third-party packages bundled in the image (report upstream), Flatpaks (report to Flathub), Homebrew packages (report to upstream tap).

--- a/docs/skills/security.md
+++ b/docs/skills/security.md
@@ -49,12 +49,12 @@ Bluefin verifies upstream containers before building.
 
 From the Justfile:
 ```bash
-just verify-container IMAGE ghcr.io/ublue-os cosign.pub
+just verify-container IMAGE ghcr.io/projectbluefin cosign.pub
 ```
 
 Manual form:
 ```bash
-cosign verify --key cosign.pub ghcr.io/ublue-os/IMAGE:TAG
+cosign verify --key cosign.pub ghcr.io/projectbluefin/IMAGE:TAG
 ```
 
 ## Secureboot checks


### PR DESCRIPTION
## Summary

### SECURITY.md (#72)
Add a vulnerability disclosure policy with:
- Supported versions table (testing/stable/latest/gts)
- GitHub Private Vulnerability Reporting as the preferred channel
- Response timeline (48h ack, 7d assessment, 30–90d fix)
- Coordinated disclosure policy and scope definition
- Link added to README

### Fix stale ublue-os references (#79)
- `docs/skills/security.md`: update `ghcr.io/ublue-os` → `ghcr.io/projectbluefin`

Note: External service URLs (star-history, LFX badge, countme badge) still reference the old repo — those services need to be updated on their respective platforms.

Closes #72
Closes #79

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot