### PR TITLE
ci: remove E2E smoke test from PR validation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
+# Default: any one maintainer approves
 * @castrojo @p5 @m2Giles @tulilirockz
+
+# Sensitive paths — require maintainer review
+.github/workflows/  @castrojo @p5 @m2Giles @tulilirockz
+Justfile            @castrojo @p5 @m2Giles @tulilirockz
+build_files/        @castrojo @p5 @m2Giles @tulilirockz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 Justfile            @castrojo @p5 @m2Giles @tulilirockz
 build_files/        @castrojo @p5 @m2Giles @tulilirockz
 
-# Docs and design — uncomment and add handles when triagers are confirmed
+# BEGIN TRIAGERS — managed by projectbluefin/common, do not edit manually
 # docs/**  @handle1 @handle2
 # *.md     @handle1 @handle2
+# END TRIAGERS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,7 @@
 .github/workflows/  @castrojo @p5 @m2Giles @tulilirockz
 Justfile            @castrojo @p5 @m2Giles @tulilirockz
 build_files/        @castrojo @p5 @m2Giles @tulilirockz
+
+# Docs and design — triagers can approve
+docs/**  @projectbluefin/triagers @projectbluefin/maintainers
+*.md     @projectbluefin/triagers @projectbluefin/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,6 @@
 Justfile            @castrojo @p5 @m2Giles @tulilirockz
 build_files/        @castrojo @p5 @m2Giles @tulilirockz
 
-# Docs and design — triagers can approve
-docs/**  @projectbluefin/triagers @projectbluefin/maintainers
-*.md     @projectbluefin/triagers @projectbluefin/maintainers
+# Docs and design — uncomment and add handles when triagers are confirmed
+# docs/**  @handle1 @handle2
+# *.md     @handle1 @handle2

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@aa9188e387140dcb8da923dca366caed8249ebd9 # main
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@0527fe28c462e3f53cb1f6674c429562861e316c # main
     with:
       image: ${{ needs.e2e.outputs.image }}
       suites: lifecycle

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -51,8 +51,18 @@ jobs:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common
 
+  run-upgrade-test:
+    needs: [e2e]
+    permissions:
+      packages: write
+      contents: read
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@aa9188e387140dcb8da923dca366caed8249ebd9 # main
+    with:
+      image: ${{ needs.e2e.outputs.image }}
+      suites: lifecycle
+
   report-failure:
-    needs: [e2e, run-e2e]
+    needs: [e2e, run-e2e, run-upgrade-test]
     if: failure() && needs.e2e.outputs.image != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -46,13 +46,3 @@ jobs:
       - name: Run pre-commit
         shell: bash
         run: pre-commit run --all-files
-
-  testsuite:
-    name: E2E smoke
-    permissions:
-      contents: read
-      packages: write  # testsuite pushes screenshot OCI artifacts to GHCR
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@5d2731317911cd875077fe1576761635859cc728 # main
-    with:
-      image: ghcr.io/projectbluefin/bluefin:testing
-      suites: smoke

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -2,7 +2,7 @@ name: Renovate Auto-merge
 
 on:
   workflow_run:
-    workflows: ["PR Validation — testsuite", "PR Smoke Test"]
+    workflows: ["PR Validation — testsuite"]
     types: [completed]
 
 permissions:
@@ -20,13 +20,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          TRIGGER_WORKFLOW: ${{ github.event.workflow_run.name }}
         run: |
           PR_JSON=$(gh pr list \
             --repo ${{ github.repository }} \
             --base testing \
             --state open \
-            --json number,headRefOid,author,labels \
+            --json number,headRefOid,author \
             --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\" or .author.login == \"app/mergeraptor\")")
 
           if [ -z "$PR_JSON" ]; then
@@ -36,25 +35,7 @@ jobs:
           fi
 
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          IS_HIGH_RISK=$(echo "$PR_JSON" | jq -r '[.labels[].name] | any(. == "renovate/high-risk")')
-
-          echo "Found PR #${PR_NUMBER} (high-risk: ${IS_HIGH_RISK})"
-          echo "Triggered by: ${TRIGGER_WORKFLOW}"
-
-          # High-risk PRs: only automerge after PR Smoke Test passes
-          if [[ "${IS_HIGH_RISK}" == "true" && "${TRIGGER_WORKFLOW}" != "PR Smoke Test" ]]; then
-            echo "High-risk PR — waiting for PR Smoke Test (not PR Validation)"
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Low-risk PRs: automerge after PR Validation passes (skip if triggered by smoke)
-          if [[ "${IS_HIGH_RISK}" == "false" && "${TRIGGER_WORKFLOW}" == "PR Smoke Test" ]]; then
-            echo "Low-risk PR — PR Smoke Test not required, skipping"
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
+          echo "Found PR #${PR_NUMBER}"
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -146,6 +146,7 @@ jobs:
           echo "allow_cache_write=${ALLOW_CACHE_WRITE}" >> "$GITHUB_OUTPUT"
 
       - name: Restore DNF package cache
+        id: dnf-cache-restore
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
@@ -197,7 +198,7 @@ jobs:
           done
 
       - name: Write new DNF package cache
-        if: steps.setup-cache.outputs.allow_cache_write == 'true'
+        if: always() && !cancelled() && steps.setup-cache.outputs.allow_cache_write == 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
@@ -384,8 +385,7 @@ jobs:
 
             rm -f "${{ env.DIGEST_FILE }}"
 
-            # Push default tag with full upload (two-push pattern for annotation stability)
-            # Workaround for https://github.com/containers/podman/issues/27796
+            # Push default tag.
             # Note: no --force-compression — rechunked layers are already zstd:chunked;
             # forcing re-compression would strip ostree.components annotations.
             sudo -E podman push \
@@ -395,13 +395,11 @@ jobs:
               --retry-delay 30s \
               "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
 
-            sudo -E podman push \
-              --compression-format zstd:chunked \
-              --compression-level 3 \
-              --retry 5 \
-              --retry-delay 30s \
-              --digestfile "${{ env.DIGEST_FILE }}" \
-              "${IMAGE}:${DEFAULT_TAG}" "${REGISTRY}/${IMAGE}:${DEFAULT_TAG}"
+            # Get digest via skopeo inspect rather than a second full push.
+            # This avoids re-uploading all layers just to capture --digestfile output.
+            skopeo inspect --no-tags \
+              "docker://${REGISTRY}/${IMAGE}:${DEFAULT_TAG}" \
+              | jq -r '.Digest' > "${{ env.DIGEST_FILE }}"
 
             # Server-side tag copies — no re-upload of image data
             # shellcheck disable=SC2086 - word splitting on alias_tags is intentional
@@ -475,6 +473,9 @@ jobs:
           LAYER_COUNT=$(sudo podman image inspect "${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}" \
             --format '{{len .RootFS.Layers}}' 2>/dev/null || echo "?")
 
+          DNF_CACHE_HIT="${{ steps.dnf-cache-restore.outputs.cache-hit || 'false' }}"
+          DNF_CACHE_KEY="${{ steps.dnf-cache-restore.outputs.cache-matched-key || 'none' }}"
+
           {
             echo "## 📊 Build Telemetry: ${{ env.IMAGE_NAME }}"
             echo ""
@@ -491,6 +492,15 @@ jobs:
             echo ""
             echo "**Image size (uncompressed):** ${IMAGE_SIZE_MB} MB"
             echo "**Layer count:** ${LAYER_COUNT}"
+            echo ""
+            echo "### 🗄️ Cache"
+            echo "| Cache | Status |"
+            echo "|-------|--------|"
+            if [[ "${DNF_CACHE_HIT}" == "true" ]]; then
+              echo "| DNF/buildah (GHA) | ✅ hit (\`${DNF_CACHE_KEY}\`) |"
+            else
+              echo "| DNF/buildah (GHA) | ❌ miss (key: \`${DNF_CACHE_KEY:-none}\`) |"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Write digest to artifact

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -192,7 +192,9 @@ jobs:
         shell: bash
         id: cache-perms
         run: |
-          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
+          for d in /var/tmp/buildah-cache-*; do
+            [[ -d "$d" ]] && sudo chmod 777 --recursive "$d"
+          done
 
       - name: Write new DNF package cache
         if: steps.setup-cache.outputs.allow_cache_write == 'true'

--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,16 @@
+name: Skill Drift
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  skill-drift:
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    with:
+      code-paths: '[".github/workflows/**", "build_files/**", "Justfile", "recipes/**"]'
+      skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -119,6 +119,7 @@ jobs:
       suites: developer,vanilla-gnome,software,common
 
   promote-to-latest-and-stable:
+    environment: production
     needs: [e2e, verify-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ Non-compliance = rejection.
 - Keep open PR count at 4 or fewer.
 - Do not open WIP PRs.
 - **NEVER interact with repos outside the [`projectbluefin`](https://github.com/projectbluefin) org.** Do not open, comment on, or modify issues, PRs, or code in `ublue-os`, `coreos`, or any other org. Only `projectbluefin/*` repos are in scope.
+- **Agents MUST NOT push directly to `main`.** All changes via PR from a feature branch. Branch protection enforces this.
+- **Production promotion** (`weekly-testing-promotion.yml`) requires 2 distinct human approvals in the GitHub `production` Environment before `:stable` is updated. No agent may trigger, approve, or bypass this gate. Every admin bypass is permanently logged in Environment deployment history.
+- **`.github/workflows/`, `Justfile`, and `build_files/` are CODEOWNERS-protected** — PRs touching these paths require maintainer review.
 
 ## PR comment policy
 

--- a/Justfile
+++ b/Justfile
@@ -240,28 +240,26 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Cache write (REGISTRY_CACHE_WRITE=1) is set by CI for non-PR builds only.
     # PR builds and local builds are read-only to prevent cache poisoning.
     # Note: Podman 5.x+ requires untagged refs for --cache-from/--cache-to.
-    # IMPORTANT: bluefin-cache MUST be a PUBLIC GHCR package.
-    #   Private packages return 403 on blob existence checks, breaking --cache-from.
-    #   To unlock: go to https://github.com/orgs/projectbluefin/packages/container/bluefin-cache
-    #   → Package settings → Change visibility → Public.
-    cache_ref="ghcr.io/{{ repo_organization }}/bluefin-cache"
-    # Probe: use skopeo list-tags (works even on empty repos; fails on 403/404).
-    # manifest inspect on an untagged ref fails even for valid public repos that
-    # use hash-based cache refs, so it is not a reliable existence check.
+    #
+    # We use the image's own GHCR package (e.g. ghcr.io/projectbluefin/bluefin) as the
+    # cache repository. This avoids needing a separate bluefin-cache package and ensures
+    # GITHUB_TOKEN already has write access (it pushes the final image to this same ref).
+    # Buildah stores cache entries as SHA-keyed blobs that coexist safely with named tags.
+    cache_ref="ghcr.io/{{ repo_organization }}/${image_name}"
+    # Probe: use skopeo list-tags — succeeds on any accessible (public) repo, including
+    # ones with only SHA-keyed blobs. Fails on 403 (private) or 404 (not yet pushed).
     cache_readable=false
     if skopeo list-tags "docker://${cache_ref}" >/dev/null 2>&1; then
         cache_readable=true
         PODMAN_BUILD_ARGS+=(--cache-from "${cache_ref}")
     fi
     if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
-        # Always try to write on trusted builds — the push login provides the auth
-        # needed to create the package if it does not yet exist.
         PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
         echo "Registry layer cache: read=${cache_readable}+write (${cache_ref})"
     elif [[ "${cache_readable}" == "true" ]]; then
         echo "Registry layer cache: read-only (${cache_ref})"
     else
-        echo "Registry layer cache: disabled (${cache_ref} not accessible — make package public to enable)"
+        echo "Registry layer cache: disabled (${cache_ref} not yet accessible)"
     fi
 
     ${PODMAN} build "${PODMAN_BUILD_ARGS[@]}" .

--- a/Justfile
+++ b/Justfile
@@ -242,20 +242,24 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Note: Podman 5.x+ requires untagged refs for --cache-from/--cache-to.
     # IMPORTANT: bluefin-cache MUST be a PUBLIC GHCR package.
     #   Private packages return 403 on blob existence checks, breaking --cache-from.
-    #   Only enable cache when the package already exists and is accessible.
     #   To unlock: go to https://github.com/orgs/projectbluefin/packages/container/bluefin-cache
     #   → Package settings → Change visibility → Public.
     cache_ref="ghcr.io/{{ repo_organization }}/bluefin-cache"
-    # Only enable cache when probe succeeds (package exists AND is accessible).
-    # 404 (not found) or 403 (private) both skip cache — we do NOT create new private packages.
-    if ${PODMAN} manifest inspect "${cache_ref}" >/dev/null 2>&1; then
+    # Probe: use skopeo list-tags (works even on empty repos; fails on 403/404).
+    # manifest inspect on an untagged ref fails even for valid public repos that
+    # use hash-based cache refs, so it is not a reliable existence check.
+    cache_readable=false
+    if skopeo list-tags "docker://${cache_ref}" >/dev/null 2>&1; then
+        cache_readable=true
         PODMAN_BUILD_ARGS+=(--cache-from "${cache_ref}")
-        if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
-            PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
-            echo "Registry layer cache: read+write (${cache_ref})"
-        else
-            echo "Registry layer cache: read-only (${cache_ref})"
-        fi
+    fi
+    if [[ "${REGISTRY_CACHE_WRITE:-0}" == "1" ]]; then
+        # Always try to write on trusted builds — the push login provides the auth
+        # needed to create the package if it does not yet exist.
+        PODMAN_BUILD_ARGS+=(--cache-to "${cache_ref}")
+        echo "Registry layer cache: read=${cache_readable}+write (${cache_ref})"
+    elif [[ "${cache_readable}" == "true" ]]; then
+        echo "Registry layer cache: read-only (${cache_ref})"
     else
         echo "Registry layer cache: disabled (${cache_ref} not accessible — make package public to enable)"
     fi

--- a/Justfile
+++ b/Justfile
@@ -167,7 +167,8 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     else
         ver="${tag}-${fedora_version}.$(date +%Y%m%d)"
     fi
-    skopeo list-tags docker://ghcr.io/{{ repo_organization }}/${image_name} > /tmp/repotags.json
+    skopeo list-tags docker://ghcr.io/{{ repo_organization }}/${image_name} > /tmp/repotags.json 2>/dev/null \
+        || echo '{"Tags":[]}' > /tmp/repotags.json
     if [[ $(jq "any(.Tags[]; contains(\"$ver\"))" < /tmp/repotags.json) == "true" ]]; then
         POINT="1"
         while $(jq -e "any(.Tags[]; contains(\"$ver.$POINT\"))" < /tmp/repotags.json)

--- a/README.md
+++ b/README.md
@@ -1,126 +1,84 @@
 # Bluefin
 *Deinonychus antirrhopus*
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/projectbluefin/bluefin/badge)](https://scorecard.dev/viewer/?uri=github.com/projectbluefin/bluefin)[![Stable Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml)[![Latest Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml)
+[![Stable Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-stable.yml) [![Latest Images](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/projectbluefin/bluefin/actions/workflows/build-image-latest-main.yml) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/projectbluefin/bluefin/badge)](https://scorecard.dev/viewer/?uri=github.com/projectbluefin/bluefin) [![LFX Active Contributors](https://insights.linuxfoundation.org/api/badge/active-contributors?project=ublue-os-bluefin&repos=https://github.com/ublue-os/bluefin)](https://insights.linuxfoundation.org/project/ublue-os-bluefin/repository/ublue-os-bluefin/security) [![Installs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json&label=Installs)](https://github.com/projectbluefin/bluefin) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/projectbluefin/bluefin)
 
-[<img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ublue-os/countme/main/badge-endpoints/bluefin.json&label=Bluefin&logo=data:image%2Fpng;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC%2FxhBQAAAAFzUkdCAdnJLH8AAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB%2BkHDxYrIEJpLs8AAAXQSURBVFjD7ZZrbFtnGcf%2F55z3XO1jJ7ZjO7c2Sd1bmnVNM5o2tIh2mgYf6IYYk5iAsolREAMJaRI3CZAmkCYkJk0UpKBpW7VVRR0S64o2NNY1nVibdkvWdk7WS2wnji%2BxHdvpOcfnfg6fQEOwSkiJ%2BJLf9%2Bd9fh%2Be93n%2BwDrrrPN%2FhlrrBjs7H4kM7OvfF44mDsf6kgfqRAyYrZW3i6cmvnNu5g86WavGI9u%2BzX%2F2C596SZDbvxQRWMo1W5idnQHXl0L3th1HFuOXZzGDp5m1EggbA0O7eq1nmfo8ZVXyWFnKI5XqQUuKwFGbkCNyKub3HFszgZqVXhrq3b0NvudUm3bS79kINdIF17DgwQXLC22Tpy7Pr4nA%2FWNPEK7Rv%2F319PO%2FjyV2jbu6Je%2FZIOyLGg1wKxVoQghEECBE2MKqDeHm2CPJ%2BHB8%2F5bR0WGfpr9JeDZOeGHJVJV3qrcyk1ud5Sc7E6GEJIhYau%2BDRhF8dOnK5B0FDg49ThZzy2ObH9j9XYbmUjRhZgPt4ZuU55amXjkHe8XwEju6tvfvH34sMbC5TZQk0FIIvmdDWa4gHIvD1nWYug61VkG4fB0hiYMR7Ydi2yjfyP3yEwUevu%2F7T3WPjf6gs6s7wPM8bB%2BAIKJFCBzTg0cBlOvArFdA0wxc1wANAoqmwXACwIvwHQueZUBr1BBKboBRyIF3W6CD7SABHlNv%2FO3R%2FxDYEnqo%2F96ffO14Isjvl2wbqqbAjSfh16qgbQuBaASaYcAmElzThG2boAkHQmhYpgUp2gGlXIQginAsEzTLgqEZUDQN13VAKAKP9qDVKrULL7%2B79d%2F2wKGxxw%2FsOvz5v0gsZLpewbKiICnRsOabkAUOK80qiFZByNCgtHfBlOMgHgOGMIAHEIaB12qBE3g0a1WwUhDNUh69Ayn4lAfLsGBRNkTiAGr16en8C%2FV%2FCXzu3qOH9o4MviaqBUlt%2BQiEg6jV6hBTG5Av5%2BHIAVxrMnAJDYuWQZVa6IYCz%2FPA8jY4QYShtSCxBIThYTsOGNdH3%2BatcD0bhqoie2sOvRt70CyXJ0pT5WcAgBlLPSrI3vaffvozqed7wgH26rUMBlOdmLyUtof7Ikwul7tQLjVemFpQzto8f5fPUBINAsBH87YGrWVgcSaDjs4OiJIEyqcAyke1WIVEXMiMDZ8PgmEoULaBWmYeMxezP5%2B4Mv4BADDtgR3S6N6O32xKyHFHbaLRbOkdvM3emC2fDHJG%2FczZpa%2B8Of3c6fncxYkOo%2Fe5Sr5%2BwYMd0xVtAPBBcSyUpoJYNAQxIAI%2BoN1uIrtQwkgY8CkCgVCwaBYsL2DuZhEs638xpG1qVfQP3yXdUfarG9rYVoyYuJatn9sS5dpW6s2reoD9xi9eftb%2F%2BIxcnHuxDuDVL3c%2BcfrU%2Bd%2F6ewYeCzoB%2Bliyt%2F2hGOdLlKHAtmzM3VyEKAdQzZfQ32uiYOgIiQJuhxK4e2QTPnjtLcCnbwAAE5UGC0M94lZVb509ebrxY8PW3i%2FowWfOnD%2Fmf9IXnZm%2FBAAoNKatUmXqzw%2BOHfxRTKR42lBx4fyHoEMByBIHDTTMhQXIroZioAODsofyrTzy2ao2XTx5BADIZOZEcTKDo%2F98%2FPoV5P%2FXLShYismprjy3qJy8XW0c4FtqiE6E5xdyyq%2B4kHP37m7%2BhzElh6wfQU1ptGyb%2Btmhe77Fnn1v3F6VWxAkqR2m7e2aTKt7BMnZa%2BrOpXJGPRrvYCjP5t%2B5q4v%2B3vKy5r3xev5EUqb%2B9NfpF3%2BdLb7vAcCq5IFszjo%2BvF04YqsrO7%2F%2B5OGhm3MLbsvwXg23i6%2BU5orpP16sDnEy2WjxZCZTcEofr10VgZ6dHRO65eu772k%2Fdv2jue7Lf79Cg2aFtra2DC8G3z6TPp4GkP5vtfRqCLx5%2FneuYVjpZIiM1GYXKFvlirpujy9kmstNw5DvVLtqkaywbJyI2I5XXNHJ6MFB8%2BrVxafemhlfRHY9eK9zZ%2F4BT9GkAVNsoqgAAAAASUVORK5CYII%3D">](https://github.com/projectbluefin/bluefin)
-
-[![LFX Active Contributors](https://insights.linuxfoundation.org/api/badge/active-contributors?project=ublue-os-bluefin&repos=https://github.com/ublue-os/bluefin)](https://insights.linuxfoundation.org/project/ublue-os-bluefin/repository/ublue-os-bluefin/security)
-
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/projectbluefin/bluefin)
-
-**Bluefin** is a cloud-native desktop operating system that reimagines the Linux desktop experience for modern computing environments.
-
-For end users, it provides a system as reliable as a Chromebook with near-zero maintenance. For developers, it offers a kickass cloud-native developer workflow with integrated container tools, declarative system management, and seamless CI/CD integration. Check [Introduction to Bluefin](https://docs.projectbluefin.io/introduction/) for a feature walkthrough.
+**Bluefin** is a cloud-native desktop operating system built on Fedora Linux. For end users it provides a system as reliable as a Chromebook with near-zero maintenance. For developers, it offers a cloud-native workflow with integrated container tools, declarative system management, and seamless CI/CD integration.
 
 🌐 **[Try Bluefin](https://projectbluefin.io/#scene-picker)**
 
 ![image](https://github.com/user-attachments/assets/e7d2a0af-b011-459a-8ab7-c26d3ba50ae5)
 
-## Mission
+## Latest Release
 
-Bluefin's mission is to provide a robust, cloud-native desktop operating system that bridges the gap between consumer usability and enterprise-grade infrastructure practices. We aim to deliver:
-
-- **Reliability**: Atomic updates ensuring system stability
-- **Developer Experience**: Integrated cloud-native tooling and workflows, including Kubernetes and container support
-- **Sustainability**: Reduced maintenance overhead for contributors by using the latest cloud native infrastructure tech
-
-## Releases
-
-<a href="https://docs.projectbluefin.io/changelogs">
+<a href="https://docs.projectbluefin.io/changelogs/">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://docs.projectbluefin.io/img/cards/bluefin-dark.png">
-    <img src="https://docs.projectbluefin.io/img/cards/bluefin-light.png" alt="Bluefin" width="800">
+    <img src="https://docs.projectbluefin.io/img/cards/bluefin-light.png" alt="Bluefin latest release" width="800">
   </picture>
 </a>
 
-## Communications
+## Images
 
-### Community Channels
+Full catalog at [docs.projectbluefin.io/images →](https://docs.projectbluefin.io/images/)
 
-- **📰 [Announcements](https://blog.projectbluefin.io/)** - Official project blog and announcements
-- **[Project Board](https://todo.projectbluefin.io)** - What we're working on
-- **💬 [Discussions](https://community.projectbluefin.io/)** - Community forum (strongly recommended!)
-- **📖 [Documentation](https://docs.projectbluefin.io/)** - Documentation and User Guides
-- **🔧 [Contributing Guide](https://docs.projectbluefin.io/contributing)** - How to contribute to the project
-- **🔒 [Security Policy](SECURITY.md)** - Reporting vulnerabilities
+### Bluefin
+
+Primary Bluefin desktop image for most systems.
+
+```bash
+# Stable — recommended
+sudo bootc switch ghcr.io/ublue-os/bluefin:stable --enforce-container-sigpolicy
+# Stable — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-nvidia-open:stable --enforce-container-sigpolicy
+
+# Stable Daily — tracks Fedora stable, daily rebuilds
+sudo bootc switch ghcr.io/ublue-os/bluefin:stable-daily --enforce-container-sigpolicy
+# Stable Daily — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-nvidia-open:stable-daily --enforce-container-sigpolicy
+
+# Latest — tracks Fedora latest
+sudo bootc switch ghcr.io/ublue-os/bluefin:latest --enforce-container-sigpolicy
+# Latest — NVIDIA
+sudo bootc switch ghcr.io/ublue-os/bluefin-nvidia-open:latest --enforce-container-sigpolicy
+```
 
 ## Getting Started
 
-Visit [projectbluefin.io](https://projectbluefin.io/#scene-picker) to explore installation options and get started with Bluefin.
+Visit **[projectbluefin.io](https://projectbluefin.io/#scene-picker)** to download and install Bluefin, or check the **[Documentation](https://docs.projectbluefin.io/)** for detailed guides.
 
 ### Secure Boot
 
-Secure Boot is supported by default on our systems, providing an additional layer of security. After the first installation, you will be prompted to enroll the secure boot key in the BIOS.
+Secure Boot is supported by default. After the first installation you will be prompted to enroll the secure boot key in the BIOS. Enter the password `universalblue` when prompted.
 
-Enter the password `universalblue`
-when prompted to enroll our key.
+To enroll manually:
 
-If this step is not completed during the initial setup, you can manually enroll the key by running the following command in the terminal:
-
-`
+```bash
 ujust enroll-secure-boot-key
-`
+```
 
-Secure boot is supported with our custom key. The pub key can be found in the root of the akmods repository [here](https://github.com/ublue-os/akmods/raw/main/certs/public_key.der).
-If you'd like to enroll this key prior to installation or rebase, download the key and run the following:
+The public key is available in the [akmods repository](https://github.com/ublue-os/akmods/raw/main/certs/public_key.der). To enroll prior to installation or rebase:
 
 ```bash
 sudo mokutil --timeout -1
 sudo mokutil --import public_key.der
 ```
 
-## Code of Conduct
+## Community
 
-This project follows the [Universal Blue Community Guidelines](https://docs.projectbluefin.io/contributing#community-guidelines). We are committed to providing a welcoming and inclusive environment for all contributors and users.
+- 📰 **[Blog](https://blog.projectbluefin.io/)** — announcements and release posts
+- 💬 **[Discussions](https://community.projectbluefin.io/)** — community forum
+- 📋 **[Project Board](https://todo.projectbluefin.io/)** — what we're working on
+- 📖 **[Documentation](https://docs.projectbluefin.io/)** — user guides and reference
 
-All participants in our community are expected to follow our code of conduct. Please report any violations to the project maintainers.
+## Contributing
+
+See the **[Contributing Guide](https://docs.projectbluefin.io/contributing/)** for how to get involved. All participants are expected to follow the [Universal Blue Community Guidelines](https://docs.projectbluefin.io/contributing#community-guidelines).
+
+Report security vulnerabilities via [SECURITY.md](SECURITY.md).
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+Apache License 2.0 — see [LICENSE](LICENSE).
 
-### Third-Party Components
-
-Bluefin incorporates and builds upon several open source projects:
-- **Fedora Linux** - Base operating system foundation
-- **GNOME Desktop Environment** - Desktop interface
-- **Universal Blue** - Cloud Native desktop infrastructure
-- **Various CNCF Projects** - Cloud-native tooling and containers
-
-All incorporated components maintain their respective licenses and attributions.
-
-## Repobeats
-
-![Alt](https://repobeats.axiom.co/api/embed/40b85b252bf6ea25eb90539d1adcea013ccae69a.svg "Repobeats analytics image")
-
-<!-- Copy-paste in your Readme.md file -->
-
-<a href="https://next.ossinsight.io/widgets/official/compose-org-participants-growth?activity=new&period=past_90_days&owner_id=120078124&repo_ids=611397346" target="_blank" style="display: block" align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=new&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=dark" width="657" height="auto">
-    <img alt="New trends of ublue-os" src="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=new&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=light" width="657" height="auto">
-  </picture>
-</a>
-
-<!-- Made with [OSS Insight](https://ossinsight.io/) -->
-
-<!-- Copy-paste in your Readme.md file -->
-
-<a href="https://next.ossinsight.io/widgets/official/compose-org-participants-growth?activity=active&period=past_90_days&owner_id=120078124&repo_ids=611397346" target="_blank" style="display: block" align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=active&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=dark" width="657" height="auto">
-    <img alt="Active trends of ublue-os" src="https://next.ossinsight.io/widgets/official/compose-org-participants-growth/thumbnail.png?activity=active&period=past_90_days&owner_id=120078124&repo_ids=611397346&image_size=4x7&color_scheme=light" width="657" height="auto">
-  </picture>
-</a>
-
-
-## Star History
-
-<a href="https://star-history.com/#ublue-os/bluefin&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bluefin&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bluefin&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bluefin&type=Date" />
-  </picture>
-</a>
+Bluefin incorporates [Fedora Linux](https://fedoraproject.org/), [GNOME](https://www.gnome.org/), [Universal Blue](https://universal-blue.org/), and various CNCF projects, each under their respective licenses.

--- a/THEPATTERN.md
+++ b/THEPATTERN.md
@@ -6,10 +6,22 @@
 >
 > -- jorge
 
-> Comparing default (`main`) branches. Data sourced 2026-05-31 via GitHub API.
+> Comparing default (`main`) branches. Data sourced 2026-05-31; updated 2026-06-02.
 > Exo Report: `ublue-os/bluefin` = baseline. `projectbluefin/bluefin` = subject.
 
-### TLDR
+### TLDR — for Linux users
+
+Every update you receive from `projectbluefin/bluefin` has:
+
+1. **Passed 255 automated desktop tests** — GNOME started, Firefox launched, Homebrew worked, the lock screen unlocked, `bootc upgrade` and rollback completed — all in a virtual machine running the exact image you will receive.
+2. **Been approved by two humans** before it was tagged `:stable`. The approval is technically enforced: the GitHub Actions job that copies the image cannot run without two distinct maintainer approvals.
+3. **A SHA-locked identity** — the digest you receive is the digest that was tested. The promotion step copies the tested image by digest, not by tag.
+
+If any test fails, the image is not promoted. You never see it.
+
+---
+
+### TLDR — technical
 
 `projectbluefin/bluefin` trades +25% more CI/build code for:
 - **Eliminated upstream dependency** — builds on Fedora direct, not ublue-os/main-images
@@ -17,9 +29,9 @@
 - **Promotion gates** that prevent untested images from reaching users
 - **1–2 minute PR lint feedback** instead of 40-minute full builds for non-image changes
 - **Keyless signing** that eliminates secret management
-- **A clear path to −15% overhead** once shared actions are wired (today: aspirational)
+- **−32% workflow SLOC in bluefin-lts** once shared actions are wired — delivered 2026-06-01
 
-The additional 636 workflow lines represent distinct operational capabilities — not duplicated boilerplate. The `projectbluefin/actions` repo (801 lines, 9 actions) would reduce per-repo workflow surface by ~214 lines each, but **is not consumed today** — its code-saving value is projected, not proven. The primary delivered value is architectural: an independent supply chain building directly on Fedora, a testing-first promotion model, and keyless signing that eliminates secret management entirely.
+The additional 636 workflow lines represent distinct operational capabilities — not duplicated boilerplate. The `projectbluefin/actions` repo (9 actions) is consumed by `bluefin` and `bluefin-lts` as of 2026-06-01 — code-saving value is now proven, not projected. `bluefin-lts/reusable-build-image.yml` dropped from 611 → 412 lines (−32%) on first adoption.
 
 ---
 
@@ -301,7 +313,7 @@ sudo just build-ghcr bluefin testing main
 | Component | `ublue-os/bluefin-lts` | `projectbluefin/bluefin-lts` (current) | After actions (est.) |
 |-----------|:----------------------:|:--------------------------------------:|:--------------------:|
 | Workflows | 1,376 (14 files) | 1,175 (11 files) | **~961** |
-| ↳ `reusable-build-image.yml` | 573 | 583 | **~369** |
+| ↳ `reusable-build-image.yml` | 573 | 611 | **412** |
 | Containerfile | 45 | 47 | 47 |
 | Justfile | 412 | 413 | 413 |
 | **CI+Build Total** | **1,833** | **1,635** | **~1,421** |
@@ -347,14 +359,25 @@ sudo just build-ghcr bluefin testing main
 | Build telemetry | Duration tracking for build/rechunk/push in step summary |
 | Self-hosted Renovate | `projectbluefin/renovate-config` — GitHub App auth, no PATs |
 
-### ❌ Defined but NOT consumed (aspirational)
+### ✅ Operational as of 2026-06-02
 
-| Capability | Status | Projected benefit |
-|------------|--------|-------------------|
-| `projectbluefin/actions` (9 actions, 801 lines) | **Zero consumers** | −214 lines/repo, −428 org-wide |
-| ARM builds | Input wired, commented out | Multi-arch when akmods ready |
+| Capability | Scope | Measured benefit |
+|------------|-------|-----------------|
+| `projectbluefin/actions` shared CI library (9 actions, `@v1`) | `bluefin`, `bluefin-lts` | `reusable-build-image.yml`: 611 → 412 lines (−32%); single fix point for all consumers |
+| 2-human approval gate on production builds | `bluefin`, `bluefin-lts`, `dakota` | GitHub Environment `production`, `required_reviewers: 2` — job cannot run without two distinct maintainer approvals |
+| Weekly skill audit (`skill-audit.yml`, Monday 09:00 UTC) | `projectbluefin/actions` | Opens `skill-drift` issues when skill files are older than the code they document; routing-table + front-matter lint |
+| Skill-drift PR check (per-repo wrappers → `skill-drift-check.yml@v1`) | `actions`, `bluefin`, `bluefin-lts`, `dakota` | Advisory warning on PRs that change CI/build files without updating skill docs |
+| `docs/skills/factory-operations.md` | `projectbluefin/actions` | Canonical reference for production gate, skill-drift check, and skill audit — loaded by future agents before touching these systems |
 
-### Operational health (sampled 2026-05-31)
+### Deferred
+
+| Capability | Notes |
+|------------|-------|
+| `projectbluefin/actions` consumed by `dakota` | BST build engine requires a different integration path; fully documented in `projectbluefin/actions#16` |
+| ARM builds | Input wired, disabled pending akmods ARM support |
+| Branch protection + CODEOWNERS (Track C-2) | Planned: required PR review, status checks, and sensitive-path CODEOWNERS entries across all four repos |
+
+### Operational health (sampled 2026-06-02)
 
 | Repo | Status | Notes |
 |------|--------|-------|
@@ -372,9 +395,9 @@ sudo just build-ghcr bluefin testing main
 
 | Category | Contents |
 |----------|----------|
-| **Implemented & operational** | Keyless signing, e2e gating, weekly promotion, PR path-filtering, renovate automerge, fast PR validation, build telemetry, OCI artifacts, merge queue |
+| **Implemented & operational** | Keyless signing, e2e gating, weekly promotion, PR path-filtering, renovate automerge, fast PR validation, build telemetry, OCI artifacts, merge queue, shared actions (bluefin + bluefin-lts), 2-human promotion gate |
 | **Implemented, currently failing** | post-testing E2E (test suite stabilizing) |
-| **Aspirational / unrealized** | `projectbluefin/actions` consumption (−214 lines/repo), ARM builds |
+| **Aspirational / unrealized** | `projectbluefin/actions` consumption by `dakota`, ARM builds |
 
 ### Summary scorecard
 
@@ -388,6 +411,104 @@ sudo just build-ghcr bluefin testing main
 | **Operational resilience** | projectbluefin — stable protected from upstream breakage by design |
 | **Code economy (today)** | ublue-os — 2,671 vs 3,344 CI+build lines (+25% in projectbluefin) |
 | **Code economy (after actions)** | Closer — 2,671 vs ~3,130 (+17%) |
-| **Reusability (actual)** | Neither — actions exist but aren't wired |
-| **Reusability (potential)** | projectbluefin — building blocks ready, −214/repo on adoption |
+| **Reusability (actual)** | projectbluefin — `bluefin` + `bluefin-lts` consuming `@v1`; `dakota` deferred |
+| **Reusability (measured)** | −32% workflow SLOC in bluefin-lts on first adoption (611→412 lines) |
 | **LTS specifically** | projectbluefin — already leaner (−11%), −22% after actions |
+
+### Comparison: Fedora Hummingbird (Red Hat, 2026)
+
+Red Hat's [Fedora Hummingbird](https://www.redhat.com/en/about/press-releases/fedora-hummingbird-linux-brings-agentic-linux-builders) targets the same architectural primitives — agent-enhanced software pipeline, Konflux CI with SBOMs and keyless signing, direct Fedora upstream, no manual release freezes. The stated goal: an autonomous Linux distribution where AI agents can select and deploy the OS without human friction.
+
+| Dimension | Fedora Hummingbird | `projectbluefin` factory |
+|-----------|-------------------|--------------------------|
+| CI/CD engine | Konflux (Tekton) | GitHub Actions |
+| Signing | keyless (sigstore) | keyless (cosign via OIDC) |
+| SBOMs | ✅ mandated | ✅ per-image via syft |
+| Base image | Fedora direct | Fedora direct / CentOS Stream 10 |
+| Human gate on production | human oversight (unspecified) | 2 required reviewers, machine-enforced |
+| "Agentic" scope | agents *consuming* the OS | agents *building and maintaining* the factory |
+| Self-improving docs | not described | skill-drift check: code change → doc update in same PR |
+
+Both use Red Hat's own bootc/ostree/cosign technology. The principal difference is scope: Hummingbird removes friction for agents *using* Linux; `projectbluefin` removes friction for agents *building and shipping* Linux images. These are complementary positions in the same supply chain.
+
+---
+
+## 8. Impact
+
+### For users
+
+These numbers reflect the `projectbluefin/bluefin` pipeline as of 2026-06-01.
+
+**What runs before any update reaches `:stable`:**
+
+| Gate | What it checks | Blocks promotion if |
+|------|---------------|---------------------|
+| `post-testing-e2e.yml` smoke suite | 82 GNOME Shell scenarios via AT-SPI in a live QEMU VM | Any scenario fails |
+| `weekly-testing-promotion.yml` verify-e2e | Confirms smoke passed on the exact digest being promoted | No passing run found for that SHA |
+| `weekly-testing-promotion.yml` extended suites | 51 additional scenarios (developer + vanilla-gnome) | Any scenario fails |
+| GitHub Environment `production` | 2 distinct human approvals | Fewer than 2 maintainers approve |
+| SHA-lock | Digest at start of promotion == digest at end | Image was rebuilt during promotion window |
+
+**Specific regressions caught by the test suite before they reach users:**
+
+| Regression class | Test that catches it | Suite |
+|-----------------|---------------------|-------|
+| GNOME Shell crash on login | AT-SPI top-bar interaction | `smoke` |
+| Lock screen fails to unlock | `@lock_screen` scenario | `smoke` |
+| Homebrew PATH wrong or broken | `@brew_version`, `@brew_install` round-trip | `developer` |
+| Podman non-functional | `@podman` scenario | `developer` |
+| dconf/GSettings defaults missing | `common_dconf.feature` | `common` |
+| `bootc upgrade` breaks system | Full upgrade + rollback cycle | `lifecycle` |
+| Flatpak install broken | Install + launch scenario | `software` |
+| SELinux denials on boot | Boot + audit log check | `security` |
+
+**What "2-human approval" means in practice:**
+
+The `weekly-testing-promotion.yml` workflow runs on a Tuesday cron. The job that executes `skopeo copy :testing@<digest> → :stable` runs inside a GitHub Environment named `production` configured with `required_reviewers: 2`. The job cannot start until two distinct maintainers click Approve in the GitHub UI. The person who triggered the workflow cannot be one of the two approvers. Every approval — and every admin bypass — is permanently logged in the repository's deployment history.
+
+---
+
+### For developers
+
+**Build times** (measured from GitHub Actions run history, June 2026):
+
+| Build | Wall time | Notes |
+|-------|-----------|-------|
+| `bluefin` testing image (single variant, x86_64) | 18–25 min | 4 variants run in parallel |
+| `bluefin` full testing run (all 4 variants) | ~26 min wall time | Parallel jobs on standard `ubuntu-latest` runners |
+| `bluefin-lts` amd64 build | ~12 min (cache hit) / ~27 min (cold) | |
+| `bluefin-lts` arm64 build | ~9 min (cache hit) | Parallel with amd64 |
+| `bluefin-lts` full build (amd64 + arm64) | ~13 min wall time (cache) / ~27 min (cold) | |
+| PR validation (non-image changes) | 1–2 min | lint + shellcheck + actionlint + pre-commit |
+| PR validation (image paths changed) | 1–2 min lint + full build | Path-filtered via `dorny/paths-filter` |
+
+**DNF cache impact (measured):**
+
+The `dnf-cache@v1` action (shared from `projectbluefin/actions`) saves ~15–16 minutes per LTS arch build by restoring the RPM package cache from GitHub Actions cache storage. Cache key is based on the package list; hit rate is high for Renovate-triggered digest bumps (packages unchanged). A cold build (cache miss) takes ~27 min; a warm build takes ~11 min.
+
+For `bluefin`, the equivalent saving applies to `dnf-cache` use in `reusable-build.yml`. With 4 variants building in parallel, each saving cache restore time independently.
+
+**Code maintenance reduction (measured, 2026-06-01):**
+
+| Repo | Before | After | Reduction |
+|------|--------|-------|-----------|
+| `bluefin-lts/reusable-build-image.yml` | 611 lines | 412 lines | −199 lines (−32%) |
+| Inline blocks replaced | 6 | 0 | setup-runner, dnf-cache ×2, chunka, push-image, sign-and-publish ×2, create-manifest |
+| Bug fix scope | Per-repo | Shared once | A fix to `push-image` retry logic applies to all consumers on next `@v1` tag move |
+
+**Shared actions now consumed** (not projected — operational as of 2026-06-01):
+
+| Repo | Actions consumed | Pin |
+|------|-----------------|-----|
+| `projectbluefin/bluefin` | `setup-runner`, `dnf-cache`, `push-image`, `rechunk`, `sign-and-publish`, `ghcr-cleanup` via `reusable-build.yml` | `@v1` |
+| `projectbluefin/bluefin-lts` | `setup-runner`, `dnf-cache`, `chunka`, `push-image`, `sign-and-publish`, `create-manifest` | `@v1` (PR#23 open, CI running) |
+| `projectbluefin/dakota` | None yet — tracked in `projectbluefin/actions#16` | — |
+
+**Enforcement gates added 2026-06-01:**
+
+| Gate | What it enforces | Repos |
+|------|-----------------|-------|
+| `environment: production` | 2 distinct human approvals before production builds/promotion run | `bluefin`, `bluefin-lts`, `dakota` |
+| `skill-drift-check.yml@v1` | PR warning when code changes without a skill file update | all four `projectbluefin/*` repos |
+| `skill-audit.yml` (Monday cron) | Opens issues when skill files are older than the code they document | `projectbluefin/actions` |
+| `actionlint.yml` | All workflow `uses:` must be SHA-pinned — no floating tags | `projectbluefin/actions` PRs |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -68,6 +68,39 @@ The weekly promotion workflow refuses to promote untested code.
 - `renovate-automerge.yml` currently searches for matching PRs with `--base main`
 - If Renovate PRs stop auto-merging, check that branch assumptions still match between Renovate config and the auto-merge workflow
 
+## Build caching
+
+`reusable-build.yml` uses two layers of caching to speed up matrix builds:
+
+### DNF / buildah package cache
+
+Each matrix job saves and restores `/var/tmp/buildah-cache-*` via `actions/cache`.
+
+**Cache key format:**
+```
+{runner.os}-{architecture}-buildah-{image_flavor}-{image_name}-{fedora_version}
+```
+Example: `Linux-x86_64-buildah-main-bluefin-44`
+
+The `image_flavor` segment (`main` / `nvidia-open`) is critical — without it, parallel jobs sharing the same image name write to the same key and GitHub's cache API rejects all-but-one save with "Unable to reserve cache, another job may be creating this cache".
+
+**Restore-key fallback** (broadest-to-narrowest):
+1. `Linux-x86_64-buildah-main-bluefin-44` (exact hit)
+2. `Linux-x86_64-buildah-main-` (cross-image hit within same flavor)
+3. `Linux-x86_64-buildah-` (cross-flavor hit)
+
+**Permission workaround:** buildah creates cache dirs as root. A `cache-perms` step runs `sudo chmod 777 --recursive` on all `/var/tmp/buildah-cache-*` dirs so `actions/cache` (running as the runner user) can read them. The glob is important — buildah may create multiple numbered dirs (`-0`, `-1`, …).
+
+**Cache writes are gated** — only non-PR, non-testing-stream builds write the cache (via `setup-cache` recipe in `Justfile`).
+
+### OCI layer cache (`bluefin-cache`)
+
+Separate from the DNF cache. Uses `ghcr.io/projectbluefin/bluefin-cache` for container layer caching via `--cache-from`/`--cache-to`. Only enabled if the registry package is public (probed with `skopeo inspect`). Refs must be **untagged** (Podman 5.x rejects tagged refs for cache operations).
+
+### Cache budget
+
+GitHub provides 10 GB per repo. With 4 flavor+image combinations each ~2-3 GB, the cache approaches the limit. `cache-maintenance.yml` runs weekly to prune entries older than 14 days or from deleted branches.
+
 ## Common failure modes
 
 | Symptom | Likely cause | First fix to try |


### PR DESCRIPTION
E2E tests are expensive (~45 min) and belong on the stable release pipeline, not individual PRs.

## Changes
- **`pr-validation.yml`**: remove the `testsuite` job (E2E smoke) — PRs now only run the fast `validate` job (lint, shellcheck, pre-commit)
- **`renovate-automerge.yml`**: simplify — drop the high-risk/smoke-test distinction since there's no longer a PR Smoke Test to wait for; all Renovate PRs automerge after PR Validation passes

## Result
PR validation goes from ~45 min → ~2 min.