### PR TITLE
feat(ci): auto-file e2e test failures as GitHub issues

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -50,3 +50,45 @@ jobs:
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common
+
+  report-failure:
+    needs: [e2e, run-e2e]
+    if: failure() && needs.e2e.outputs.image != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const image = '${{ needs.e2e.outputs.image }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = '${{ github.event.workflow_run.head_sha }}'.slice(0, 8);
+            const title = `ci: e2e smoke test failure — ${sha}`;
+
+            // Check for duplicate open issue
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/testing,kind/bug',
+              state: 'open',
+            });
+            const dup = existing.data.find(i => i.title === title);
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `Failure recurred in run ${runUrl} for image \`${image}\``,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `## E2E Smoke Test Failure\n\n**Image:** \`${image}\`\n**Commit:** ${sha}\n**Run:** ${runUrl}\n**Suites:** smoke,common\n\n_Automatically opened by post-testing-e2e.yml_`,
+                labels: ['area/testing', 'kind/bug', 'priority/p1'],
+              });
+            }

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -170,3 +170,43 @@ jobs:
           git push origin HEAD:refs/heads/stable
           echo "✅ Promoted main → latest + stable"
           echo "Push events will trigger stable and latest image builds automatically."
+
+  report-failure:
+    needs: [verify-e2e, e2e]
+    if: failure() && needs.verify-e2e.outputs.image != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const image = '${{ needs.verify-e2e.outputs.image }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = 'ci: weekly promotion e2e failure';
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/testing,kind/bug',
+              state: 'open',
+            });
+            const dup = existing.data.find(i => i.title === title);
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `Failure recurred in run ${runUrl} for image \`${image}\``,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `## Weekly Promotion E2E Failure\n\n**Image:** \`${image}\`\n**Run:** ${runUrl}\n**Suites:** developer,vanilla-gnome,software,common\n\n_Automatically opened by weekly-testing-promotion.yml_`,
+                labels: ['area/testing', 'kind/bug', 'priority/p1'],
+              });
+            }


### PR DESCRIPTION
Closes #90. Adds report-failure jobs to post-testing-e2e.yml and weekly-testing-promotion.yml. On failure: opens issue with image ref, SHA, run URL, labels area/testing+kind/bug+priority/p1. Deduplication: comments on existing open issue instead of creating duplicates.