### PR TITLE
security: pin base image by digest to prevent TOCTOU (CWE-494)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,9 @@
 ARG BASE_IMAGE_NAME="silverblue"
-ARG FEDORA_MAJOR_VERSION="43@sha256:c9d2f9f0933b9da729536ac61b64dd8d1191b1b87bda15bddeffd9076ecb73d1"
+ARG FEDORA_MAJOR_VERSION="43"
 ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/silverblue"
+# BASE_IMAGE_REF is set at build time to BASE_IMAGE:FEDORA_MAJOR_VERSION@digest after cosign verify.
+# Defaults to tag-only for local builds without digest resolution.
+ARG BASE_IMAGE_REF="${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}"
 ARG COMMON_IMAGE="ghcr.io/projectbluefin/common:latest"
 ARG COMMON_IMAGE_SHA=""
 ARG BREW_IMAGE="ghcr.io/ublue-os/brew:latest"
@@ -17,7 +20,7 @@ COPY --from=common /system_files/bluefin /system_files/shared
 COPY --from=brew /system_files /system_files/shared
 
 ## bluefin image section
-FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS base
+FROM ${BASE_IMAGE_REF} AS base
 
 ARG AKMODS_FLAVOR="coreos-stable"
 ARG BASE_IMAGE_NAME="silverblue"

--- a/Justfile
+++ b/Justfile
@@ -128,6 +128,10 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Verify Base Image with cosign
     {{ just }} verify-container silverblue:${fedora_version} quay.io/fedora-ostree-desktops "https://gitlab.com/fedora/ostree/ci-test/-/raw/main/quay.io-fedora-ostree-desktops.pub?ref_type=heads"
 
+    # Resolve base image tag to digest (TOCTOU fix: pin the exact image cosign just verified)
+    base_image_digest=$(skopeo inspect --retry-times 3 --format '{{{{.Digest}}}}' docker://quay.io/fedora-ostree-desktops/silverblue:"${fedora_version}")
+    base_image_ref="quay.io/fedora-ostree-desktops/silverblue:${fedora_version}@${base_image_digest}"
+
     # Kernel Release/Pin
     if [[ -z "${kernel_pin:-}" ]]; then
         kernel_release=$(skopeo inspect --retry-times 3 docker://ghcr.io/ublue-os/akmods:"${akmods_flavor}"-"${fedora_version}" | jq -r '.Labels["ostree.linux"]')
@@ -173,6 +177,7 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
         target="dx"
     fi
     BUILD_ARGS+=("--build-arg" "AKMODS_FLAVOR=${akmods_flavor}")
+    BUILD_ARGS+=("--build-arg" "BASE_IMAGE_REF=${base_image_ref}")
     BUILD_ARGS+=("--build-arg" "COMMON_IMAGE={{ common_image }}")
     BUILD_ARGS+=("--build-arg" "COMMON_IMAGE_SHA=${common_image_sha}")
     BUILD_ARGS+=("--build-arg" "BREW_IMAGE={{ brew_image }}")


### PR DESCRIPTION
## Summary

Closes #64.

## Problem

After cosign verifies `silverblue:VERSION`, the tag could be silently retargeted before `podman build` pulls the image. The cosign check and the actual pull are two separate registry operations with a window between them (TOCTOU: Time-of-Check to Time-of-Use).

## Fix

Immediately after cosign verification, resolve the tag to a digest with `skopeo inspect`. Pass `BASE_IMAGE_REF=quay.io/.../silverblue:<tag>@sha256:<digest>` to the build — ensuring the build uses the exact image that was verified.

## Containerfile changes

- Added `ARG BASE_IMAGE_REF="${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}"` (defaults to tag for local builds without digest resolution)
- `FROM ${BASE_IMAGE_REF} AS base` — uses the digest-pinned ref when provided
- `FEDORA_MAJOR_VERSION` remains a plain integer for build scripts (case statements)

## Justfile changes

- After cosign verify, runs `skopeo inspect --format '{{.Digest}}'` to resolve tag → digest
- Sets `base_image_ref=quay.io/.../silverblue:<ver>@<digest>`
- Passes `BASE_IMAGE_REF` as a build arg

`common` and `brew` already use `@sha256` digest pinning via `COMMON_IMAGE_SHA` and `BREW_IMAGE_SHA`. This extends the same pattern to the Fedora base image.