### PR TITLE
fix(build): mount tmpfs on /boot instead of /tmp to fix dracut cross-device link

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=cache,dst=/var/cache/rpm-ostree \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=secret,id=GITHUB_TOKEN \
-    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,dst=/boot \
     /ctx/build_files/shared/build.sh
 
 # Makes `/opt` writeable by default


### PR DESCRIPTION
## Summary

Fixes dracut initramfs generation failing with `Invalid cross-device link (os error 18)` during kernel installation in container builds.

**Root cause:** When `/tmp` is mounted as tmpfs and dracut tries to stage initramfs in `/tmp/dracut.XXXXXX`, the final move/hardlink to `/lib/modules/VERSION/` fails because you can't create hard links across different filesystem types (tmpfs → overlay).

**Fix:** Replace `--mount=type=tmpfs,target=/tmp` with `--mount=type=tmpfs,dst=/boot`. The `/boot` directory does not need to persist in the OCI layer (ostree manages boot artifacts outside the container filesystem). This matches Aurora's Containerfile pattern exactly.

## Test plan

CI will run a full container build via `Build PR image`. Kernel install (script `04-install-kernel-akmods.sh`) must complete without dracut errors.

Closes #148 side effect (the tmpfs mount for /tmp causes dracut failures with Fedora 44 kernel 7.0.x)