### PR TITLE
docs: restructure README with consistent structure and release cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,126 +1,63 @@
 # Bluefin
 *Deinonychus antirrhopus*
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/projectbluefin/bluefin/badge)](https://scorecard.dev/viewer/?uri=github.com/projectbluefin/bluefin)[![Stable Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml)[![Latest Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml)
+[![Stable Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml) [![Latest Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/projectbluefin/bluefin/badge)](https://scorecard.dev/viewer/?uri=github.com/projectbluefin/bluefin) [![LFX Active Contributors](https://insights.linuxfoundation.org/api/badge/active-contributors?project=ublue-os-bluefin&repos=https://github.com/ublue-os/bluefin)](https://insights.linuxfoundation.org/project/ublue-os-bluefin/repository/ublue-os-bluefin/security) [![Installs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json&label=Installs)](https://github.com/projectbluefin/bluefin) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/projectbluefin/bluefin)
 
-[<img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json&label=Bluefin&logo=data:image%2Fpng;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC%2FxhBQAAAAFzUkdCAdnJLH8AAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB%2BkHDxYrIEJpLs8AAAXQSURBVFjD7ZZrbFtnGcf%2F55z3XO1jJ7ZjO7c2Sd1bmnVNM5o2tIh2mgYf6IYYk5iAsolREAMJaRI3CZAmkCYkJk0UpKBpW7VVRR0S64o2NNY1nVibdkvWdk7WS2wnji%2BxHdvpOcfnfg6fQEOwSkiJ%2BJLf9%2Bd9fh%2Be93n%2BwDrrrPN%2FhlrrBjs7H4kM7OvfF44mDsf6kgfqRAyYrZW3i6cmvnNu5g86WavGI9u%2BzX%2F2C596SZDbvxQRWMo1W5idnQHXl0L3th1HFuOXZzGDp5m1EggbA0O7eq1nmfo8ZVXyWFnKI5XqQUuKwFGbkCNyKub3HFszgZqVXhrq3b0NvudUm3bS79kINdIF17DgwQXLC22Tpy7Pr4nA%2FWNPEK7Rv%2F319PO%2FjyV2jbu6Je%2FZIOyLGg1wKxVoQghEECBE2MKqDeHm2CPJ%2BHB8%2F5bR0WGfpr9JeDZOeGHJVJV3qrcyk1ud5Sc7E6GEJIhYau%2BDRhF8dOnK5B0FDg49ThZzy2ObH9j9XYbmUjRhZgPt4ZuU55amXjkHe8XwEju6tvfvH34sMbC5TZQk0FIIvmdDWa4gHIvD1nWYug61VkG4fB0hiYMR7Ydi2yjfyP3yEwUevu%2F7T3WPjf6gs6s7wPM8bB%2BAIKJFCBzTg0cBlOvArFdA0wxc1wANAoqmwXACwIvwHQueZUBr1BBKboBRyIF3W6CD7SABHlNv%2FO3R%2FxDYEnqo%2F96ffO14Isjvl2wbqqbAjSfh16qgbQuBaASaYcAmElzThG2boAkHQmhYpgUp2gGlXIQginAsEzTLgqEZUDQN13VAKAKP9qDVKrULL7%2B79d%2F2wKGxxw%2FsOvz5v0gsZLpewbKiICnRsOabkAUOK80qiFZByNCgtHfBlOMgHgOGMIAHEIaB12qBE3g0a1WwUhDNUh69Ayn4lAfLsGBRNkTiAGr16en8C%2FV%2FCXzu3qOH9o4MviaqBUlt%2BQiEg6jV6hBTG5Av5%2BHIAVxrMnAJDYuWQZVa6IYCz%2FPA8jY4QYShtSCxBIThYTsOGNdH3%2BatcD0bhqoie2sOvRt70CyXJ0pT5WcAgBlLPSrI3vaffvozqed7wgH26rUMBlOdmLyUtof7Ikwul7tQLjVemFpQzto8f5fPUBINAsBH87YGrWVgcSaDjs4OiJIEyqcAyke1WIVEXMiMDZ8PgmEoULaBWmYeMxezP5%2B4Mv4BADDtgR3S6N6O32xKyHFHbaLRbOkdvM3emC2fDHJG%2FczZpa%2B8Of3c6fncxYkOo%2Fe5Sr5%2BwYMd0xVtAPBBcSyUpoJYNAQxIAI%2BoN1uIrtQwkgY8CkCgVCwaBYsL2DuZhEs638xpG1qVfQP3yXdUfarG9rYVoyYuJatn9sS5dpW6s2reoD9xi9eftb%2F%2BIxcnHuxDuDVL3c%2BcfrU%2Bd%2F6ewYeCzoB%2Bliyt%2F2hGOdLlKHAtmzM3VyEKAdQzZfQ32uiYOgIiQJuhxK4e2QTPnjtLcCnbwAAE5UGC0M94lZVb509ebrxY8PW3i%2FowWfOnD%2Fmf9IXnZm%2FBAAoNKatUmXqzw%2BOHfxRTKR42lBx4fyHoEMByBIHDTTMhQXIroZioAODsofyrTzy2ao2XTx5BADIZOZEcTKDo%2F98%2FPoV5P%2FXLShYismprjy3qJy8XW0c4FtqiE6E5xdyyq%2B4kHP37m7%2BhzElh6wfQU1ptGyb%2Btmhe77Fnn1v3F6VWxAkqR2m7e2aTKt7BMnZa%2BrOpXJGPRrvYCjP5t%2B5q4v%2B3vKy5r3xev5EUqb%2B9NfpF3%2BdLb7vAcCq5IFszjo%2BvF04YqsrO7%2F%2B5OGhm3MLbsvwXg23i6%2BU5orpP16sDnEy2WjxZCZTcEofr10VgZ6dHRO65eu772k%2Fdv2jue7Lf79Cg2aFtra2DC8G3z6TPp4GkP5vtfRqCLx5%2FneuYVjpZIiM1GYXKFvlirpujy9kmstNw5DvVLtqkaywbJyI2I5XXNHJ6MFB8%2BrVxafemhlfRHY9eK9zZ%2F4BT9GkAVNsoqgAAAAASUVORK5CYII%3D">](https://github.com/projectbluefin/bluefin)
-
-[![LFX Active Contributors](https://insights.linuxfoundation.org/api/badge/active-contributors?project=ublue-os-bluefin&repos=https://github.com/ublue-os/bluefin)](https://insights.linuxfoundation.org/project/ublue-os-bluefin/repository/ublue-os-bluefin/security)
-
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/projectbluefin/bluefin)
-
-**Bluefin** is a cloud-native desktop operating system that reimagines the Linux desktop experience for modern computing environments.
-
-For end users, it provides a system as reliable as a Chromebook with near-zero maintenance. For developers, it offers a kickass cloud-native developer workflow with integrated container tools, declarative system management, and seamless CI/CD integration. Check [Introduction to Bluefin](https://docs.projectbluefin.io/introduction/) for a feature walkthrough.
+**Bluefin** is a cloud-native desktop operating system built on Fedora Linux. For end users it provides a system as reliable as a Chromebook with near-zero maintenance. For developers, it offers a cloud-native workflow with integrated container tools, declarative system management, and seamless CI/CD integration.
 
 🌐 **[Try Bluefin](https://projectbluefin.io/#scene-picker)**
 
 ![image](https://github.com/user-attachments/assets/e7d2a0af-b011-459a-8ab7-c26d3ba50ae5)
 
-## Mission
+## Latest Release
 
-Bluefin's mission is to provide a robust, cloud-native desktop operating system that bridges the gap between consumer usability and enterprise-grade infrastructure practices. We aim to deliver:
-
-- **Reliability**: Atomic updates ensuring system stability
-- **Developer Experience**: Integrated cloud-native tooling and workflows, including Kubernetes and container support
-- **Sustainability**: Reduced maintenance overhead for contributors by using the latest cloud native infrastructure tech
-
-## Releases
-
-<a href="https://docs.projectbluefin.io/changelogs">
+<a href="https://docs.projectbluefin.io/changelogs/">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://docs.projectbluefin.io/img/cards/bluefin-dark.png">
-    <img src="https://docs.projectbluefin.io/img/cards/bluefin-light.png" alt="Bluefin" width="800">
+    <img src="https://docs.projectbluefin.io/img/cards/bluefin-light.png" alt="Bluefin latest release" width="800">
   </picture>
 </a>
 
-## Communications
+## Images
 
-### Community Channels
-
-- **📰 [Announcements](https://blog.projectbluefin.io/)** - Official project blog and announcements
-- **[Project Board](https://todo.projectbluefin.io)** - What we're working on
-- **💬 [Discussions](https://community.projectbluefin.io/)** - Community forum (strongly recommended!)
-- **📖 [Documentation](https://docs.projectbluefin.io/)** - Documentation and User Guides
-- **🔧 [Contributing Guide](https://docs.projectbluefin.io/contributing)** - How to contribute to the project
-- **🔒 [Security Policy](SECURITY.md)** - Reporting vulnerabilities
+Browse available streams, versions, and `bootc switch` commands on the **[Images page →](https://docs.projectbluefin.io/images/)**
 
 ## Getting Started
 
-Visit [projectbluefin.io](https://projectbluefin.io/#scene-picker) to explore installation options and get started with Bluefin.
+Visit **[projectbluefin.io](https://projectbluefin.io/#scene-picker)** to download and install Bluefin, or check the **[Documentation](https://docs.projectbluefin.io/)** for detailed guides.
 
 ### Secure Boot
 
-Secure Boot is supported by default on our systems, providing an additional layer of security. After the first installation, you will be prompted to enroll the secure boot key in the BIOS.
+Secure Boot is supported by default. After the first installation you will be prompted to enroll the secure boot key in the BIOS. Enter the password `universalblue` when prompted.
 
-Enter the password `universalblue`
-when prompted to enroll our key.
+To enroll manually:
 
-If this step is not completed during the initial setup, you can manually enroll the key by running the following command in the terminal:
-
-`
+```bash
 ujust enroll-secure-boot-key
-`
+```
 
-Secure boot is supported with our custom key. The pub key can be found in the root of the akmods repository [here](https://github.com/ublue-os/akmods/raw/main/certs/public_key.der).
-If you'd like to enroll this key prior to installation or rebase, download the key and run the following:
+The public key is available in the [akmods repository](https://github.com/ublue-os/akmods/raw/main/certs/public_key.der). To enroll prior to installation or rebase:
 
 ```bash
 sudo mokutil --timeout -1
 sudo mokutil --import public_key.der
 ```
 
-## Code of Conduct
+## Community
 
-This project follows the [Universal Blue Community Guidelines](https://docs.projectbluefin.io/contributing#community-guidelines). We are committed to providing a welcoming and inclusive environment for all contributors and users.
+- 📰 **[Blog](https://blog.projectbluefin.io/)** — announcements and release posts
+- �� **[Discussions](https://community.projectbluefin.io/)** — community forum
+- 📋 **[Project Board](https://todo.projectbluefin.io/)** — what we're working on
+- 📖 **[Documentation](https://docs.projectbluefin.io/)** — user guides and reference
 
-All participants in our community are expected to follow our code of conduct. Please report any violations to the project maintainers.
+## Contributing
+
+See the **[Contributing Guide](https://docs.projectbluefin.io/contributing/)** for how to get involved. All participants are expected to follow the [Universal Blue Community Guidelines](https://docs.projectbluefin.io/contributing#community-guidelines).
+
+Report security vulnerabilities via [SECURITY.md](SECURITY.md).
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+Apache License 2.0 — see [LICENSE](LICENSE).
 
-### Third-Party Components
-
-Bluefin incorporates and builds upon several open source projects:
-- **Fedora Linux** - Base operating system foundation
-- **GNOME Desktop Environment** - Desktop interface
-- **Universal Blue** - Cloud Native desktop infrastructure
-- **Various CNCF Projects** - Cloud-native tooling and containers
-
-All incorporated components maintain their respective licenses and attributions.
-
-## Repobeats
-
-![Alt](https://repobeats.axiom.co/api/embed/40b85b252bf6ea25eb90539d1adcea013ccae69a.svg "Repobeats analytics image")
-
-<!-- Copy-paste in your Readme.md file -->
-
-<a href="https://next.ossinsight.io/widgets/official/compose-org-participants-growth?activity=new&period=past_90_days&owner_id=120078124&repo_ids=611397346" target="_blank" style="display: block" align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=new&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=dark" width="657" height="auto">
-    <img alt="New trends of ublue-os" src="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=new&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=light" width="657" height="auto">
-  </picture>
-</a>
-
-<!-- Made with [OSS Insight](https://ossinsight.io/) -->
-
-<!-- Copy-paste in your Readme.md file -->
-
-<a href="https://next.ossinsight.io/widgets/official/compose-org-participants-growth?activity=active&period=past_90_days&owner_id=120078124&repo_ids=611397346" target="_blank" style="display: block" align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=active&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=dark" width="657" height="auto">
-    <img alt="Active trends of ublue-os" src="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=active&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=light" width="657" height="auto">
-  </picture>
-</a>
-
-
-## Star History
-
-<a href="https://star-history.com/#ublue-os/bluefin&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bluefin&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bluefin&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bluefin&type=Date" />
-  </picture>
-</a>
+Bluefin incorporates [Fedora Linux](https://fedoraproject.org/), [GNOME](https://www.gnome.org/), [Universal Blue](https://universal-blue.org/), and various CNCF projects, each under their respective licenses.

--- a/README.md
+++ b/README.md
@@ -43,22 +43,6 @@ sudo bootc switch ghcr.io/ublue-os/bluefin:latest --enforce-container-sigpolicy
 sudo bootc switch ghcr.io/ublue-os/bluefin-nvidia-open:latest --enforce-container-sigpolicy
 ```
 
-### Bluefin DX
-
-Developer-focused image with cloud-native tooling pre-installed.
-
-```bash
-# Stable — recommended
-sudo bootc switch ghcr.io/ublue-os/bluefin-dx:stable --enforce-container-sigpolicy
-# Stable — NVIDIA
-sudo bootc switch ghcr.io/ublue-os/bluefin-dx-nvidia-open:stable --enforce-container-sigpolicy
-
-# Latest — tracks Fedora latest
-sudo bootc switch ghcr.io/ublue-os/bluefin-dx:latest --enforce-container-sigpolicy
-# Latest — NVIDIA
-sudo bootc switch ghcr.io/ublue-os/bluefin-dx-nvidia-open:latest --enforce-container-sigpolicy
-```
-
 ## Getting Started
 
 Visit **[projectbluefin.io](https://projectbluefin.io/#scene-picker)** to download and install Bluefin, or check the **[Documentation](https://docs.projectbluefin.io/)** for detailed guides.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,44 @@
 
 ## Images
 
-Browse available streams, versions, and `bootc switch` commands on the **[Images page →](https://docs.projectbluefin.io/images/)**
+Full catalog at [docs.projectbluefin.io/images →](https://docs.projectbluefin.io/images/)
+
+### Bluefin
+
+Primary Bluefin desktop image for most systems.
+
+```bash
+# Stable — recommended
+sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy
+# Stable — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-nvidia-open:stable --enforce-container-sigpolicy
+
+# Stable Daily — tracks Fedora stable, daily rebuilds
+sudo bootc switch ghcr.io/ublue-os/bluefin:stable-daily --enforce-container-sigpolicy
+# Stable Daily — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-nvidia-open:stable-daily --enforce-container-sigpolicy
+
+# Latest — tracks Fedora latest
+sudo bootc switch ghcr.io/ublue-os/bluefin:latest --enforce-container-sigpolicy
+# Latest — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-nvidia-open:latest --enforce-container-sigpolicy
+```
+
+### Bluefin DX
+
+Developer-focused image with cloud-native tooling pre-installed.
+
+```bash
+# Stable — recommended
+sudo bootc switch ghcr.io/ublue-os/bluefin-dx:stable --enforce-container-sigpolicy
+# Stable — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-dx-nvidia-open:stable --enforce-container-sigpolicy
+
+# Latest — tracks Fedora latest
+sudo bootc switch ghcr.io/ublue-os/bluefin-dx:latest --enforce-container-sigpolicy
+# Latest — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-dx-nvidia-open:latest --enforce-container-sigpolicy
+```
 
 ## Getting Started
 
@@ -46,7 +83,7 @@ sudo mokutil --import public_key.der
 ## Community
 
 - 📰 **[Blog](https://blog.projectbluefin.io/)** — announcements and release posts
-- �� **[Discussions](https://community.projectbluefin.io/)** — community forum
+- 💬 **[Discussions](https://community.projectbluefin.io/)** — community forum
 - 📋 **[Project Board](https://todo.projectbluefin.io/)** — what we're working on
 - 📖 **[Documentation](https://docs.projectbluefin.io/)** — user guides and reference
 


### PR DESCRIPTION
Restructures the README to a consistent Option A layout across all three Bluefin repos (bluefin, bluefin-lts, dakota).

## Structure
1. Title + latin name + badges
2. Description + hero screenshot
3. **Latest Release** — changelog card (SBOM-sourced, regenerated nightly by docs CI)
4. **Images** — link to docs.projectbluefin.io/images/
5. Getting Started
6. Community
7. Contributing + Code of Conduct
8. License

## Changes
- Changelog card moved into dedicated 'Latest Release' section
- Added Images section linking to the images catalog page
- Consistent Community section with links to blog, discussions, project board, docs
- Cleaned badges: removed base64 logo blobs from countme badges, removed OSS Insight, Star History, and Repobeats widgets
- All doc links point to docs.projectbluefin.io