### PR TITLE
ci: remove E2E smoke test from PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -24,13 +24,3 @@ jobs:
           dockerfile: Containerfile
           hadolint-config: .hadolint.yaml
           shellcheck-glob: "build_files/**/*.sh"
-
-  testsuite:
-    name: E2E smoke
-    permissions:
-      contents: read
-      packages: write  # testsuite pushes screenshot OCI artifacts to GHCR
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@32f06097321bc4237dbdee2484b7e3e1b2a89155 # main
-    with:
-      image: ghcr.io/projectbluefin/bluefin:testing
-      suites: smoke

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -2,7 +2,7 @@ name: Renovate Auto-merge
 
 on:
   workflow_run:
-    workflows: ["PR Validation — testsuite", "PR Smoke Test"]
+    workflows: ["PR Validation — testsuite"]
     types: [completed]
 
 permissions:
@@ -20,13 +20,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          TRIGGER_WORKFLOW: ${{ github.event.workflow_run.name }}
         run: |
           PR_JSON=$(gh pr list \
             --repo ${{ github.repository }} \
             --base testing \
             --state open \
-            --json number,headRefOid,author,labels \
+            --json number,headRefOid,author \
             --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\" or .author.login == \"app/mergeraptor\")")
 
           if [ -z "$PR_JSON" ]; then
@@ -36,25 +35,7 @@ jobs:
           fi
 
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          IS_HIGH_RISK=$(echo "$PR_JSON" | jq -r '[.labels[].name] | any(. == "renovate/high-risk")')
-
-          echo "Found PR #${PR_NUMBER} (high-risk: ${IS_HIGH_RISK})"
-          echo "Triggered by: ${TRIGGER_WORKFLOW}"
-
-          # High-risk PRs: only automerge after PR Smoke Test passes
-          if [[ "${IS_HIGH_RISK}" == "true" && "${TRIGGER_WORKFLOW}" != "PR Smoke Test" ]]; then
-            echo "High-risk PR — waiting for PR Smoke Test (not PR Validation)"
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Low-risk PRs: automerge after PR Validation passes (skip if triggered by smoke)
-          if [[ "${IS_HIGH_RISK}" == "false" && "${TRIGGER_WORKFLOW}" == "PR Smoke Test" ]]; then
-            echo "Low-risk PR — PR Smoke Test not required, skipping"
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
+          echo "Found PR #${PR_NUMBER}"
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge


### PR DESCRIPTION
E2E tests are expensive (~45 min) and belong on the stable release pipeline, not individual PRs.

## Changes
- `pr-validation.yml`: drop the `testsuite` job — PRs now only run the fast `validate` job (~2 min)
- `renovate-automerge.yml`: remove `PR Smoke Test` trigger and high-risk/smoke distinction — all Renovate PRs automerge after `PR Validation` passes