### PR TITLE
ci(hive): add hive-progress-sync workflow

### DIFF
--- a/.github/workflows/hive-progress-sync.yml
+++ b/.github/workflows/hive-progress-sync.yml
@@ -1,0 +1,141 @@
+# hive-progress-sync — posts Bluefin queue stats to the projectbluefin org
+# project board (todo.projectbluefin.io) hourly and on every push to testing.
+#
+# Tracks: queue/agent-ready, queue/claimed, hive/p0, hive/p1 counts
+# CI status: build-image-testing.yml
+#
+# Requires: PROJECT_TOKEN secret with project + read:project OAuth scopes
+# Project board: PVT_kwDOCCE0ds4BLZBC (todo.projectbluefin.io, #2)
+
+name: Hive Progress Sync
+
+on:
+  push:
+    branches: [testing]
+  schedule:
+    - cron: '15 * * * *'  # :15 offset — staggers with common (:20), dakota (:00), knuckle (:30), lts (:45)
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Post Bluefin queue status to org project board
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          python3 << 'PYEOF'
+          import json, subprocess, sys, os
+          from datetime import datetime, timezone
+
+          PROJECT_ID    = "PVT_kwDOCCE0ds4BLZBC"
+          REPO          = "projectbluefin/bluefin"
+          ISSUES_URL    = f"https://github.com/{REPO}/issues"
+          CI_WORKFLOW   = "build-image-testing.yml"
+
+          def gh(*args):
+              result = subprocess.run(
+                  ["gh"] + list(args),
+                  capture_output=True, text=True
+              )
+              if result.returncode != 0:
+                  print(f"gh error: {result.stderr}", file=sys.stderr)
+                  sys.exit(1)
+              return result.stdout.strip()
+
+          # CI status: latest completed build-image-testing.yml run
+          ci_raw  = gh("run", "list", "--repo", REPO, "--workflow", CI_WORKFLOW,
+                       "--limit", "1", "--json", "conclusion,url")
+          ci_runs = json.loads(ci_raw)
+          if ci_runs:
+              run = ci_runs[0]
+              conclusion = run.get("conclusion", "")
+              url        = run.get("url", "")
+              if conclusion == "success":
+                  ci = f"[✅ CI passing]({url})"
+              elif conclusion in ("failure", "startup_failure"):
+                  ci = f"[❌ CI failing]({url})"
+              else:
+                  ci = "CI ⏳"
+          else:
+              ci = "CI ⏳"
+
+          # Queue counts
+          def count_label(label):
+              raw = gh("issue", "list", "--repo", REPO,
+                       "--label", label, "--state", "open", "--json", "number")
+              return len(json.loads(raw))
+
+          n_ready   = count_label("queue/agent-ready")
+          n_claimed = count_label("queue/claimed")
+          n_p0      = count_label("hive/p0")
+          n_p1      = count_label("hive/p1")
+
+          now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+          # Status body
+          p0_fragment = f" · ▲ {n_p0} P0" if n_p0 > 0 else ""
+          p1_fragment = f" · {n_p1} P1" if n_p1 > 0 else ""
+          status_line = f"{ci} · {n_ready} ready · {n_claimed} claimed{p0_fragment}{p1_fragment}"
+
+          body = "\n".join([
+              "### Bluefin 🦕",
+              "",
+              status_line,
+              "",
+              f"_Updated {now_utc} · [Issue queue]({ISSUES_URL})_",
+          ])
+
+          print(f"Status body:\n{body}")
+
+          # Determine project status
+          if n_p0 > 0:
+              status = "OFF_TRACK"
+          elif n_claimed > 0:
+              status = "ON_TRACK"
+          else:
+              status = "AT_RISK"
+
+          # Skip posting if PROJECT_TOKEN is not configured
+          project_token = os.environ.get("PROJECT_TOKEN", "")
+          if not project_token:
+              print("WARNING: PROJECT_TOKEN secret not set — skipping project board post", file=sys.stderr)
+              sys.exit(0)
+
+          mutation = """
+          mutation($projectId: ID!, $body: String!, $status: ProjectV2StatusUpdateStatus!) {
+            createProjectV2StatusUpdate(input: {
+              projectId: $projectId
+              body: $body
+              status: $status
+            }) {
+              statusUpdate { id createdAt }
+            }
+          }
+          """
+
+          result = subprocess.run(
+              ["gh", "api", "graphql",
+               "-f", f"query={mutation}",
+               "-f", f"projectId={PROJECT_ID}",
+               "-f", f"body={body}",
+               "-f", f"status={status}"],
+              capture_output=True, text=True,
+              env={**os.environ, "GH_TOKEN": project_token}
+          )
+
+          if result.returncode != 0 or '"errors"' in result.stdout:
+              print("ERROR posting status update:", file=sys.stderr)
+              print(result.stdout, file=sys.stderr)
+              print(result.stderr, file=sys.stderr)
+              sys.exit(1)
+
+          resp      = json.loads(result.stdout)
+          update_id = resp["data"]["createProjectV2StatusUpdate"]["statusUpdate"]["id"]
+          print(f"Posted: {update_id}")
+          PYEOF
+        shell: bash


### PR DESCRIPTION
## What

Adds a Hive progress sync workflow that posts hourly queue stats to the org project board (todo.projectbluefin.io).

**Tracks:**
- `queue/agent-ready` — issues approved and ready for an agent
- `queue/claimed` — issues actively being worked
- `hive/p0` — current cycle release blockers
- `hive/p1` — current cycle high priority items

**Schedule:** Runs at :15 past the hour (offset from other repos: dakota :00, common :20, lts :45, knuckle :30).

**Token scoping:** Uses `github.token` for all read operations; `PROJECT_TOKEN` only for the GraphQL mutation (write).

## Context
Part of org-wide Hive label taxonomy standardization. See [agentic-contributing.md](https://github.com/projectbluefin/documentation/blob/main/docs/agentic-contributing.md).

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot