### PR TITLE
feat(ci): add Grype vulnerability scanning with SARIF upload

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,0 +1,92 @@
+name: Vulnerability Scan
+
+on:
+  workflow_run:
+    workflows: ["Testing Images"]
+    types: [completed]
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1' # Monday 08:00 UTC — weekly scan for newly-disclosed CVEs
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: "Full image ref to scan (default: latest testing image)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: vulnerability-scan-${{ github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Grype scan — ${{ matrix.image_name }}
+    # Only run on successful upstream builds (or on schedule/dispatch)
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - bluefin
+          - bluefin-dx
+          - bluefin-nvidia-open
+    steps:
+      - name: Resolve image ref
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.image_ref }}" ]]; then
+            REF="${{ inputs.image_ref }}"
+          else
+            REF="ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:testing"
+          fi
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "Scanning: ${REF}"
+
+      - name: Scan image with Grype
+        id: scan
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        with:
+          image: ${{ steps.resolve.outputs.ref }}
+          fail-build: false
+          severity-cutoff: critical
+          output-format: sarif
+
+      - name: Upload SARIF results
+        if: always()
+        uses: github/codeql-action/upload-sarif@bd726e2a6ef9fb1305ebd28a690e459525916958 # v3.29.1
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: grype-${{ matrix.image_name }}
+
+      - name: Check for critical CVEs
+        if: always()
+        run: |
+          set -euo pipefail
+          CRITICAL_COUNT=$(cat "${{ steps.scan.outputs.sarif }}" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          runs = data.get('runs', [])
+          criticals = sum(
+            1 for run in runs
+            for result in run.get('results', [])
+            if result.get('ruleId', '').startswith('CVE') and
+               any(prop.get('security-severity', '0') >= '9.0'
+                   for prop in [result.get('properties', {})])
+          )
+          print(criticals)
+          " 2>/dev/null || echo "0")
+
+          echo "Critical CVEs found: ${CRITICAL_COUNT}"
+
+          if [[ "${CRITICAL_COUNT}" -gt 0 ]]; then
+            echo "::warning::${CRITICAL_COUNT} critical CVE(s) found in ${{ matrix.image_name }} — see Security tab"
+          fi

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -71,9 +71,9 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          CRITICAL_COUNT=$(cat "${{ steps.scan.outputs.sarif }}" | python3 -c "
+          CRITICAL_COUNT=$(python3 -c "
           import json, sys
-          data = json.load(sys.stdin)
+          data = json.load(open('${{ steps.scan.outputs.sarif }}'))
           runs = data.get('runs', [])
           criticals = sum(
             1 for run in runs


### PR DESCRIPTION
## Summary

Closes #70.

Adds `vulnerability-scan.yml` that runs Grype on published images and reports results to GitHub Security code-scanning.

## Behavior

- Triggers after every successful **Testing Images** build (via `workflow_run`)
- Weekly scan every Monday 08:00 UTC for newly-disclosed CVEs
- Supports `workflow_dispatch` with optional custom image ref

## Scanned images
- `bluefin:testing`
- `bluefin-dx:testing`
- `bluefin-nvidia-open:testing`

## CVE handling
- SARIF uploaded to **Security → Code scanning** tab (each image gets its own category)
- Starts permissive (`fail-build: false`) — tighten after baseline is established
- `::warning` annotation when critical CVEs (`>= 9.0`) are detected
- `severity-cutoff: critical` so only high-signal findings are flagged