### PR TITLE
fix(ci): centralize testsuite SHA pin through run-testsuite.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@32f06097321bc4237dbdee2484b7e3e1b2a89155 # main
+    uses: ./.github/workflows/run-testsuite.yml
     with:
       image: ghcr.io/${{ github.repository_owner }}/bluefin:latest
       suites: smoke,common,vanilla-gnome

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -78,7 +78,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@32f06097321bc4237dbdee2484b7e3e1b2a89155 # main
+    uses: ./.github/workflows/run-testsuite.yml
     with:
       image: ${{ needs.build.outputs.image }}
       suites: smoke


### PR DESCRIPTION
Fixes #223

Routes nightly.yml, pr-smoke.yml, and pr-validation.yml through the single canonical wrapper run-testsuite.yml. Only one file now contains the testsuite SHA pin.