### PR TITLE
fix(ci): replace inline pr-validation steps with validate-pr composite action

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,34 +18,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Bootstrap just
-        uses: ./.github/actions/bootstrap-just
-
-      - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
-
-      - name: Install pre-commit
-        run: pip install pre-commit
-
-      - name: Check Just syntax
-        shell: bash
-        run: just check
-
-      - name: Shellcheck build scripts
-        shell: bash
-        run: |
-          shopt -s globstar nullglob
-          shellcheck build_files/**/*.sh
-
-      - name: Lint Containerfile
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+      - name: Validate PR
+        uses: projectbluefin/actions/bootc-build/validate-pr@v1
         with:
           dockerfile: Containerfile
-          config: .hadolint.yaml
-
-      - name: Run pre-commit
-        shell: bash
-        run: pre-commit run --all-files
+          hadolint-config: .hadolint.yaml
+          shellcheck-glob: "build_files/**/*.sh"
 
   testsuite:
     name: E2E smoke


### PR DESCRIPTION
## Summary

Completes the migration to `projectbluefin/actions` that was started in #232.

The build workflows now use the shared reusable workflow. This PR migrates the `validate` job in `pr-validation.yml` to use the `validate-pr` composite action, centralizing pin management for `just`, `shellcheck`, `hadolint`, and `pre-commit` in `projectbluefin/actions` (where Renovate updates them once for all consumers).

## Changes

- `.github/workflows/pr-validation.yml`: replace 8 inline steps with single `validate-pr` call

## What `validate-pr` covers

Identical behavior to current inline steps: just-check, shellcheck, hadolint, pre-commit.

## Test plan

- Ran `just check`
- Ran `pre-commit run --all-files`