### PR TITLE
chore: update centralized actions ref to @v1

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -28,7 +28,7 @@ jobs:
   build-image-latest:
     name: Build Latest Images
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'latest'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@ba3519cccc368df4f55e472e82837444f47b2d2a
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@v1
     secrets: inherit
     with:
       stream_name: latest

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -21,7 +21,7 @@ jobs:
   build-image-stable:
     name: Build Stable Images
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'stable'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@ba3519cccc368df4f55e472e82837444f47b2d2a
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@v1
     secrets: inherit
     with:
  #    kernel_pin: 6.17.12-300.fc43.x86_64 ## Pin to 6.17 for ZFS compatibility

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -69,7 +69,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@ba3519cccc368df4f55e472e82837444f47b2d2a
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@v1
     secrets: inherit
     with:
       image_flavors: >-


### PR DESCRIPTION
Updates all three build callers from pinned SHA `@ba3519c` to the `@v1` tag.

## Changes
- `build-image-testing.yml`
- `build-image-stable.yml`  
- `build-image-latest-main.yml`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>