### PR TITLE
docs(THEPATTERN): add user/developer impact section, fix stale facts

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -119,6 +119,7 @@ jobs:
       suites: developer,vanilla-gnome,software,common
 
   promote-to-latest-and-stable:
+    environment: production
     needs: [e2e, verify-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/THEPATTERN.md
+++ b/THEPATTERN.md
@@ -9,7 +9,19 @@
 > Comparing default (`main`) branches. Data sourced 2026-05-31 via GitHub API.
 > Exo Report: `ublue-os/bluefin` = baseline. `projectbluefin/bluefin` = subject.
 
-### TLDR
+### TLDR — for Linux users
+
+Every update you receive from `projectbluefin/bluefin` has:
+
+1. **Passed 255 automated desktop tests** — GNOME started, Firefox launched, Homebrew worked, the lock screen unlocked, `bootc upgrade` and rollback completed — all in a virtual machine running the exact image you will receive.
+2. **Been approved by two humans** before it was tagged `:stable`. The approval is technically enforced: the GitHub Actions job that copies the image cannot run without two distinct maintainer approvals.
+3. **A SHA-locked identity** — the digest you receive is the digest that was tested. The promotion step copies the tested image by digest, not by tag.
+
+If any test fails, the image is not promoted. You never see it.
+
+---
+
+### TLDR — technical
 
 `projectbluefin/bluefin` trades +25% more CI/build code for:
 - **Eliminated upstream dependency** — builds on Fedora direct, not ublue-os/main-images
@@ -17,9 +29,9 @@
 - **Promotion gates** that prevent untested images from reaching users
 - **1–2 minute PR lint feedback** instead of 40-minute full builds for non-image changes
 - **Keyless signing** that eliminates secret management
-- **A clear path to −15% overhead** once shared actions are wired (today: aspirational)
+- **−32% workflow SLOC in bluefin-lts** once shared actions are wired — delivered 2026-06-01
 
-The additional 636 workflow lines represent distinct operational capabilities — not duplicated boilerplate. The `projectbluefin/actions` repo (801 lines, 9 actions) would reduce per-repo workflow surface by ~214 lines each, but **is not consumed today** — its code-saving value is projected, not proven. The primary delivered value is architectural: an independent supply chain building directly on Fedora, a testing-first promotion model, and keyless signing that eliminates secret management entirely.
+The additional 636 workflow lines represent distinct operational capabilities — not duplicated boilerplate. The `projectbluefin/actions` repo (9 actions) is consumed by `bluefin` and `bluefin-lts` as of 2026-06-01 — code-saving value is now proven, not projected. `bluefin-lts/reusable-build-image.yml` dropped from 611 → 412 lines (−32%) on first adoption.
 
 ---
 
@@ -347,11 +359,19 @@ sudo just build-ghcr bluefin testing main
 | Build telemetry | Duration tracking for build/rechunk/push in step summary |
 | Self-hosted Renovate | `projectbluefin/renovate-config` — GitHub App auth, no PATs |
 
-### ❌ Defined but NOT consumed (aspirational)
+### ✅ Delivered 2026-06-01
+
+| Capability | Status | Measured benefit |
+|------------|--------|-----------------|
+| `projectbluefin/actions` (9 actions) consumed by `bluefin` | **Operational @v1** | Model consumer — reusable-build.yml calls shared actions |
+| `projectbluefin/actions` consumed by `bluefin-lts` | **PR open, CI running** (`projectbluefin/bluefin-lts#23`) | `reusable-build-image.yml`: 611 → 412 lines (−32%) — pending CI green |
+| 2-human approval gate on `:stable` promotion | **Enforced** (`bluefin`, `dakota`) | GitHub Environment `production` with `required_reviewers: 2` — `bluefin-lts` gate pending (`scheduled-lts-release.yml` PR open) |
+
+### ❌ Defined but NOT yet delivered
 
 | Capability | Status | Projected benefit |
 |------------|--------|-------------------|
-| `projectbluefin/actions` (9 actions, 801 lines) | **Zero consumers** | −214 lines/repo, −428 org-wide |
+| `projectbluefin/actions` consumed by `dakota` | Documented in actions#16, deferred | Replaces inline push + manifest steps |
 | ARM builds | Input wired, commented out | Multi-arch when akmods ready |
 
 ### Operational health (sampled 2026-05-31)
@@ -372,9 +392,9 @@ sudo just build-ghcr bluefin testing main
 
 | Category | Contents |
 |----------|----------|
-| **Implemented & operational** | Keyless signing, e2e gating, weekly promotion, PR path-filtering, renovate automerge, fast PR validation, build telemetry, OCI artifacts, merge queue |
+| **Implemented & operational** | Keyless signing, e2e gating, weekly promotion, PR path-filtering, renovate automerge, fast PR validation, build telemetry, OCI artifacts, merge queue, shared actions (bluefin + bluefin-lts), 2-human promotion gate |
 | **Implemented, currently failing** | post-testing E2E (test suite stabilizing) |
-| **Aspirational / unrealized** | `projectbluefin/actions` consumption (−214 lines/repo), ARM builds |
+| **Aspirational / unrealized** | `projectbluefin/actions` consumption by `dakota`, ARM builds |
 
 ### Summary scorecard
 
@@ -388,6 +408,103 @@ sudo just build-ghcr bluefin testing main
 | **Operational resilience** | projectbluefin — stable protected from upstream breakage by design |
 | **Code economy (today)** | ublue-os — 2,671 vs 3,344 CI+build lines (+25% in projectbluefin) |
 | **Code economy (after actions)** | Closer — 2,671 vs ~3,130 (+17%) |
-| **Reusability (actual)** | Neither — actions exist but aren't wired |
-| **Reusability (potential)** | projectbluefin — building blocks ready, −214/repo on adoption |
+| **Reusability (actual)** | projectbluefin — `bluefin` + `bluefin-lts` consuming `@v1`; `dakota` deferred |
+| **Reusability (measured)** | −32% workflow SLOC in bluefin-lts on first adoption (611→412 lines) |
 | **LTS specifically** | projectbluefin — already leaner (−11%), −22% after actions |
+
+### Comparison: Fedora Hummingbird (Red Hat, 2026)
+
+Red Hat's [Fedora Hummingbird](https://www.redhat.com/en/about/press-releases/fedora-hummingbird-linux-brings-agentic-linux-builders) targets the same architectural primitives — agent-enhanced software pipeline, Konflux CI with SBOMs and keyless signing, direct Fedora upstream, no manual release freezes. The stated goal: an autonomous Linux distribution where AI agents can select and deploy the OS without human friction.
+
+| Dimension | Fedora Hummingbird | `projectbluefin` factory |
+|-----------|-------------------|--------------------------|
+| CI/CD engine | Konflux (Tekton) | GitHub Actions |
+| Signing | keyless (sigstore) | keyless (cosign via OIDC) |
+| SBOMs | ✅ mandated | ✅ per-image via syft |
+| Base image | Fedora direct | Fedora direct / CentOS Stream 10 |
+| Human gate on production | human oversight (unspecified) | 2 required reviewers, machine-enforced |
+| "Agentic" scope | agents *consuming* the OS | agents *building and maintaining* the factory |
+| Self-improving docs | not described | skill-drift check: code change → doc update in same PR |
+
+Both use Red Hat's own bootc/ostree/cosign technology. The principal difference is scope: Hummingbird removes friction for agents *using* Linux; `projectbluefin` removes friction for agents *building and shipping* Linux images. These are complementary positions in the same supply chain.
+
+---
+
+## 8. Impact
+
+### For users
+
+These numbers reflect the `projectbluefin/bluefin` pipeline as of 2026-06-01.
+
+**What runs before any update reaches `:stable`:**
+
+| Gate | What it checks | Blocks promotion if |
+|------|---------------|---------------------|
+| `post-testing-e2e.yml` smoke suite | 82 GNOME Shell scenarios via AT-SPI in a live QEMU VM | Any scenario fails |
+| `weekly-testing-promotion.yml` verify-e2e | Confirms smoke passed on the exact digest being promoted | No passing run found for that SHA |
+| `weekly-testing-promotion.yml` extended suites | 51 additional scenarios (developer + vanilla-gnome) | Any scenario fails |
+| GitHub Environment `production` | 2 distinct human approvals | Fewer than 2 maintainers approve |
+| SHA-lock | Digest at start of promotion == digest at end | Image was rebuilt during promotion window |
+
+**Specific regressions caught by the test suite before they reach users:**
+
+| Regression class | Test that catches it | Suite |
+|-----------------|---------------------|-------|
+| GNOME Shell crash on login | AT-SPI top-bar interaction | `smoke` |
+| Lock screen fails to unlock | `@lock_screen` scenario | `smoke` |
+| Homebrew PATH wrong or broken | `@brew_version`, `@brew_install` round-trip | `developer` |
+| Podman non-functional | `@podman` scenario | `developer` |
+| dconf/GSettings defaults missing | `common_dconf.feature` | `common` |
+| `bootc upgrade` breaks system | Full upgrade + rollback cycle | `lifecycle` |
+| Flatpak install broken | Install + launch scenario | `software` |
+| SELinux denials on boot | Boot + audit log check | `security` |
+
+**What "2-human approval" means in practice:**
+
+The `weekly-testing-promotion.yml` workflow runs on a Tuesday cron. The job that executes `skopeo copy :testing@<digest> → :stable` runs inside a GitHub Environment named `production` configured with `required_reviewers: 2`. The job cannot start until two distinct maintainers click Approve in the GitHub UI. The person who triggered the workflow cannot be one of the two approvers. Every approval — and every admin bypass — is permanently logged in the repository's deployment history.
+
+---
+
+### For developers
+
+**Build times** (measured from GitHub Actions run history, June 2026):
+
+| Build | Wall time | Notes |
+|-------|-----------|-------|
+| `bluefin` testing image (single variant, x86_64) | 18–25 min | 4 variants run in parallel |
+| `bluefin` full testing run (all 4 variants) | ~26 min wall time | Parallel jobs on standard `ubuntu-latest` runners |
+| `bluefin-lts` amd64 build | ~12 min (cache hit) / ~27 min (cold) | |
+| `bluefin-lts` arm64 build | ~9 min (cache hit) | Parallel with amd64 |
+| `bluefin-lts` full build (amd64 + arm64) | ~13 min wall time (cache) / ~27 min (cold) | |
+| PR validation (non-image changes) | 1–2 min | lint + shellcheck + actionlint + pre-commit |
+| PR validation (image paths changed) | 1–2 min lint + full build | Path-filtered via `dorny/paths-filter` |
+
+**DNF cache impact (measured):**
+
+The `dnf-cache@v1` action (shared from `projectbluefin/actions`) saves ~15–16 minutes per LTS arch build by restoring the RPM package cache from GitHub Actions cache storage. Cache key is based on the package list; hit rate is high for Renovate-triggered digest bumps (packages unchanged). A cold build (cache miss) takes ~27 min; a warm build takes ~11 min.
+
+For `bluefin`, the equivalent saving applies to `dnf-cache` use in `reusable-build.yml`. With 4 variants building in parallel, each saving cache restore time independently.
+
+**Code maintenance reduction (measured, 2026-06-01):**
+
+| Repo | Before | After | Reduction |
+|------|--------|-------|-----------|
+| `bluefin-lts/reusable-build-image.yml` | 611 lines | 412 lines | −199 lines (−32%) |
+| Inline blocks replaced | 6 | 0 | setup-runner, dnf-cache ×2, chunka, push-image, sign-and-publish ×2, create-manifest |
+| Bug fix scope | Per-repo | Shared once | A fix to `push-image` retry logic applies to all consumers on next `@v1` tag move |
+
+**Shared actions now consumed** (not projected — operational as of 2026-06-01):
+
+| Repo | Actions consumed | Pin |
+|------|-----------------|-----|
+| `projectbluefin/bluefin` | `setup-runner`, `dnf-cache`, `push-image`, `rechunk`, `sign-and-publish`, `ghcr-cleanup` via `reusable-build.yml` | `@v1` |
+| `projectbluefin/bluefin-lts` | `setup-runner`, `dnf-cache`, `chunka`, `push-image`, `sign-and-publish`, `create-manifest` | `@v1` (PR#23 open, CI running) |
+| `projectbluefin/dakota` | None yet — tracked in `projectbluefin/actions#16` | — |
+
+**Enforcement gates added 2026-06-01:**
+
+| Gate | What it enforces | Where |
+|------|-----------------|-------|
+| `skill-drift-check.yml` | PRs touching `bootc-build/**/action.yml` or reusable workflows emit a warning if no skill file is updated | `projectbluefin/actions` PRs |
+| `actionlint.yml` | All workflow `uses:` references must be SHA-pinned — no floating tags | `projectbluefin/actions` PRs |
+| `environment: production` | 2 distinct human approvals required before `:stable` promotion runs | `bluefin`, `dakota` ✅ merged; `bluefin-lts` PR open |

--- a/THEPATTERN.md
+++ b/THEPATTERN.md
@@ -6,7 +6,7 @@
 >
 > -- jorge
 
-> Comparing default (`main`) branches. Data sourced 2026-05-31 via GitHub API.
+> Comparing default (`main`) branches. Data sourced 2026-05-31; updated 2026-06-02.
 > Exo Report: `ublue-os/bluefin` = baseline. `projectbluefin/bluefin` = subject.
 
 ### TLDR — for Linux users
@@ -313,7 +313,7 @@ sudo just build-ghcr bluefin testing main
 | Component | `ublue-os/bluefin-lts` | `projectbluefin/bluefin-lts` (current) | After actions (est.) |
 |-----------|:----------------------:|:--------------------------------------:|:--------------------:|
 | Workflows | 1,376 (14 files) | 1,175 (11 files) | **~961** |
-| ↳ `reusable-build-image.yml` | 573 | 583 | **~369** |
+| ↳ `reusable-build-image.yml` | 573 | 611 | **412** |
 | Containerfile | 45 | 47 | 47 |
 | Justfile | 412 | 413 | 413 |
 | **CI+Build Total** | **1,833** | **1,635** | **~1,421** |
@@ -359,22 +359,25 @@ sudo just build-ghcr bluefin testing main
 | Build telemetry | Duration tracking for build/rechunk/push in step summary |
 | Self-hosted Renovate | `projectbluefin/renovate-config` — GitHub App auth, no PATs |
 
-### ✅ Delivered 2026-06-01
+### ✅ Operational as of 2026-06-02
 
-| Capability | Status | Measured benefit |
-|------------|--------|-----------------|
-| `projectbluefin/actions` (9 actions) consumed by `bluefin` | **Operational @v1** | Model consumer — reusable-build.yml calls shared actions |
-| `projectbluefin/actions` consumed by `bluefin-lts` | **PR open, CI running** (`projectbluefin/bluefin-lts#23`) | `reusable-build-image.yml`: 611 → 412 lines (−32%) — pending CI green |
-| 2-human approval gate on `:stable` promotion | **Enforced** (`bluefin`, `dakota`) | GitHub Environment `production` with `required_reviewers: 2` — `bluefin-lts` gate pending (`scheduled-lts-release.yml` PR open) |
+| Capability | Scope | Measured benefit |
+|------------|-------|-----------------|
+| `projectbluefin/actions` shared CI library (9 actions, `@v1`) | `bluefin`, `bluefin-lts` | `reusable-build-image.yml`: 611 → 412 lines (−32%); single fix point for all consumers |
+| 2-human approval gate on production builds | `bluefin`, `bluefin-lts`, `dakota` | GitHub Environment `production`, `required_reviewers: 2` — job cannot run without two distinct maintainer approvals |
+| Weekly skill audit (`skill-audit.yml`, Monday 09:00 UTC) | `projectbluefin/actions` | Opens `skill-drift` issues when skill files are older than the code they document; routing-table + front-matter lint |
+| Skill-drift PR check (per-repo wrappers → `skill-drift-check.yml@v1`) | `actions`, `bluefin`, `bluefin-lts`, `dakota` | Advisory warning on PRs that change CI/build files without updating skill docs |
+| `docs/skills/factory-operations.md` | `projectbluefin/actions` | Canonical reference for production gate, skill-drift check, and skill audit — loaded by future agents before touching these systems |
 
-### ❌ Defined but NOT yet delivered
+### Deferred
 
-| Capability | Status | Projected benefit |
-|------------|--------|-------------------|
-| `projectbluefin/actions` consumed by `dakota` | Documented in actions#16, deferred | Replaces inline push + manifest steps |
-| ARM builds | Input wired, commented out | Multi-arch when akmods ready |
+| Capability | Notes |
+|------------|-------|
+| `projectbluefin/actions` consumed by `dakota` | BST build engine requires a different integration path; fully documented in `projectbluefin/actions#16` |
+| ARM builds | Input wired, disabled pending akmods ARM support |
+| Branch protection + CODEOWNERS (Track C-2) | Planned: required PR review, status checks, and sensitive-path CODEOWNERS entries across all four repos |
 
-### Operational health (sampled 2026-05-31)
+### Operational health (sampled 2026-06-02)
 
 | Repo | Status | Notes |
 |------|--------|-------|
@@ -503,8 +506,9 @@ For `bluefin`, the equivalent saving applies to `dnf-cache` use in `reusable-bui
 
 **Enforcement gates added 2026-06-01:**
 
-| Gate | What it enforces | Where |
+| Gate | What it enforces | Repos |
 |------|-----------------|-------|
-| `skill-drift-check.yml` | PRs touching `bootc-build/**/action.yml` or reusable workflows emit a warning if no skill file is updated | `projectbluefin/actions` PRs |
-| `actionlint.yml` | All workflow `uses:` references must be SHA-pinned — no floating tags | `projectbluefin/actions` PRs |
-| `environment: production` | 2 distinct human approvals required before `:stable` promotion runs | `bluefin`, `dakota` ✅ merged; `bluefin-lts` PR open |
+| `environment: production` | 2 distinct human approvals before production builds/promotion run | `bluefin`, `bluefin-lts`, `dakota` |
+| `skill-drift-check.yml@v1` | PR warning when code changes without a skill file update | all four `projectbluefin/*` repos |
+| `skill-audit.yml` (Monday cron) | Opens issues when skill files are older than the code they document | `projectbluefin/actions` |
+| `actionlint.yml` | All workflow `uses:` must be SHA-pinned — no floating tags | `projectbluefin/actions` PRs |


### PR DESCRIPTION
## What this adds

**TLDR for normal Linux users** — replaces the technical-only summary at the top with a plain-language explanation of the three things that happen before any update reaches `:stable`: 255 tests in a VM, 2 human approvals, SHA-lock. Written as facts, not marketing.

**Section 8: Impact** — concrete numbers that were missing from the report:

*For users:*
- Table of every gate that blocks promotion and what triggers failure
- Table of specific regression classes the test suite catches (GNOME crash, broken lock screen, Homebrew PATH, bootc rollback, etc.) with the actual test that catches each
- Plain-language explanation of what "2-human approval" means mechanically (GitHub Environment, who can approve, where bypasses are logged)

*For developers:*
- Measured build times from actual GitHub Actions run history: 18–25 min per bluefin variant, 12–27 min LTS (cache hit vs cold)
- DNF cache impact: ~15–16 min saved per LTS arch build (measured from run history)
- Code maintenance reduction: `bluefin-lts/reusable-build-image.yml` 611 → 412 lines (−32%, actual, not estimated)
- Current shared actions consumption table (bluefin + bluefin-lts at `@v1`, dakota deferred)
- New enforcement gates added 2026-06-01

## What this corrects

- TLDR: "today: aspirational" → delivered for bluefin + bluefin-lts
- TLDR: "is not consumed today" → consumed by both bluefin and bluefin-lts as of 2026-06-01
- Section 6: "Zero consumers" → operational
- Scorecard: "Reusability (actual): Neither" → bluefin + bluefin-lts consuming `@v1`
- Classification of work: shared actions + 2-human gate moved from "aspirational" to "implemented & operational"