### PR TITLE
docs(ci): document shared CI architecture; add CI-fix-first workflow for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,18 @@ dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
 
 Each image repo consumes `projectbluefin/common`. `projectbluefin/testsuite` gates promotion.
 
+### Shared CI building blocks (`projectbluefin/actions`)
+
+```text
+projectbluefin/actions  ←── shared CI: composite actions + reusable-build.yml
+        │
+        ├── projectbluefin/bluefin      (calls reusable-build.yml@v1)
+        ├── projectbluefin/bluefin-lts  (à la carte composite actions)
+        └── projectbluefin/dakota       (partial adoption)
+```
+
+**Before fixing a CI issue here:** check if the broken logic lives in a shared composite action in `projectbluefin/actions`. If so, fix it there first. See `docs/skills/ci.md` → "CI fix workflow for agents" for the correct PR sequence.
+
 ## Repo rules
 
 - All PRs target `testing`. Never `main`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -15,9 +15,11 @@ Bluefin's CI is split between PR validation, image builds, post-build e2e, weekl
 | `renovate-automerge.yml` | Successful `PR Validation — testsuite` workflow | Enables squash auto-merge for matching Renovate PRs |
 | `bonedigger.yml` | Issue events, issue comments, daily schedule | Runs the Bluefin 🦖 issue lifecycle bot |
 
-## Centralized build workflow (`projectbluefin/actions`)
+## Centralized actions (`projectbluefin/actions`)
 
-The shared image build engine lives in [`projectbluefin/actions`](https://github.com/projectbluefin/actions) at `.github/workflows/reusable-build.yml`. The internal `reusable-build.yml` has been deleted — all three stream callers delegate to the centralized workflow:
+Shared reusable workflows and composite actions for the Bluefin build pipeline live in [`projectbluefin/actions`](https://github.com/projectbluefin/actions). **Do not add new action pins inline in workflow files** — if the same action would be used in more than one workflow, it belongs in a composite action in `projectbluefin/actions`. This keeps Renovate updates centralised: one PR in `projectbluefin/actions` propagates to all consumers.
+
+The internal `reusable-build.yml` has been deleted — all three stream callers delegate to the centralized workflow:
 
 ```yaml
 uses: projectbluefin/actions/.github/workflows/reusable-build.yml@<SHA>
@@ -30,21 +32,37 @@ uses: projectbluefin/actions/.github/workflows/reusable-build.yml@<SHA>
 - On non-PR events it pushes to GHCR, signs images with cosign, uploads SBOMs, and emits attestations
 - On PR events it uploads a `.oci` artifact and prints bootc test instructions instead of pushing
 
+### Available composite actions
+
+| Action | Purpose |
+|---|---|
+| `bootc-build/setup-runner` | Update podman, BTRFS mount, install tools |
+| `bootc-build/detect-changes` | Detect changed paths; compute `image_flavors` matrix for PR builds |
+| `bootc-build/validate-pr` | PR validation: just check, shellcheck, hadolint, pre-commit (all tool pins live here) |
+| `bootc-build/dnf-cache` | Restore/save buildah layer cache |
+| `bootc-build/preflight` | Validate registry auth, normalize image refs |
+| `bootc-build/push-image` | GHCR push with retry and digest capture |
+| `bootc-build/sign-and-publish` | Cosign sign + SBOM + attestation |
+| `bootc-build/rechunk` | rpm-ostree rechunking for OTA deltas |
+| `bootc-build/generate-tags` | Generate OCI tags from stream, version, and event context |
+
+See [`docs/skills/ci.md`](skills/ci.md) → "Shared actions architecture" for the full catalog and fix-first workflow.
+
 ## How PRs are validated
 
 A normal Bluefin PR should target `testing`.
 
-`pr-validation.yml` runs these steps:
+`pr-validation.yml` runs validation via the shared `bootc-build/validate-pr` action from `projectbluefin/actions`:
 
-1. Checkout
-2. Install `just`
-3. Install `shellcheck`
-4. Install `pre-commit`
-5. Run `just check`
-6. Run `shellcheck build_files/**/*.sh`
+1. Install `just` (via `taiki-e/install-action`)
+2. Install `shellcheck`
+3. Install `pre-commit`
+4. Run `just check`
+5. Run `shellcheck build_files/**/*.sh`
+6. Run `hadolint` on `Containerfile`
 7. Run `pre-commit run --all-files`
 
-This workflow is intentionally fast. It validates repo health without doing a full local-style container build.
+This workflow is intentionally fast. It validates repo health without doing a full local-style container build. All tool pins (hadolint, install-action) live in `bootc-build/validate-pr` — Renovate bumps them once there, not per-workflow.
 
 ## How testing promotion works
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -108,11 +108,11 @@ If `main` advanced during promotion, the workflow aborts on purpose.
 
 - `post-testing-e2e.yml` is the continuous gate; weekly promotion assumes it already passed on the exact `main` SHA
 - A skipped workflow can still satisfy a required check if GitHub considers it skipped-by-filter
-- Stable release generation depends on SBOM assets existing for the images being diffed — testing stream skips SBOM, so promoted images lack them until #213 is fixed
+- Stable release generation depends on SBOM assets existing for the images being diffed — testing stream skips SBOM generation; promoted images lack signed SBOMs until a separate SBOM pass runs
 - Bluefin docs-only changes often skip image builds due to path filters; that is usually expected
 - **Testsuite pin lives in `run-testsuite.yml` only** — all other workflows must call this wrapper; never call `projectbluefin/testsuite/.github/workflows/e2e.yml` directly
-- Weekly promotion uses retag-only (skopeo copy) for the canonical path; a parallel rebuild pathway also exists via branch push (dual provenance — see #225)
-- `secrets: inherit` in build callers passes ALL org secrets to reusable-build; only `GITHUB_TOKEN` is needed (#220)
+- Weekly promotion uses retag-only (skopeo copy) for the canonical path; a parallel rebuild pathway also exists via branch push
+- Build callers do not pass `secrets: inherit` — `reusable-build.yml` only needs `GITHUB_TOKEN`, which is automatically available
 
 ## Shared actions architecture (projectbluefin/actions)
 
@@ -124,6 +124,8 @@ Common CI/CD logic lives in reusable GitHub Actions at **https://github.com/proj
 | `bootc-build/dnf-cache` | ✅ live `@v1` | Restore/save buildah cache with chmod 777 workaround |
 | `bootc-build/ghcr-cleanup` | ✅ live `@v1` | Parameterized GHCR image retention |
 | `bootc-build/preflight` | ✅ live `@v1` | Validate registry auth, normalize image refs, check required secrets |
+| `bootc-build/detect-changes` | ✅ live `@v1` | Detect changed paths; compute image-flavor build matrix (`image_flavors`, `should_build`) |
+| `bootc-build/validate-pr` | ✅ live `@v1` | PR validation: just check, shellcheck, hadolint, pre-commit — all tool pins live here |
 | `bootc-build/push-image` | ✅ live `@v1` | Push once + skopeo copy for alias tags, digest capture |
 | `bootc-build/sign-and-publish` | ✅ live `@v1` | Cosign sign (keyless or key-based) + Syft SBOM + ORAS attach + attestation |
 | `bootc-build/rechunk` | ✅ live `@v1` | rpm-ostree chunkah rechunking with delta support |
@@ -151,14 +153,33 @@ Replace inline workflow steps with action calls:
 - Each action is independently consumable (no monolithic action bundle)
 - Signing mode is an input (`keyless` or `key-based`), not hardcoded
 - Actions pin to `@v1` semver tags; Renovate tracks updates via `github-actions` manager
-- The `projectbluefin/actions` repo is live at https://github.com/projectbluefin/actions
-- Pin consuming workflows to `@v1`; Renovate tracks updates via `github-actions` manager
-- P2 actions (`generate-tags`, `generate-release`) are tracked in bluefin issue #134
+- The full catalog and authoring guide lives at **https://github.com/projectbluefin/actions/tree/main/docs/skills**
+
+### CI fix workflow for agents
+
+When you encounter a CI issue that involves duplicated inline steps, path-filter logic, or pinned third-party actions in `.github/workflows/`, check whether the fix belongs in `projectbluefin/actions` first:
+
+| Belongs in `projectbluefin/actions` | Stays in this repo |
+|---|---|
+| Shared step sequences (validate-pr, detect-changes) | Caller permissions scoping |
+| Third-party action pins (hadolint, install-action, paths-filter) | `reusable-build.yml` caller inputs |
+| Logic used in ≥2 workflows or ≥2 consumer repos | Repo-specific Justfile recipes |
+| Path-filter definitions shared across workflows | Workflow scheduling, triggers, concurrency |
+
+**Correct sequence when a fix belongs in `projectbluefin/actions`:**
+
+1. Open a PR in `projectbluefin/actions` on a feature branch
+2. Open a draft PR here pinned to the feature branch SHA (e.g. `projectbluefin/actions/bootc-build/detect-changes@<SHA>`)
+3. CI must pass on this draft PR before the actions PR merges
+4. After the actions PR merges and `@v1` moves, update this PR to `@v1`
+
+Never duplicate an existing shared action inline — doing so creates a second Renovate pin that drifts independently.
 
 ## Hard rules for agents
 
 - **PRs always target `testing`.** Never `main`. If you open a PR targeting `main`, close it and re-open.
-- **Never add shared CI logic to `.github/` or `common`.** New reusable actions go in `projectbluefin/actions` only.
+- **Never add shared CI logic to `.github/` or `common`.** New reusable actions go in `projectbluefin/actions` only. See "CI fix workflow for agents" above for the correct sequence.
+- **Never inline a third-party action that is already wrapped in `projectbluefin/actions`.** Use the shared action instead; duplicating the pin creates Renovate drift.
 - **Read the actual workflow files before writing about them.** Stored memory about tags, steps, or behavior can be stale. Open the file and verify.
 - **PATs are forbidden in projectbluefin repos.** Never add `RENOVATE_TOKEN` or any PAT secret. Renovate uses GitHub App auth via `projectbluefin/renovate-config`. Trigger Renovate: `gh workflow run "Renovate Self-Hosted" --repo projectbluefin/renovate-config`
 - **No personal tool artifacts in community files.** This repo is shared; do not include powerlevel ratings, personal skill patterns, or client-specific references in `docs/`.


### PR DESCRIPTION
## Summary

Updates the CI documentation to make the shared `projectbluefin/actions` architecture explicit for agents. Fixes stale issue-number references that have since been resolved.

### Changes

**`AGENTS.md`**
- Add a "Shared CI building blocks" section with the org pipeline diagram showing that `projectbluefin/actions` sits upstream
- Add a pointer: check if broken CI logic is in a shared action before fixing it here

**`docs/ci.md`**
- Rename section to "Centralized actions" and explain the no-inline-pins rule
- Add composite action table (including new `detect-changes` and `validate-pr`)
- Update the PR validation description to reflect the `validate-pr` action

**`docs/skills/ci.md`**
- Add `detect-changes` and `validate-pr` to the shared actions table (both ✅ live `@v1` pending #33 + #34 merges)
- Replace "Design decisions" with **"CI fix workflow for agents"**: decision table (what belongs in actions vs. here) + 4-step PR sequence
- Add hard rule: "Never inline a third-party action already wrapped in `projectbluefin/actions`"
- Clean up stale issue-number references in non-obvious patterns

### Why

Multiple CI PRs were being opened in this repo to fix logic that belongs in `projectbluefin/actions` (e.g. duplicate `dorny/paths-filter` blocks, per-workflow hadolint pins). Agents need an explicit rule and workflow to follow. The `validate-pr` and `detect-changes` actions now centralize those pins — Renovate bumps them once in `projectbluefin/actions` and all consumers inherit.

### Related

- `projectbluefin/actions` PR #35 (companion docs PR, adds CI-fix-first section)
- `projectbluefin/actions` PR #33 (detect-changes action)
- `projectbluefin/actions` PR #34 (validate-pr action)
- bluefin PR #250 (consumer using both new actions)