### PR TITLE
feat(ci): implement registry-side layer cache with --cache-from/--cache-to

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -142,11 +142,16 @@ jobs:
         shell: bash
         run: echo "build_start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Login to GHCR for layer cache
+        if: github.event_name != 'pull_request'
+        run: echo ${{ secrets.GITHUB_TOKEN }} | sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Build Image
         id: build-image
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_CACHE_WRITE: ${{ github.event_name != 'pull_request' && '1' || '0' }}
         run: |
           sudo -E "$(command -v just)" repo_organization="${{ github.repository_owner }}" \
                     build-ghcr "${{ matrix.base_name }}" \

--- a/Justfile
+++ b/Justfile
@@ -221,6 +221,18 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
         echo "No GitHub token found - build may hit rate limit"
     fi
 
+    # Registry layer cache — reduces build time by reusing unchanged layers from GHCR
+    # Cache write (REGISTRY_CACHE_WRITE=1) is set by CI for non-PR builds only.
+    # PR builds and local builds are read-only to prevent cache poisoning.
+    cache_ref="ghcr.io/{{ repo_organization }}/bluefin-cache:${fedora_version}"
+    PODMAN_BUILD_ARGS+=(--cache-from "${cache_ref}")
+    if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
+        PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
+        echo "Registry layer cache: read+write (${cache_ref})"
+    else
+        echo "Registry layer cache: read-only (${cache_ref})"
+    fi
+
     ${PODMAN} build "${PODMAN_BUILD_ARGS[@]}" .
     echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

Partially closes #121.

## Changes

Implements the registry-side layer cache infrastructure using `ghcr.io/projectbluefin/bluefin-cache:${fedora_version}` as the dedicated cache image.

### Justfile
- Adds `--cache-from ${cache_ref}` to every build (safe — build continues if cache unreachable)
- Adds `--cache-to ${cache_ref}` when `REGISTRY_CACHE_WRITE=1` env var is set

### reusable-build.yml
- Adds GHCR login step before build on non-PR builds (needed for cache write)
- Sets `REGISTRY_CACHE_WRITE=1` for non-PR trusted branch builds (cache write)
- Sets `REGISTRY_CACHE_WRITE=0` for PR builds (read-only, prevents cache poisoning from untrusted forks)

## Cache image design
- Tag: `bluefin-cache:FEDORA_VERSION` — one key per Fedora major version
- Separate image from production images (no tag pollution)
- Compatible with Podman 5.x+ `--cache-from`/`--cache-to` OCI registry support

## Current limitation
With the current monolithic `RUN` in Containerfile, the cache hits only when no build inputs change. Full benefit requires #112 (split monolithic RUN into cacheable stages). This PR puts the infrastructure in place.