### PR TITLE
feat(build): tag large unpackaged assets with user.component for rechunking

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -14,6 +14,8 @@ mkdir -p /usr/share/doc/bluefin
 # Offline Bluefin documentation
 ghcurl "https://github.com/projectbluefin/documentation/releases/download/0.1/bluefin.pdf" --retry 3 -o /tmp/bluefin.pdf
 install -Dm0644 -t /usr/share/doc/bluefin/ /tmp/bluefin.pdf
+# Tag for rechunker — large unpackaged file gets its own layer
+setfattr -n user.component -v bluefin-docs /usr/share/doc/bluefin/bluefin.pdf
 
 # Footgun, See: https://github.com/ublue-os/main/issues/598
 rm -f /usr/bin/chsh /usr/bin/lchsh
@@ -40,6 +42,8 @@ ghcurl "${STARSHIP_BASE}.sha256" --retry 3 -o /tmp/starship.tar.gz.sha256
 (cd /tmp && sha256sum -c starship.tar.gz.sha256)
 tar -xzf /tmp/starship.tar.gz -C /tmp
 install -c -m 0755 /tmp/starship /usr/bin
+# Tag for rechunker — standalone binary not tracked by RPM
+setfattr -n user.component -v starship /usr/bin/starship
 
 # Configure firewalld with Fedora Workstation defaults
 # https://src.fedoraproject.org/rpms/firewalld/blob/rawhide/f/firewalld.spec

--- a/build_files/shared/build-gnome-extensions.sh
+++ b/build_files/shared/build-gnome-extensions.sh
@@ -51,6 +51,10 @@ glib-compile-schemas --strict /usr/share/gnome-shell/extensions/search-light@ice
 rm /usr/share/glib-2.0/schemas/gschemas.compiled
 glib-compile-schemas /usr/share/glib-2.0/schemas
 
+# Tag all compiled GNOME extensions for the rechunker so they get their
+# own layer and don't share with unrelated content (user.component = component name)
+setfattr -n user.component -v gnome-extensions /usr/share/gnome-shell/extensions/
+
 # Cleanup
 dnf5 -y remove glib2-devel meson sassc cmake dbus-devel
 rm -rf /usr/share/gnome-shell/extensions/tmp


### PR DESCRIPTION
Closes #114. Adds `setfattr user.component` xattrs to bluefin.pdf (~8MB), starship binary (~5MB), and all compiled GNOME extensions so rpm-ostree's rechunker can isolate them into dedicated layers. Improves OTA delta efficiency — config-only changes no longer force re-download of large unchanged asset layers.