### PR TITLE
feat: add production environment gate to promotion workflow

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -119,6 +119,7 @@ jobs:
       suites: developer,vanilla-gnome,software,common
 
   promote-to-latest-and-stable:
+    environment: production
     needs: [e2e, verify-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
Adds `environment: production` to the `promote-to-latest-and-stable` job in the weekly testing promotion workflow, enforcing required approval gates before testing→stable promotion.

## Details
- Environment configured with required reviewers at GitHub UI level
- Resolves projectbluefin/actions#17 (Track C-1)

## Test Plan
- Verify that manual promotion workflow runs require approval from required reviewers
- Confirm that testing→latest/stable promotion is blocked until approved