### PR TITLE
feat(ci): add PR smoke test gate and Renovate risk-tier automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -96,6 +96,23 @@
     {
       "matchDepTypes": ["gnome-extension"],
       "groupName": "GNOME extensions"
+    },
+    // Risk-tier labels for automerge gating (issue #73):
+    // low-risk: action SHA pins, non-build deps — lint validation sufficient
+    // high-risk: base image, COPR, build_files deps — require pr-smoke build+test
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["pinDigest", "digest"],
+      "addLabels": ["renovate/low-risk"]
+    },
+    {
+      "matchDepNames": [
+        "quay.io/fedora-ostree-desktops/silverblue",
+        "ghcr.io/projectbluefin/common",
+        "ghcr.io/ublue-os/brew",
+        "quay.io/coreos/chunkah"
+      ],
+      "addLabels": ["renovate/high-risk"]
     }
   ]
 }

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -1,0 +1,96 @@
+name: PR Smoke Test
+
+# Runs a full image build + smoke test on PRs that touch build-affecting files.
+# Results appear as a required check on the PR.
+#
+# Closed issues: #75 (community PRs), #73 (Renovate risk-tier gating — high-risk)
+on:
+  pull_request:
+    branches:
+      - testing
+    paths:
+      - Containerfile
+      - Justfile
+      - image-versions.yml
+      - build_files/**
+      - system_files/**
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+
+concurrency:
+  group: pr-smoke-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build PR image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    outputs:
+      image: ${{ steps.get-image.outputs.image }}
+    env:
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+    steps:
+      - name: Bootstrap just
+        uses: ./.github/actions/bootstrap-just
+        with:
+          submodules: recursive
+
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+
+      - name: Update Podman
+        shell: bash
+        run: |
+          set -eux
+          IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
+          test "${IDV}" = "ubuntu-24.04"
+          if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+            mirror="http://azure.archive.ubuntu.com/ubuntu"
+          else
+            mirror="http://ports.ubuntu.com/ubuntu-ports"
+          fi
+          echo "deb ${mirror} resolute universe main" | sudo tee /etc/apt/sources.list.d/resolute.list
+          /bin/time -f '%E %C' sudo apt update
+          /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/resolute buildah/resolute podman/resolute skopeo/resolute
+          podman --version
+
+      - name: Build PR-scoped image
+        id: build-image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo -E "$(command -v just)" repo_organization="${{ github.repository_owner }}" \
+            build-ghcr bluefin testing main
+
+      - name: Get PR image ref
+        id: get-image
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          IMAGE="ghcr.io/${{ github.repository_owner }}/bluefin:pr-${{ github.event.pull_request.number }}-sha-${SHORT_SHA}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "PR image: ${IMAGE}"
+
+      - name: Push PR-scoped image
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo ${{ secrets.GITHUB_TOKEN }} | sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
+          sudo podman tag localhost/bluefin:testing \
+            "ghcr.io/${{ github.repository_owner }}/bluefin:pr-${{ github.event.pull_request.number }}-sha-${SHORT_SHA}"
+          sudo podman push \
+            "ghcr.io/${{ github.repository_owner }}/bluefin:pr-${{ github.event.pull_request.number }}-sha-${SHORT_SHA}"
+
+  smoke:
+    name: Smoke test PR image
+    needs: [build]
+    if: needs.build.outputs.image != ''
+    permissions:
+      packages: write
+      contents: read
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@969d471323a5aed586ba19371a4d2c74c4fa6823 # main
+    with:
+      image: ${{ needs.build.outputs.image }}
+      suites: smoke

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -2,7 +2,7 @@ name: Renovate Auto-merge
 
 on:
   workflow_run:
-    workflows: ["PR Validation — testsuite"]
+    workflows: ["PR Validation — testsuite", "PR Smoke Test"]
     types: [completed]
 
 permissions:
@@ -20,22 +20,42 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGER_WORKFLOW: ${{ github.event.workflow_run.name }}
         run: |
-          PR_NUMBER=$(gh pr list \
+          PR_JSON=$(gh pr list \
             --repo ${{ github.repository }} \
-            --base main \
+            --base testing \
             --state open \
-            --json number,headRefOid,author \
-            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\" or .author.login == \"app/mergeraptor\") | .number" \
-            | head -1)
+            --json number,headRefOid,author,labels \
+            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\" or .author.login == \"app/mergeraptor\")")
 
-          if [ -z "$PR_NUMBER" ]; then
+          if [ -z "$PR_JSON" ]; then
             echo "No open Renovate/Mergeraptor PR found for SHA $HEAD_SHA — skipping"
             echo "pr_number=" >> "$GITHUB_OUTPUT"
-          else
-            echo "Found Renovate/Mergeraptor PR #$PR_NUMBER"
-            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          IS_HIGH_RISK=$(echo "$PR_JSON" | jq -r '[.labels[].name] | any(. == "renovate/high-risk")')
+
+          echo "Found PR #${PR_NUMBER} (high-risk: ${IS_HIGH_RISK})"
+          echo "Triggered by: ${TRIGGER_WORKFLOW}"
+
+          # High-risk PRs: only automerge after PR Smoke Test passes
+          if [[ "${IS_HIGH_RISK}" == "true" && "${TRIGGER_WORKFLOW}" != "PR Smoke Test" ]]; then
+            echo "High-risk PR — waiting for PR Smoke Test (not PR Validation)"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Low-risk PRs: automerge after PR Validation passes (skip if triggered by smoke)
+          if [[ "${IS_HIGH_RISK}" == "false" && "${TRIGGER_WORKFLOW}" == "PR Smoke Test" ]]; then
+            echo "Low-risk PR — PR Smoke Test not required, skipping"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge
         if: steps.find-pr.outputs.pr_number != ''


### PR DESCRIPTION
Closes #75, #73. Adds pr-smoke.yml (path-filtered PR smoke test for build-affecting files), adds Renovate risk labels (low-risk/high-risk), updates renovate-automerge.yml to gate high-risk PRs on smoke test instead of just lint. Also fixes automerge to target testing branch.