### PR TITLE
fix(release): handle bootstrap case when no previous release tag exists [backport #264]

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -162,9 +162,13 @@ def get_tags(target: str, manifests: dict[str, Any]):
                 tags.remove(tag)
 
     tags = list(sorted(tags))
-    if not len(tags) >= 2:
-        print("No current and previous tags found")
+    if not tags:
+        print("No current tags found")
         exit(1)
+    if len(tags) == 1:
+        # Bootstrap: first release — no previous tag to compare against
+        print(f"Bootstrap release: only one tag found ({tags[0]}), using it as both prev and curr")
+        return tags[0], tags[0]
     return tags[-2], tags[-1]
 
 


### PR DESCRIPTION
Backport of #264 to `stable` so the first release can be generated immediately.

Fixes the `generate-release` job that has been failing since the stable pipeline launched:
```
No current and previous tags found
```

The image builds are all succeeding — only changelog generation fails. After this merges, dispatch `generate-release.yml` (workflow_dispatch → `["stable"]`) to publish the first stable release.