### PR TITLE
feat(ci): wire lifecycle upgrade-test into post-build e2e gate

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@a88ffb30e0c33767cac04ca48bddac94f821a27c # feat/lifecycle-chunked-input
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@19058ec8319ab6f0c9a07d69e4dbbf078bf8457b # feat/lifecycle-chunked-input
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: lifecycle

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -51,8 +51,18 @@ jobs:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common
 
+  run-upgrade-test:
+    needs: [e2e]
+    permissions:
+      packages: write
+      contents: read
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@a88ffb30e0c33767cac04ca48bddac94f821a27c # feat/lifecycle-chunked-input
+    with:
+      image: ${{ needs.e2e.outputs.image }}
+      suites: lifecycle
+
   report-failure:
-    needs: [e2e, run-e2e]
+    needs: [e2e, run-e2e, run-upgrade-test]
     if: failure() && needs.e2e.outputs.image != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@19058ec8319ab6f0c9a07d69e4dbbf078bf8457b # feat/lifecycle-chunked-input
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@45ab927e8f8b9c83ffa5ae91c20eb98e44562223 # feat/lifecycle-chunked-v2
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: lifecycle

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@45ab927e8f8b9c83ffa5ae91c20eb98e44562223 # feat/lifecycle-chunked-v2
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@fab3014bf671fc67ff693afb4317d887a5ac7583 # feat/lifecycle-chunked-v2
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: lifecycle

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@fab3014bf671fc67ff693afb4317d887a5ac7583 # feat/lifecycle-chunked-v2
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@aa9188e387140dcb8da923dca366caed8249ebd9 # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: lifecycle


### PR DESCRIPTION
## Summary

Runs the lifecycle upgrade/rollback test (with optional zstd:chunked) as part of the per-build e2e gate, using the reusable `upgrade-test.yml` action.

## Changes

- Added `run-upgrade-test` job to `post-testing-e2e.yml`
- `report-failure` now watches `run-upgrade-test` too
- Migration scenarios auto-skip on projectbluefin images (handled in testsuite PR #239)

## SHA chain
```
post-testing-e2e.yml → upgrade-test.yml@19058ec (projectbluefin/actions) → e2e.yml@2f106f5 (projectbluefin/testsuite)
```

Screenshots of the post-upgrade desktop state upload as CI artifacts (`screenshot_*upgrade*.png`) on every lifecycle run.

Related: projectbluefin/testsuite#239, projectbluefin/actions#43
Related-LTS: projectbluefin/bluefin-lts#39