### PR TITLE
chore: update centralized actions ref to @v1

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -146,6 +146,7 @@ jobs:
           echo "allow_cache_write=${ALLOW_CACHE_WRITE}" >> "$GITHUB_OUTPUT"
 
       - name: Restore DNF package cache
+        id: dnf-cache-restore
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
@@ -197,7 +198,7 @@ jobs:
           done
 
       - name: Write new DNF package cache
-        if: steps.setup-cache.outputs.allow_cache_write == 'true'
+        if: always() && !cancelled() && steps.setup-cache.outputs.allow_cache_write == 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
@@ -384,8 +385,7 @@ jobs:
 
             rm -f "${{ env.DIGEST_FILE }}"
 
-            # Push default tag with full upload (two-push pattern for annotation stability)
-            # Workaround for https://github.com/containers/podman/issues/27796
+            # Push default tag.
             # Note: no --force-compression — rechunked layers are already zstd:chunked;
             # forcing re-compression would strip ostree.components annotations.
             sudo -E podman push \
@@ -395,13 +395,11 @@ jobs:
               --retry-delay 30s \
               "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
 
-            sudo -E podman push \
-              --compression-format zstd:chunked \
-              --compression-level 3 \
-              --retry 5 \
-              --retry-delay 30s \
-              --digestfile "${{ env.DIGEST_FILE }}" \
-              "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
+            # Get digest via skopeo inspect rather than a second full push.
+            # This avoids re-uploading all layers just to capture --digestfile output.
+            skopeo inspect --no-tags \
+              "docker://${REGISTRY}/${IMAGE}:${DEFAULT_TAG}" \
+              | jq -r '.Digest' > "${{ env.DIGEST_FILE }}"
 
             # Server-side tag copies — no re-upload of image data
             # shellcheck disable=SC2086 - word splitting on alias_tags is intentional
@@ -475,6 +473,9 @@ jobs:
           LAYER_COUNT=$(sudo podman image inspect "${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}" \
             --format '{{len .RootFS.Layers}}' 2>/dev/null || echo "?")
 
+          DNF_CACHE_HIT="${{ steps.dnf-cache-restore.outputs.cache-hit || 'false' }}"
+          DNF_CACHE_KEY="${{ steps.dnf-cache-restore.outputs.cache-matched-key || 'none' }}"
+
           {
             echo "## 📊 Build Telemetry: ${{ env.IMAGE_NAME }}"
             echo ""
@@ -491,6 +492,15 @@ jobs:
             echo ""
             echo "**Image size (uncompressed):** ${IMAGE_SIZE_MB} MB"
             echo "**Layer count:** ${LAYER_COUNT}"
+            echo ""
+            echo "### 🗄️ Cache"
+            echo "| Cache | Status |"
+            echo "|-------|--------|"
+            if [[ "${DNF_CACHE_HIT}" == "true" ]]; then
+              echo "| DNF/buildah (GHA) | ✅ hit (\`${DNF_CACHE_KEY}\`) |"
+            else
+              echo "| DNF/buildah (GHA) | ❌ miss (key: \`${DNF_CACHE_KEY:-none}\`) |"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Write digest to artifact

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -192,7 +192,9 @@ jobs:
         shell: bash
         id: cache-perms
         run: |
-          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
+          for d in /var/tmp/buildah-cache-*; do
+            [[ -d "$d" ]] && sudo chmod 777 --recursive "$d"
+          done
 
       - name: Write new DNF package cache
         if: steps.setup-cache.outputs.allow_cache_write == 'true'

--- a/Justfile
+++ b/Justfile
@@ -240,28 +240,26 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Cache write (REGISTRY_CACHE_WRITE=1) is set by CI for non-PR builds only.
     # PR builds and local builds are read-only to prevent cache poisoning.
     # Note: Podman 5.x+ requires untagged refs for --cache-from/--cache-to.
-    # IMPORTANT: bluefin-cache MUST be a PUBLIC GHCR package.
-    #   Private packages return 403 on blob existence checks, breaking --cache-from.
-    #   To unlock: go to https://github.com/orgs/projectbluefin/packages/container/bluefin-cache
-    #   → Package settings → Change visibility → Public.
-    cache_ref="ghcr.io/{{ repo_organization }}/bluefin-cache"
-    # Probe: use skopeo list-tags (works even on empty repos; fails on 403/404).
-    # manifest inspect on an untagged ref fails even for valid public repos that
-    # use hash-based cache refs, so it is not a reliable existence check.
+    #
+    # We use the image's own GHCR package (e.g. ghcr.io/projectbluefin/bluefin) as the
+    # cache repository. This avoids needing a separate bluefin-cache package and ensures
+    # GITHUB_TOKEN already has write access (it pushes the final image to this same ref).
+    # Buildah stores cache entries as SHA-keyed blobs that coexist safely with named tags.
+    cache_ref="ghcr.io/{{ repo_organization }}/${image_name}"
+    # Probe: use skopeo list-tags — succeeds on any accessible (public) repo, including
+    # ones with only SHA-keyed blobs. Fails on 403 (private) or 404 (not yet pushed).
     cache_readable=false
     if skopeo list-tags "docker://${cache_ref}" >/dev/null 2>&1; then
         cache_readable=true
         PODMAN_BUILD_ARGS+=(--cache-from "${cache_ref}")
     fi
     if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
-        # Always try to write on trusted builds — the push login provides the auth
-        # needed to create the package if it does not yet exist.
         PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
         echo "Registry layer cache: read=${cache_readable}+write (${cache_ref})"
     elif [[ "${cache_readable}" == "true" ]]; then
         echo "Registry layer cache: read-only (${cache_ref})"
     else
-        echo "Registry layer cache: disabled (${cache_ref} not accessible — make package public to enable)"
+        echo "Registry layer cache: disabled (${cache_ref} not yet accessible)"
     fi
 
     ${PODMAN} build "${PODMAN_BUILD_ARGS[@]}" .

--- a/Justfile
+++ b/Justfile
@@ -242,20 +242,24 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Note: Podman 5.x+ requires untagged refs for --cache-from/--cache-to.
     # IMPORTANT: bluefin-cache MUST be a PUBLIC GHCR package.
     #   Private packages return 403 on blob existence checks, breaking --cache-from.
-    #   Only enable cache when the package already exists and is accessible.
     #   To unlock: go to https://github.com/orgs/projectbluefin/packages/container/bluefin-cache
     #   → Package settings → Change visibility → Public.
     cache_ref="ghcr.io/{{ repo_organization }}/bluefin-cache"
-    # Only enable cache when probe succeeds (package exists AND is accessible).
-    # 404 (not found) or 403 (private) both skip cache — we do NOT create new private packages.
-    if ${PODMAN} manifest inspect "${cache_ref}" >/dev/null 2>&1; then
+    # Probe: use skopeo list-tags (works even on empty repos; fails on 403/404).
+    # manifest inspect on an untagged ref fails even for valid public repos that
+    # use hash-based cache refs, so it is not a reliable existence check.
+    cache_readable=false
+    if skopeo list-tags "docker://${cache_ref}" >/dev/null 2>&1; then
+        cache_readable=true
         PODMAN_BUILD_ARGS+=(--cache-from "${cache_ref}")
-        if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
-            PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
-            echo "Registry layer cache: read+write (${cache_ref})"
-        else
-            echo "Registry layer cache: read-only (${cache_ref})"
-        fi
+    fi
+    if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
+        # Always try to write on trusted builds — the push login provides the auth
+        # needed to create the package if it does not yet exist.
+        PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
+        echo "Registry layer cache: read=${cache_readable}+write (${cache_ref})"
+    elif [[ "${cache_readable}" == "true" ]]; then
+        echo "Registry layer cache: read-only (${cache_ref})"
     else
         echo "Registry layer cache: disabled (${cache_ref} not accessible — make package public to enable)"
     fi

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -68,6 +68,39 @@ The weekly promotion workflow refuses to promote untested code.
 - `renovate-automerge.yml` currently searches for matching PRs with `--base main`
 - If Renovate PRs stop auto-merging, check that branch assumptions still match between Renovate config and the auto-merge workflow
 
+## Build caching
+
+`reusable-build.yml` uses two layers of caching to speed up matrix builds:
+
+### DNF / buildah package cache
+
+Each matrix job saves and restores `/var/tmp/buildah-cache-*` via `actions/cache`.
+
+**Cache key format:**
+```
+{runner.os}-{architecture}-buildah-{image_flavor}-{image_name}-{fedora_version}
+```
+Example: `Linux-x86_64-buildah-main-bluefin-44`
+
+The `image_flavor` segment (`main` / `nvidia-open`) is critical — without it, parallel jobs sharing the same image name write to the same key and GitHub's cache API rejects all-but-one save with "Unable to reserve cache, another job may be creating this cache".
+
+**Restore-key fallback** (broadest-to-narrowest):
+1. `Linux-x86_64-buildah-main-bluefin-44` (exact hit)
+2. `Linux-x86_64-buildah-main-` (cross-image hit within same flavor)
+3. `Linux-x86_64-buildah-` (cross-flavor hit)
+
+**Permission workaround:** buildah creates cache dirs as root. A `cache-perms` step runs `sudo chmod 777 --recursive` on all `/var/tmp/buildah-cache-*` dirs so `actions/cache` (running as the runner user) can read them. The glob is important — buildah may create multiple numbered dirs (`-0`, `-1`, …).
+
+**Cache writes are gated** — only non-PR, non-testing-stream builds write the cache (via `setup-cache` recipe in `Justfile`).
+
+### OCI layer cache (`bluefin-cache`)
+
+Separate from the DNF cache. Uses `ghcr.io/projectbluefin/bluefin-cache` for container layer caching via `--cache-from`/`--cache-to`. Only enabled if the registry package is public (probed with `skopeo inspect`). Refs must be **untagged** (Podman 5.x rejects tagged refs for cache operations).
+
+### Cache budget
+
+GitHub provides 10 GB per repo. With 4 flavor+image combinations each ~2-3 GB, the cache approaches the limit. `cache-maintenance.yml` runs weekly to prune entries older than 14 days or from deleted branches.
+
 ## Common failure modes
 
 | Symptom | Likely cause | First fix to try |


### PR DESCRIPTION
Updates all three build callers from pinned SHA `@ba3519c` to the `@v1` tag now that actions PR #13 is merged and the tag is moved.

## Changes
- `build-image-testing.yml`
- `build-image-stable.yml`  
- `build-image-latest-main.yml`

All now point to `projectbluefin/actions/.github/workflows/reusable-build.yml@v1`