### PR TITLE
fix(ci): prevent /e2e dispatch from overwriting canonical :testing tags

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -10,6 +10,12 @@ on:
       - "system_files/shared/etc/bazaar/**"
   workflow_call:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number (set by e2e-dispatch to scope image tags to the PR)"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -60,7 +66,7 @@ jobs:
     needs: [detect-changes]
     if: |
       always() &&
-      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main') &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
     uses: ./.github/workflows/reusable-build.yml
@@ -78,3 +84,4 @@ jobs:
         }}
       brand_name: ${{ matrix.brand_name }}
       stream_name: testing
+      pr_number: ${{ inputs.pr_number }}

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -89,6 +89,7 @@ jobs:
           DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           gh workflow run build-image-testing.yml \
             --ref "$PR_BRANCH" \
+            --field pr_number="${{ github.event.issue.number }}" \
             -R "${{ github.repository }}"
           sleep 60
           RUN_ID=""

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -26,6 +26,11 @@ on:
         default: "['x86_64']"
         required: false
         type: string
+      pr_number:
+        description: "PR number when dispatched from e2e-dispatch — enforces PR-scoped tags"
+        default: ""
+        required: false
+        type: string
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -257,6 +262,16 @@ jobs:
         id: generate-tags
         shell: bash
         run: |
+          # When pr_number is set (e2e dispatch from a PR branch), treat the build
+          # as a pull_request event so generate-build-tags uses PR-scoped commit tags
+          # instead of canonical stream tags (prevents overwriting :testing).
+          EFFECTIVE_EVENT="${{ github.event_name }}"
+          EFFECTIVE_NUMBER="${{ github.event.number }}"
+          if [[ -n "${{ inputs.pr_number }}" ]]; then
+            EFFECTIVE_EVENT="pull_request"
+            EFFECTIVE_NUMBER="${{ inputs.pr_number }}"
+          fi
+
           alias_tags="$(just generate-build-tags \
                      "${{ matrix.base_name }}" \
                      "${{ matrix.stream_name }}" \
@@ -264,8 +279,8 @@ jobs:
                      "${{ inputs.kernel_pin }}" \
                      "1" \
                      "$(podman inspect ${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }} | jq -r '.[].Config.Labels["org.opencontainers.image.version"]')" \
-                     "${{ github.event_name }}" \
-                     "${{ github.event.number }}")"
+                     "${EFFECTIVE_EVENT}" \
+                     "${EFFECTIVE_NUMBER}")"
 
           echo "Tags for this Action..."
           echo "$alias_tags"


### PR DESCRIPTION
## Summary

Fixes #69.

When `/e2e` triggered `build-image-testing.yml` via `workflow_dispatch` on a PR branch, the Justfile produced canonical `:testing` tags — publishing unreviewed PR code as the official testing image.

## Root cause

`generate-build-tags` uses `BUILD_TAGS` (canonical stream tags) for `workflow_dispatch` and `COMMIT_TAGS` (PR-scoped `pr-NNN-sha-SHORT`) only for `pull_request` events. The e2e dispatch used `workflow_dispatch`, so it always produced canonical tags.

## Changes

1. **`reusable-build.yml`**: Added `pr_number` input. When set, the Generate Tags step overrides the effective event to `pull_request` and the effective number to the PR number — so `generate-build-tags` uses PR-scoped commit tags.
2. **`build-image-testing.yml`**: Added `pr_number` workflow_dispatch input; forwarded to `reusable-build.yml`; relaxed dispatch ref guard to allow PR-branch dispatches when `pr_number` is set.
3. **`e2e-dispatch.yml`**: Passes `--field pr_number=${{ github.event.issue.number }}` when triggering the build.