### PR TITLE
refactor(ci): extract composite action for checkout+just bootstrap

### DIFF
--- a/.github/actions/bootstrap-just/action.yml
+++ b/.github/actions/bootstrap-just/action.yml
@@ -1,0 +1,26 @@
+name: Bootstrap just
+description: Checkout repository and install the just command runner
+
+inputs:
+  fetch-depth:
+    description: Number of commits to fetch (0 = full history)
+    required: false
+    default: '1'
+  submodules:
+    description: Whether to checkout submodules (true, false, or recursive)
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
+        submodules: ${{ inputs.submodules }}
+
+    - name: Install just
+      uses: taiki-e/install-action@35e522e91305799a18f8cee79bf13d1f7b28b796 # just
+      with:
+        tool: just

--- a/.github/actions/bootstrap-just/action.yml
+++ b/.github/actions/bootstrap-just/action.yml
@@ -1,25 +1,9 @@
 name: Bootstrap just
-description: Checkout repository and install the just command runner
-
-inputs:
-  fetch-depth:
-    description: Number of commits to fetch (0 = full history)
-    required: false
-    default: '1'
-  submodules:
-    description: Whether to checkout submodules (true, false, or recursive)
-    required: false
-    default: 'false'
+description: Install the just command runner
 
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        fetch-depth: ${{ inputs.fetch-depth }}
-        submodules: ${{ inputs.submodules }}
-
     - name: Install just
       uses: taiki-e/install-action@35e522e91305799a18f8cee79bf13d1f7b28b796 # just
       with:

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -31,15 +31,10 @@ jobs:
         version: ${{ fromJson( inputs.stream_name ) }}
 
     steps:
-      - name: Checkout last 500 commits (for <commits> to work)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Bootstrap just
+        uses: ./.github/actions/bootstrap-just
         with:
-          fetch-depth: 500
-
-      - name: Install Just
-        uses: taiki-e/install-action@35e522e91305799a18f8cee79bf13d1f7b28b796 # just
-        with:
-          tool: just
+          fetch-depth: '500'
 
       - name: Check Just Syntax
         shell: bash

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -31,10 +31,13 @@ jobs:
         version: ${{ fromJson( inputs.stream_name ) }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 500
+
       - name: Bootstrap just
         uses: ./.github/actions/bootstrap-just
-        with:
-          fetch-depth: '500'
 
       - name: Check Just Syntax
         shell: bash

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Bootstrap just
         uses: ./.github/actions/bootstrap-just
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,13 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install just
-        uses: taiki-e/install-action@35e522e91305799a18f8cee79bf13d1f7b28b796 # just
-        with:
-          tool: just
+      - name: Bootstrap just
+        uses: ./.github/actions/bootstrap-just
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -61,18 +61,13 @@ jobs:
             base_name: "${{ inputs.brand_name }}-dx"
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Bootstrap just
+        uses: ./.github/actions/bootstrap-just
         with:
           submodules: recursive
 
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
-
-      - name: Install Just
-        uses: taiki-e/install-action@35e522e91305799a18f8cee79bf13d1f7b28b796 # just
-        with:
-          tool: just
 
       - name: Update Podman
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -61,10 +61,13 @@ jobs:
             base_name: "${{ inputs.brand_name }}-dx"
 
     steps:
-      - name: Bootstrap just
-        uses: ./.github/actions/bootstrap-just
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
+
+      - name: Bootstrap just
+        uses: ./.github/actions/bootstrap-just
 
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10


### PR DESCRIPTION
## Summary

Closes #88.

Replaces the repeated checkout → install-just boilerplate across three workflows with a single `.github/actions/bootstrap-just` composite action.

## Changes

### New: `.github/actions/bootstrap-just/action.yml`
- Inputs: `fetch-depth` (default: 1), `submodules` (default: false)
- Steps: checkout → install just

### Migrated workflows
| Workflow | Special inputs |
|---|---|
| `pr-validation.yml` | defaults |
| `reusable-build.yml` | `submodules: recursive` |
| `generate-release.yml` | `fetch-depth: 500` (changelog generation) |

All special-case behavior is preserved via the composite action inputs.