### PR TITLE
chore: bump upgrade-test.yml SHA to 0527fe28

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@aa9188e387140dcb8da923dca366caed8249ebd9 # main
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@0527fe28c462e3f53cb1f6674c429562861e316c # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: lifecycle


### PR DESCRIPTION
Tracks projectbluefin/actions@main (fix PR #45) which fixes the e2e.yml Flatpak screenshot step YAML parse error.