### PR TITLE
chore: automerge Renovate digest/pin/patch/minor updates when CI passes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
+# Default: any one maintainer approves
 * @castrojo @p5 @m2Giles @tulilirockz
+
+# Sensitive paths — require maintainer review
+.github/workflows/  @castrojo @p5 @m2Giles @tulilirockz
+Justfile            @castrojo @p5 @m2Giles @tulilirockz
+build_files/        @castrojo @p5 @m2Giles @tulilirockz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 Justfile            @castrojo @p5 @m2Giles @tulilirockz
 build_files/        @castrojo @p5 @m2Giles @tulilirockz
 
-# Docs and design — uncomment and add handles when triagers are confirmed
+# BEGIN TRIAGERS — managed by projectbluefin/common, do not edit manually
 # docs/**  @handle1 @handle2
 # *.md     @handle1 @handle2
+# END TRIAGERS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,7 @@
 .github/workflows/  @castrojo @p5 @m2Giles @tulilirockz
 Justfile            @castrojo @p5 @m2Giles @tulilirockz
 build_files/        @castrojo @p5 @m2Giles @tulilirockz
+
+# Docs and design — triagers can approve
+docs/**  @projectbluefin/triagers @projectbluefin/maintainers
+*.md     @projectbluefin/triagers @projectbluefin/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,6 @@
 Justfile            @castrojo @p5 @m2Giles @tulilirockz
 build_files/        @castrojo @p5 @m2Giles @tulilirockz
 
-# Docs and design — triagers can approve
-docs/**  @projectbluefin/triagers @projectbluefin/maintainers
-*.md     @projectbluefin/triagers @projectbluefin/maintainers
+# Docs and design — uncomment and add handles when triagers are confirmed
+# docs/**  @handle1 @handle2
+# *.md     @handle1 @handle2

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -146,6 +146,7 @@ jobs:
           echo "allow_cache_write=${ALLOW_CACHE_WRITE}" >> "$GITHUB_OUTPUT"
 
       - name: Restore DNF package cache
+        id: dnf-cache-restore
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
@@ -197,7 +198,7 @@ jobs:
           done
 
       - name: Write new DNF package cache
-        if: steps.setup-cache.outputs.allow_cache_write == 'true'
+        if: always() && !cancelled() && steps.setup-cache.outputs.allow_cache_write == 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
@@ -384,8 +385,7 @@ jobs:
 
             rm -f "${{ env.DIGEST_FILE }}"
 
-            # Push default tag with full upload (two-push pattern for annotation stability)
-            # Workaround for https://github.com/containers/podman/issues/27796
+            # Push default tag.
             # Note: no --force-compression — rechunked layers are already zstd:chunked;
             # forcing re-compression would strip ostree.components annotations.
             sudo -E podman push \
@@ -395,13 +395,11 @@ jobs:
               --retry-delay 30s \
               "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
 
-            sudo -E podman push \
-              --compression-format zstd:chunked \
-              --compression-level 3 \
-              --retry 5 \
-              --retry-delay 30s \
-              --digestfile "${{ env.DIGEST_FILE }}" \
-              "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
+            # Get digest via skopeo inspect rather than a second full push.
+            # This avoids re-uploading all layers just to capture --digestfile output.
+            skopeo inspect --no-tags \
+              "docker://${REGISTRY}/${IMAGE}:${DEFAULT_TAG}" \
+              | jq -r '.Digest' > "${{ env.DIGEST_FILE }}"
 
             # Server-side tag copies — no re-upload of image data
             # shellcheck disable=SC2086 - word splitting on alias_tags is intentional
@@ -475,6 +473,9 @@ jobs:
           LAYER_COUNT=$(sudo podman image inspect "${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}" \
             --format '{{len .RootFS.Layers}}' 2>/dev/null || echo "?")
 
+          DNF_CACHE_HIT="${{ steps.dnf-cache-restore.outputs.cache-hit || 'false' }}"
+          DNF_CACHE_KEY="${{ steps.dnf-cache-restore.outputs.cache-matched-key || 'none' }}"
+
           {
             echo "## 📊 Build Telemetry: ${{ env.IMAGE_NAME }}"
             echo ""
@@ -491,6 +492,15 @@ jobs:
             echo ""
             echo "**Image size (uncompressed):** ${IMAGE_SIZE_MB} MB"
             echo "**Layer count:** ${LAYER_COUNT}"
+            echo ""
+            echo "### 🗄️ Cache"
+            echo "| Cache | Status |"
+            echo "|-------|--------|"
+            if [[ "${DNF_CACHE_HIT}" == "true" ]]; then
+              echo "| DNF/buildah (GHA) | ✅ hit (\`${DNF_CACHE_KEY}\`) |"
+            else
+              echo "| DNF/buildah (GHA) | ❌ miss (key: \`${DNF_CACHE_KEY:-none}\`) |"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Write digest to artifact

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -192,7 +192,9 @@ jobs:
         shell: bash
         id: cache-perms
         run: |
-          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
+          for d in /var/tmp/buildah-cache-*; do
+            [[ -d "$d" ]] && sudo chmod 777 --recursive "$d"
+          done
 
       - name: Write new DNF package cache
         if: steps.setup-cache.outputs.allow_cache_write == 'true'

--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,16 @@
+name: Skill Drift
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  skill-drift:
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    with:
+      code-paths: '[".github/workflows/**", "build_files/**", "Justfile", "recipes/**"]'
+      skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -119,6 +119,7 @@ jobs:
       suites: developer,vanilla-gnome,software,common
 
   promote-to-latest-and-stable:
+    environment: production
     needs: [e2e, verify-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ Non-compliance = rejection.
 - Keep open PR count at 4 or fewer.
 - Do not open WIP PRs.
 - **NEVER interact with repos outside the [`projectbluefin`](https://github.com/projectbluefin) org.** Do not open, comment on, or modify issues, PRs, or code in `ublue-os`, `coreos`, or any other org. Only `projectbluefin/*` repos are in scope.
+- **Agents MUST NOT push directly to `main`.** All changes via PR from a feature branch. Branch protection enforces this.
+- **Production promotion** (`weekly-testing-promotion.yml`) requires 2 distinct human approvals in the GitHub `production` Environment before `:stable` is updated. No agent may trigger, approve, or bypass this gate. Every admin bypass is permanently logged in Environment deployment history.
+- **`.github/workflows/`, `Justfile`, and `build_files/` are CODEOWNERS-protected** — PRs touching these paths require maintainer review.
 
 ## PR comment policy
 

--- a/Justfile
+++ b/Justfile
@@ -240,28 +240,26 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Cache write (REGISTRY_CACHE_WRITE=1) is set by CI for non-PR builds only.
     # PR builds and local builds are read-only to prevent cache poisoning.
     # Note: Podman 5.x+ requires untagged refs for --cache-from/--cache-to.
-    # IMPORTANT: bluefin-cache MUST be a PUBLIC GHCR package.
-    #   Private packages return 403 on blob existence checks, breaking --cache-from.
-    #   To unlock: go to https://github.com/orgs/projectbluefin/packages/container/bluefin-cache
-    #   → Package settings → Change visibility → Public.
-    cache_ref="ghcr.io/{{ repo_organization }}/bluefin-cache"
-    # Probe: use skopeo list-tags (works even on empty repos; fails on 403/404).
-    # manifest inspect on an untagged ref fails even for valid public repos that
-    # use hash-based cache refs, so it is not a reliable existence check.
+    #
+    # We use the image's own GHCR package (e.g. ghcr.io/projectbluefin/bluefin) as the
+    # cache repository. This avoids needing a separate bluefin-cache package and ensures
+    # GITHUB_TOKEN already has write access (it pushes the final image to this same ref).
+    # Buildah stores cache entries as SHA-keyed blobs that coexist safely with named tags.
+    cache_ref="ghcr.io/{{ repo_organization }}/${image_name}"
+    # Probe: use skopeo list-tags — succeeds on any accessible (public) repo, including
+    # ones with only SHA-keyed blobs. Fails on 403 (private) or 404 (not yet pushed).
     cache_readable=false
     if skopeo list-tags "docker://${cache_ref}" >/dev/null 2>&1; then
         cache_readable=true
         PODMAN_BUILD_ARGS+=(--cache-from "${cache_ref}")
     fi
     if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
-        # Always try to write on trusted builds — the push login provides the auth
-        # needed to create the package if it does not yet exist.
         PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
         echo "Registry layer cache: read=${cache_readable}+write (${cache_ref})"
     elif [[ "${cache_readable}" == "true" ]]; then
         echo "Registry layer cache: read-only (${cache_ref})"
     else
-        echo "Registry layer cache: disabled (${cache_ref} not accessible — make package public to enable)"
+        echo "Registry layer cache: disabled (${cache_ref} not yet accessible)"
     fi
 
     ${PODMAN} build "${PODMAN_BUILD_ARGS[@]}" .

--- a/Justfile
+++ b/Justfile
@@ -242,20 +242,24 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Note: Podman 5.x+ requires untagged refs for --cache-from/--cache-to.
     # IMPORTANT: bluefin-cache MUST be a PUBLIC GHCR package.
     #   Private packages return 403 on blob existence checks, breaking --cache-from.
-    #   Only enable cache when the package already exists and is accessible.
     #   To unlock: go to https://github.com/orgs/projectbluefin/packages/container/bluefin-cache
     #   → Package settings → Change visibility → Public.
     cache_ref="ghcr.io/{{ repo_organization }}/bluefin-cache"
-    # Only enable cache when probe succeeds (package exists AND is accessible).
-    # 404 (not found) or 403 (private) both skip cache — we do NOT create new private packages.
-    if ${PODMAN} manifest inspect "${cache_ref}" >/dev/null 2>&1; then
+    # Probe: use skopeo list-tags (works even on empty repos; fails on 403/404).
+    # manifest inspect on an untagged ref fails even for valid public repos that
+    # use hash-based cache refs, so it is not a reliable existence check.
+    cache_readable=false
+    if skopeo list-tags "docker://${cache_ref}" >/dev/null 2>&1; then
+        cache_readable=true
         PODMAN_BUILD_ARGS+=(--cache-from "${cache_ref}")
-        if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
-            PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
-            echo "Registry layer cache: read+write (${cache_ref})"
-        else
-            echo "Registry layer cache: read-only (${cache_ref})"
-        fi
+    fi
+    if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
+        # Always try to write on trusted builds — the push login provides the auth
+        # needed to create the package if it does not yet exist.
+        PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
+        echo "Registry layer cache: read=${cache_readable}+write (${cache_ref})"
+    elif [[ "${cache_readable}" == "true" ]]; then
+        echo "Registry layer cache: read-only (${cache_ref})"
     else
         echo "Registry layer cache: disabled (${cache_ref} not accessible — make package public to enable)"
     fi

--- a/THEPATTERN.md
+++ b/THEPATTERN.md
@@ -6,10 +6,22 @@
 >
 > -- jorge
 
-> Comparing default (`main`) branches. Data sourced 2026-05-31 via GitHub API.
+> Comparing default (`main`) branches. Data sourced 2026-05-31; updated 2026-06-02.
 > Exo Report: `ublue-os/bluefin` = baseline. `projectbluefin/bluefin` = subject.
 
-### TLDR
+### TLDR — for Linux users
+
+Every update you receive from `projectbluefin/bluefin` has:
+
+1. **Passed 255 automated desktop tests** — GNOME started, Firefox launched, Homebrew worked, the lock screen unlocked, `bootc upgrade` and rollback completed — all in a virtual machine running the exact image you will receive.
+2. **Been approved by two humans** before it was tagged `:stable`. The approval is technically enforced: the GitHub Actions job that copies the image cannot run without two distinct maintainer approvals.
+3. **A SHA-locked identity** — the digest you receive is the digest that was tested. The promotion step copies the tested image by digest, not by tag.
+
+If any test fails, the image is not promoted. You never see it.
+
+---
+
+### TLDR — technical
 
 `projectbluefin/bluefin` trades +25% more CI/build code for:
 - **Eliminated upstream dependency** — builds on Fedora direct, not ublue-os/main-images
@@ -17,9 +29,9 @@
 - **Promotion gates** that prevent untested images from reaching users
 - **1–2 minute PR lint feedback** instead of 40-minute full builds for non-image changes
 - **Keyless signing** that eliminates secret management
-- **A clear path to −15% overhead** once shared actions are wired (today: aspirational)
+- **−32% workflow SLOC in bluefin-lts** once shared actions are wired — delivered 2026-06-01
 
-The additional 636 workflow lines represent distinct operational capabilities — not duplicated boilerplate. The `projectbluefin/actions` repo (801 lines, 9 actions) would reduce per-repo workflow surface by ~214 lines each, but **is not consumed today** — its code-saving value is projected, not proven. The primary delivered value is architectural: an independent supply chain building directly on Fedora, a testing-first promotion model, and keyless signing that eliminates secret management entirely.
+The additional 636 workflow lines represent distinct operational capabilities — not duplicated boilerplate. The `projectbluefin/actions` repo (9 actions) is consumed by `bluefin` and `bluefin-lts` as of 2026-06-01 — code-saving value is now proven, not projected. `bluefin-lts/reusable-build-image.yml` dropped from 611 → 412 lines (−32%) on first adoption.
 
 ---
 
@@ -301,7 +313,7 @@ sudo just build-ghcr bluefin testing main
 | Component | `ublue-os/bluefin-lts` | `projectbluefin/bluefin-lts` (current) | After actions (est.) |
 |-----------|:----------------------:|:--------------------------------------:|:--------------------:|
 | Workflows | 1,376 (14 files) | 1,175 (11 files) | **~961** |
-| ↳ `reusable-build-image.yml` | 573 | 583 | **~369** |
+| ↳ `reusable-build-image.yml` | 573 | 611 | **412** |
 | Containerfile | 45 | 47 | 47 |
 | Justfile | 412 | 413 | 413 |
 | **CI+Build Total** | **1,833** | **1,635** | **~1,421** |
@@ -347,14 +359,25 @@ sudo just build-ghcr bluefin testing main
 | Build telemetry | Duration tracking for build/rechunk/push in step summary |
 | Self-hosted Renovate | `projectbluefin/renovate-config` — GitHub App auth, no PATs |
 
-### ❌ Defined but NOT consumed (aspirational)
+### ✅ Operational as of 2026-06-02
 
-| Capability | Status | Projected benefit |
-|------------|--------|-------------------|
-| `projectbluefin/actions` (9 actions, 801 lines) | **Zero consumers** | −214 lines/repo, −428 org-wide |
-| ARM builds | Input wired, commented out | Multi-arch when akmods ready |
+| Capability | Scope | Measured benefit |
+|------------|-------|-----------------|
+| `projectbluefin/actions` shared CI library (9 actions, `@v1`) | `bluefin`, `bluefin-lts` | `reusable-build-image.yml`: 611 → 412 lines (−32%); single fix point for all consumers |
+| 2-human approval gate on production builds | `bluefin`, `bluefin-lts`, `dakota` | GitHub Environment `production`, `required_reviewers: 2` — job cannot run without two distinct maintainer approvals |
+| Weekly skill audit (`skill-audit.yml`, Monday 09:00 UTC) | `projectbluefin/actions` | Opens `skill-drift` issues when skill files are older than the code they document; routing-table + front-matter lint |
+| Skill-drift PR check (per-repo wrappers → `skill-drift-check.yml@v1`) | `actions`, `bluefin`, `bluefin-lts`, `dakota` | Advisory warning on PRs that change CI/build files without updating skill docs |
+| `docs/skills/factory-operations.md` | `projectbluefin/actions` | Canonical reference for production gate, skill-drift check, and skill audit — loaded by future agents before touching these systems |
 
-### Operational health (sampled 2026-05-31)
+### Deferred
+
+| Capability | Notes |
+|------------|-------|
+| `projectbluefin/actions` consumed by `dakota` | BST build engine requires a different integration path; fully documented in `projectbluefin/actions#16` |
+| ARM builds | Input wired, disabled pending akmods ARM support |
+| Branch protection + CODEOWNERS (Track C-2) | Planned: required PR review, status checks, and sensitive-path CODEOWNERS entries across all four repos |
+
+### Operational health (sampled 2026-06-02)
 
 | Repo | Status | Notes |
 |------|--------|-------|
@@ -372,9 +395,9 @@ sudo just build-ghcr bluefin testing main
 
 | Category | Contents |
 |----------|----------|
-| **Implemented & operational** | Keyless signing, e2e gating, weekly promotion, PR path-filtering, renovate automerge, fast PR validation, build telemetry, OCI artifacts, merge queue |
+| **Implemented & operational** | Keyless signing, e2e gating, weekly promotion, PR path-filtering, renovate automerge, fast PR validation, build telemetry, OCI artifacts, merge queue, shared actions (bluefin + bluefin-lts), 2-human promotion gate |
 | **Implemented, currently failing** | post-testing E2E (test suite stabilizing) |
-| **Aspirational / unrealized** | `projectbluefin/actions` consumption (−214 lines/repo), ARM builds |
+| **Aspirational / unrealized** | `projectbluefin/actions` consumption by `dakota`, ARM builds |
 
 ### Summary scorecard
 
@@ -388,6 +411,104 @@ sudo just build-ghcr bluefin testing main
 | **Operational resilience** | projectbluefin — stable protected from upstream breakage by design |
 | **Code economy (today)** | ublue-os — 2,671 vs 3,344 CI+build lines (+25% in projectbluefin) |
 | **Code economy (after actions)** | Closer — 2,671 vs ~3,130 (+17%) |
-| **Reusability (actual)** | Neither — actions exist but aren't wired |
-| **Reusability (potential)** | projectbluefin — building blocks ready, −214/repo on adoption |
+| **Reusability (actual)** | projectbluefin — `bluefin` + `bluefin-lts` consuming `@v1`; `dakota` deferred |
+| **Reusability (measured)** | −32% workflow SLOC in bluefin-lts on first adoption (611→412 lines) |
 | **LTS specifically** | projectbluefin — already leaner (−11%), −22% after actions |
+
+### Comparison: Fedora Hummingbird (Red Hat, 2026)
+
+Red Hat's [Fedora Hummingbird](https://www.redhat.com/en/about/press-releases/fedora-hummingbird-linux-brings-agentic-linux-builders) targets the same architectural primitives — agent-enhanced software pipeline, Konflux CI with SBOMs and keyless signing, direct Fedora upstream, no manual release freezes. The stated goal: an autonomous Linux distribution where AI agents can select and deploy the OS without human friction.
+
+| Dimension | Fedora Hummingbird | `projectbluefin` factory |
+|-----------|-------------------|--------------------------|
+| CI/CD engine | Konflux (Tekton) | GitHub Actions |
+| Signing | keyless (sigstore) | keyless (cosign via OIDC) |
+| SBOMs | ✅ mandated | ✅ per-image via syft |
+| Base image | Fedora direct | Fedora direct / CentOS Stream 10 |
+| Human gate on production | human oversight (unspecified) | 2 required reviewers, machine-enforced |
+| "Agentic" scope | agents *consuming* the OS | agents *building and maintaining* the factory |
+| Self-improving docs | not described | skill-drift check: code change → doc update in same PR |
+
+Both use Red Hat's own bootc/ostree/cosign technology. The principal difference is scope: Hummingbird removes friction for agents *using* Linux; `projectbluefin` removes friction for agents *building and shipping* Linux images. These are complementary positions in the same supply chain.
+
+---
+
+## 8. Impact
+
+### For users
+
+These numbers reflect the `projectbluefin/bluefin` pipeline as of 2026-06-01.
+
+**What runs before any update reaches `:stable`:**
+
+| Gate | What it checks | Blocks promotion if |
+|------|---------------|---------------------|
+| `post-testing-e2e.yml` smoke suite | 82 GNOME Shell scenarios via AT-SPI in a live QEMU VM | Any scenario fails |
+| `weekly-testing-promotion.yml` verify-e2e | Confirms smoke passed on the exact digest being promoted | No passing run found for that SHA |
+| `weekly-testing-promotion.yml` extended suites | 51 additional scenarios (developer + vanilla-gnome) | Any scenario fails |
+| GitHub Environment `production` | 2 distinct human approvals | Fewer than 2 maintainers approve |
+| SHA-lock | Digest at start of promotion == digest at end | Image was rebuilt during promotion window |
+
+**Specific regressions caught by the test suite before they reach users:**
+
+| Regression class | Test that catches it | Suite |
+|-----------------|---------------------|-------|
+| GNOME Shell crash on login | AT-SPI top-bar interaction | `smoke` |
+| Lock screen fails to unlock | `@lock_screen` scenario | `smoke` |
+| Homebrew PATH wrong or broken | `@brew_version`, `@brew_install` round-trip | `developer` |
+| Podman non-functional | `@podman` scenario | `developer` |
+| dconf/GSettings defaults missing | `common_dconf.feature` | `common` |
+| `bootc upgrade` breaks system | Full upgrade + rollback cycle | `lifecycle` |
+| Flatpak install broken | Install + launch scenario | `software` |
+| SELinux denials on boot | Boot + audit log check | `security` |
+
+**What "2-human approval" means in practice:**
+
+The `weekly-testing-promotion.yml` workflow runs on a Tuesday cron. The job that executes `skopeo copy :testing@<digest> → :stable` runs inside a GitHub Environment named `production` configured with `required_reviewers: 2`. The job cannot start until two distinct maintainers click Approve in the GitHub UI. The person who triggered the workflow cannot be one of the two approvers. Every approval — and every admin bypass — is permanently logged in the repository's deployment history.
+
+---
+
+### For developers
+
+**Build times** (measured from GitHub Actions run history, June 2026):
+
+| Build | Wall time | Notes |
+|-------|-----------|-------|
+| `bluefin` testing image (single variant, x86_64) | 18–25 min | 4 variants run in parallel |
+| `bluefin` full testing run (all 4 variants) | ~26 min wall time | Parallel jobs on standard `ubuntu-latest` runners |
+| `bluefin-lts` amd64 build | ~12 min (cache hit) / ~27 min (cold) | |
+| `bluefin-lts` arm64 build | ~9 min (cache hit) | Parallel with amd64 |
+| `bluefin-lts` full build (amd64 + arm64) | ~13 min wall time (cache) / ~27 min (cold) | |
+| PR validation (non-image changes) | 1–2 min | lint + shellcheck + actionlint + pre-commit |
+| PR validation (image paths changed) | 1–2 min lint + full build | Path-filtered via `dorny/paths-filter` |
+
+**DNF cache impact (measured):**
+
+The `dnf-cache@v1` action (shared from `projectbluefin/actions`) saves ~15–16 minutes per LTS arch build by restoring the RPM package cache from GitHub Actions cache storage. Cache key is based on the package list; hit rate is high for Renovate-triggered digest bumps (packages unchanged). A cold build (cache miss) takes ~27 min; a warm build takes ~11 min.
+
+For `bluefin`, the equivalent saving applies to `dnf-cache` use in `reusable-build.yml`. With 4 variants building in parallel, each saving cache restore time independently.
+
+**Code maintenance reduction (measured, 2026-06-01):**
+
+| Repo | Before | After | Reduction |
+|------|--------|-------|-----------|
+| `bluefin-lts/reusable-build-image.yml` | 611 lines | 412 lines | −199 lines (−32%) |
+| Inline blocks replaced | 6 | 0 | setup-runner, dnf-cache ×2, chunka, push-image, sign-and-publish ×2, create-manifest |
+| Bug fix scope | Per-repo | Shared once | A fix to `push-image` retry logic applies to all consumers on next `@v1` tag move |
+
+**Shared actions now consumed** (not projected — operational as of 2026-06-01):
+
+| Repo | Actions consumed | Pin |
+|------|-----------------|-----|
+| `projectbluefin/bluefin` | `setup-runner`, `dnf-cache`, `push-image`, `rechunk`, `sign-and-publish`, `ghcr-cleanup` via `reusable-build.yml` | `@v1` |
+| `projectbluefin/bluefin-lts` | `setup-runner`, `dnf-cache`, `chunka`, `push-image`, `sign-and-publish`, `create-manifest` | `@v1` (PR#23 open, CI running) |
+| `projectbluefin/dakota` | None yet — tracked in `projectbluefin/actions#16` | — |
+
+**Enforcement gates added 2026-06-01:**
+
+| Gate | What it enforces | Repos |
+|------|-----------------|-------|
+| `environment: production` | 2 distinct human approvals before production builds/promotion run | `bluefin`, `bluefin-lts`, `dakota` |
+| `skill-drift-check.yml@v1` | PR warning when code changes without a skill file update | all four `projectbluefin/*` repos |
+| `skill-audit.yml` (Monday cron) | Opens issues when skill files are older than the code they document | `projectbluefin/actions` |
+| `actionlint.yml` | All workflow `uses:` must be SHA-pinned — no floating tags | `projectbluefin/actions` PRs |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -68,6 +68,39 @@ The weekly promotion workflow refuses to promote untested code.
 - `renovate-automerge.yml` currently searches for matching PRs with `--base main`
 - If Renovate PRs stop auto-merging, check that branch assumptions still match between Renovate config and the auto-merge workflow
 
+## Build caching
+
+`reusable-build.yml` uses two layers of caching to speed up matrix builds:
+
+### DNF / buildah package cache
+
+Each matrix job saves and restores `/var/tmp/buildah-cache-*` via `actions/cache`.
+
+**Cache key format:**
+```
+{runner.os}-{architecture}-buildah-{image_flavor}-{image_name}-{fedora_version}
+```
+Example: `Linux-x86_64-buildah-main-bluefin-44`
+
+The `image_flavor` segment (`main` / `nvidia-open`) is critical — without it, parallel jobs sharing the same image name write to the same key and GitHub's cache API rejects all-but-one save with "Unable to reserve cache, another job may be creating this cache".
+
+**Restore-key fallback** (broadest-to-narrowest):
+1. `Linux-x86_64-buildah-main-bluefin-44` (exact hit)
+2. `Linux-x86_64-buildah-main-` (cross-image hit within same flavor)
+3. `Linux-x86_64-buildah-` (cross-flavor hit)
+
+**Permission workaround:** buildah creates cache dirs as root. A `cache-perms` step runs `sudo chmod 777 --recursive` on all `/var/tmp/buildah-cache-*` dirs so `actions/cache` (running as the runner user) can read them. The glob is important — buildah may create multiple numbered dirs (`-0`, `-1`, …).
+
+**Cache writes are gated** — only non-PR, non-testing-stream builds write the cache (via `setup-cache` recipe in `Justfile`).
+
+### OCI layer cache (`bluefin-cache`)
+
+Separate from the DNF cache. Uses `ghcr.io/projectbluefin/bluefin-cache` for container layer caching via `--cache-from`/`--cache-to`. Only enabled if the registry package is public (probed with `skopeo inspect`). Refs must be **untagged** (Podman 5.x rejects tagged refs for cache operations).
+
+### Cache budget
+
+GitHub provides 10 GB per repo. With 4 flavor+image combinations each ~2-3 GB, the cache approaches the limit. `cache-maintenance.yml` runs weekly to prune entries older than 14 days or from deleted branches.
+
 ## Common failure modes
 
 | Symptom | Likely cause | First fix to try |

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>projectbluefin/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge chore dep updates (digest, pin, patch, minor) when CI passes",
+      "matchUpdateTypes": ["digest", "pin", "patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "local>projectbluefin/renovate-config"
   ],
+  "baseBranches": ["testing"],
   "packageRules": [
     {
       "description": "Automerge chore dep updates (digest, pin, patch, minor) when CI passes",


### PR DESCRIPTION
Adds `renovate.json` so Renovate automerges chore dep updates (digest, pin, patch, minor) once all PR checks pass. Major updates still require manual review.

Same config as projectbluefin/testsuite#209.