### PR TITLE
security: restrict GITHUB_TOKEN to GitHub-owned hosts in ghcurl (CWE-201)

### DIFF
--- a/build_files/shared/utils/ghcurl
+++ b/build_files/shared/utils/ghcurl
@@ -15,7 +15,16 @@ URL="$1"
 shift
 OPTIONS=("$@")
 
-if [[ -n "$AUTH_HEADER" ]]; then
+# Only send the auth header to GitHub-owned hosts to prevent token leakage (CWE-201).
+# Matches: github.com, raw.githubusercontent.com, api.github.com, ghcr.io, and subdomains.
+_is_github_host() {
+  local url="$1"
+  local host
+  host="$(echo "${url}" | sed -E 's|^https?://([^/]+).*|\1|')"
+  [[ "${host}" =~ (^|\.)(github\.com|githubusercontent\.com|ghcr\.io)$ ]]
+}
+
+if [[ -n "$AUTH_HEADER" ]] && _is_github_host "$URL"; then
   curl -sSL -H "$AUTH_HEADER" "${OPTIONS[@]}" "$URL"
 else
   curl -sSL "${OPTIONS[@]}" "$URL"


### PR DESCRIPTION
## Summary

Fixes #62.

The `ghcurl` helper was sending `Authorization: Bearer $GITHUB_TOKEN` to every URL, leaking the build token to third-party hosts (e.g. `src.fedoraproject.org`).

Add a `_is_github_host()` guard: the auth header is only attached when the URL host ends with `github.com`, `githubusercontent.com`, or `ghcr.io`. Third-party URLs fall back to unauthenticated `curl` as before.

## Test plan
- Shellcheck passes via `just check`
- Build: `ghcurl https://src.fedoraproject.org/...` will no longer include the auth header