### PR TITLE
refactor(ci): extract reusable run-testsuite.yml wrapper workflow

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -134,7 +134,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@969d471323a5aed586ba19371a4d2c74c4fa6823 # main
+    uses: ./.github/workflows/run-testsuite.yml
     with:
       image: ${{ needs.dispatch.outputs.image }}
       suites: smoke,developer,vanilla-gnome

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@969d471323a5aed586ba19371a4d2c74c4fa6823 # main
+    uses: ./.github/workflows/run-testsuite.yml
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -3,6 +3,7 @@ name: Run Testsuite
 # Reusable wrapper around projectbluefin/testsuite e2e.yml.
 # Centralises the testsuite SHA pin — Renovate manages it here only.
 # Callers resolve their own image digest, then pass the full image ref.
+# Callers can access overall result via needs.<job-id>.result.
 on:
   workflow_call:
     inputs:
@@ -14,10 +15,6 @@ on:
         description: "Comma-separated test suites to run"
         required: true
         type: string
-    outputs:
-      conclusion:
-        description: "Test conclusion: success or failure"
-        value: ${{ jobs.e2e.result }}
 
 permissions:
   contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -1,0 +1,34 @@
+name: Run Testsuite
+
+# Reusable wrapper around projectbluefin/testsuite e2e.yml.
+# Centralises the testsuite SHA pin — Renovate manages it here only.
+# Callers resolve their own image digest, then pass the full image ref.
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Full image ref to test (e.g. ghcr.io/projectbluefin/bluefin@sha256:…)"
+        required: true
+        type: string
+      suites:
+        description: "Comma-separated test suites to run"
+        required: true
+        type: string
+    outputs:
+      conclusion:
+        description: "Test conclusion: success or failure"
+        value: ${{ jobs.e2e.result }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  e2e:
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@969d471323a5aed586ba19371a4d2c74c4fa6823 # main
+    permissions:
+      packages: write
+      contents: read
+    with:
+      image: ${{ inputs.image }}
+      suites: ${{ inputs.suites }}

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -112,7 +112,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@969d471323a5aed586ba19371a4d2c74c4fa6823 # main
+    uses: ./.github/workflows/run-testsuite.yml
     with:
       image: ${{ needs.verify-e2e.outputs.image }}
       suites: developer,vanilla-gnome,software,common


### PR DESCRIPTION
Closes #91. Consolidates repeated testsuite call pattern into run-testsuite.yml. Single SHA pin managed by Renovate. Callers migrated: post-testing-e2e.yml, weekly-testing-promotion.yml, e2e-dispatch.yml.