### PR TITLE
fix(ci): handle new GHCR repos in skopeo list-tags version probe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -167,7 +167,8 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     else
         ver="${tag}-${fedora_version}.$(date +%Y%m%d)"
     fi
-    skopeo list-tags docker://ghcr.io/{{ repo_organization }}/${image_name} > /tmp/repotags.json
+    skopeo list-tags docker://ghcr.io/{{ repo_organization }}/${image_name} > /tmp/repotags.json 2>/dev/null \
+        || echo '{"Tags":[]}' > /tmp/repotags.json
     if [[ $(jq "any(.Tags[]; contains(\"$ver\"))" < /tmp/repotags.json) == "true" ]]; then
         POINT="1"
         while $(jq -e "any(.Tags[]; contains(\"$ver.$POINT\"))" < /tmp/repotags.json)


### PR DESCRIPTION
## Summary

Fixes the Testing Images failure on `main` where building a new image flavor (`bluefin-dx-nvidia-open`) crashes because the GHCR repository doesn't exist yet.

### Root Cause

`skopeo list-tags docker://ghcr.io/projectbluefin/bluefin-dx-nvidia-open` fails with `name unknown` when the repo has never been pushed to. This aborts the build at the version-probe step before anything is built.

### Fix

Gracefully fall back to an empty tag list when `skopeo list-tags` fails. A non-existent repo has no existing tags, so the version string won't collide — this is the correct behavior.

```bash
skopeo list-tags docker://ghcr.io/projectbluefin/${image_name} > /tmp/repotags.json 2>/dev/null \\
    || echo '{"Tags":[]}' > /tmp/repotags.json
```

### Testing

- `just check` passes
- Reproduces: run [26894360427](https://github.com/projectbluefin/bluefin/actions/runs/26894360427) — `level=fatal msg="Error listing repository tags: fetching tags list: name unknown"`