### PR TITLE
fix(ci): upload SBOM as GitHub Actions artifact for release workflow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -200,6 +200,20 @@ jobs:
                             "${MATRIX_IMAGE_FLAVOR}" \
                             "${SYFT_CMD}"
 
+      - name: Upload SBOM as release artifact
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/sbom-upload
+          cp "sbom_out/${{ env.IMAGE_NAME }}/sbom.json" "/tmp/sbom-upload/${{ env.IMAGE_NAME }}.sbom.json"
+
+      - name: Upload SBOM artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sbom-${{ env.IMAGE_NAME }}
+          path: /tmp/sbom-upload/
+          retention-days: 7
+
       - name: Record rechunk start time
         id: rechunk-timing
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

Fixes #92.

`generate-release.yml` downloads `sbom-*` artifacts to attach to GitHub releases, but `reusable-build.yml` only uploaded OCI dirs and image digests — no SBOM artifacts were uploaded.

## Changes

Added two steps after "Generate SBOM" in `reusable-build.yml`:
1. Copy `sbom_out/IMAGE_NAME/sbom.json` → `/tmp/sbom-upload/IMAGE_NAME.sbom.json`
2. Upload via `actions/upload-artifact` with name `sbom-IMAGE_NAME` (matches the `sbom-*` download pattern)

Retention is 7 days — long enough to survive to the weekly release run.

## Test plan
- Lint/check passes
- After a non-PR build, `sbom-*` artifacts should appear in the workflow run