### PR TITLE
feat(ci): auto-file e2e test failures as GitHub issues

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -50,3 +50,44 @@ jobs:
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common
+
+  report-failure:
+    needs: [e2e, run-e2e]
+    if: failure() && needs.e2e.outputs.image != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const image = '${{ needs.e2e.outputs.image }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = '${{ github.event.workflow_run.head_sha }}'.slice(0, 8);
+            const title = `ci: e2e smoke test failure — ${sha}`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/testing,kind/bug',
+              state: 'open',
+            });
+            const dup = existing.data.find(i => i.title === title);
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `Failure recurred in run ${runUrl} for image \`${image}\``,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `## E2E Smoke Test Failure\n\n**Image:** \`${image}\`\n**Commit:** ${sha}\n**Run:** ${runUrl}\n**Suites:** smoke,common\n\n_Automatically opened by post-testing-e2e.yml_`,
+                labels: ['area/testing', 'kind/bug', 'priority/p1'],
+              });
+            }

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -34,10 +34,13 @@ jobs:
     env:
       IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
     steps:
-      - name: Bootstrap just
-        uses: ./.github/actions/bootstrap-just
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
+
+      - name: Bootstrap just
+        uses: ./.github/actions/bootstrap-just
 
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -191,3 +191,43 @@ jobs:
 
           echo "✅ Promoted ${PROMOTED} image(s) to :latest and :stable"
           echo "Tested artifacts are now live — no rebuild was triggered."
+
+  report-failure:
+    needs: [verify-e2e, e2e, promote-to-latest-and-stable]
+    if: failure() && needs.verify-e2e.outputs.image != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const image = '${{ needs.verify-e2e.outputs.image }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = 'ci: weekly promotion e2e failure';
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/testing,kind/bug',
+              state: 'open',
+            });
+            const dup = existing.data.find(i => i.title === title);
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `Failure recurred in run ${runUrl} for image \`${image}\``,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `## Weekly Promotion E2E Failure\n\n**Image:** \`${image}\`\n**Run:** ${runUrl}\n**Suites:** developer,vanilla-gnome,software,common\n\n_Automatically opened by weekly-testing-promotion.yml_`,
+                labels: ['area/testing', 'kind/bug', 'priority/p1'],
+              });
+            }


### PR DESCRIPTION
Closes #90. Adds `report-failure` jobs to `post-testing-e2e.yml` and `weekly-testing-promotion.yml`. On failure, opens a deduplicated GitHub issue with image ref, commit SHA, and run URL. Re-opens existing issues with a comment if same failure recurs.