### PR TITLE
chore: automerge Renovate digest/pin/patch/minor updates when CI passes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>projectbluefin/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge chore dep updates (digest, pin, patch, minor) when CI passes",
+      "matchUpdateTypes": ["digest", "pin", "patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "local>projectbluefin/renovate-config"
   ],
+  "baseBranches": ["testing"],
   "packageRules": [
     {
       "description": "Automerge chore dep updates (digest, pin, patch, minor) when CI passes",


### PR DESCRIPTION
Adds `renovate.json` so Renovate automerges chore dep updates (digest, pin, patch, minor) once all PR checks pass. Major updates still require manual review.

Same config as projectbluefin/testsuite#209.

Closes #258