### PR TITLE
security: verify starship binary checksum before extraction (CWE-494)

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -33,7 +33,11 @@ chmod +x /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 
 # Starship Shell Prompt
 STARSHIP_VERSION="$(grep -A1 'datasource=github-releases depName=starship/starship' /ctx/image-versions.yml | grep 'starship:' | awk '{print $2}' | tr -d '"')"
-ghcurl "https://github.com/starship/starship/releases/download/v${STARSHIP_VERSION}/starship-x86_64-unknown-linux-gnu.tar.gz" --retry 3 -o /tmp/starship.tar.gz
+STARSHIP_BASE="https://github.com/starship/starship/releases/download/v${STARSHIP_VERSION}/starship-x86_64-unknown-linux-gnu.tar.gz"
+ghcurl "${STARSHIP_BASE}"        --retry 3 -o /tmp/starship.tar.gz
+ghcurl "${STARSHIP_BASE}.sha256" --retry 3 -o /tmp/starship.tar.gz.sha256
+# Verify download integrity before extracting (CWE-494)
+(cd /tmp && sha256sum -c starship.tar.gz.sha256)
 tar -xzf /tmp/starship.tar.gz -C /tmp
 install -c -m 0755 /tmp/starship /usr/bin
 


### PR DESCRIPTION
## Summary

Fixes #66.

`05-override-install.sh` was downloading the starship binary and extracting it without verifying integrity. An attacker who compromises the CDN or the network path could serve a malicious binary.

Download the co-released `.sha256` file and validate with `sha256sum -c` before untarring.

## Changes
- Download `starship-x86_64-unknown-linux-gnu.tar.gz.sha256` alongside the tarball
- Verify with `(cd /tmp && sha256sum -c starship.tar.gz.sha256)` — aborts build on mismatch