### PR TITLE
docs: update CI/PR workflow docs for validate-only PRs and automerge

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,13 +6,13 @@ Bluefin's CI is split between PR validation, image builds, post-build e2e, weekl
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `pr-validation.yml` | PRs to `testing`, `merge_group` | Fast validation: `just check`, `shellcheck`, `pre-commit` |
+| `pr-validation.yml` | PRs to `testing`, `merge_group` | Fast validation via `validate-pr@v1`: `just check`, `shellcheck`, `hadolint`, `pre-commit` — **no E2E on PRs** |
 | `build-image-testing.yml` | Push to `main`, `merge_group`, dispatch, workflow call | Builds testing images via centralized `projectbluefin/actions` workflow |
 | `post-testing-e2e.yml` | Successful `Testing Images` workflow on `main` push | Downloads the testing digest and runs smoke tests in `projectbluefin/testsuite` |
 | `weekly-testing-promotion.yml` | Tuesday 06:00 UTC, manual dispatch | Verifies e2e on current `main`, promotes `main` to `latest` + `stable`, triggers downstream builds |
 | `build-image-stable.yml` | Push to `stable`, dispatch, workflow call | Builds stable images and then runs `generate-release.yml` |
 | `build-image-latest-main.yml` | PR/push to `latest`, `merge_group`, dispatch | Builds latest images |
-| `renovate-automerge.yml` | Successful `PR Validation — testsuite` workflow | Enables squash auto-merge for matching Renovate PRs |
+| `renovate-automerge.yml` | Successful `PR Validation — testsuite` | Enables squash auto-merge (`gh pr merge --auto --squash`) for Renovate/mergeraptor PRs |
 | `bonedigger.yml` | Issue events, issue comments, daily schedule | Runs the Bluefin 🦖 issue lifecycle bot |
 
 ## Centralized actions (`projectbluefin/actions`)

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -34,8 +34,8 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `pr-validation.yml` | PRs to `testing`, merge_group | Fast gate via **`validate-pr@v1`**: just check, shellcheck, hadolint, pre-commit; + e2e smoke |
-| `pr-smoke.yml` | PRs touching build files | Full build + smoke test |
+| `pr-validation.yml` | PRs to `testing`, merge_group | Fast gate via **`validate-pr@v1`**: just check, shellcheck, hadolint, pre-commit — **no E2E on PRs** |
+| `pr-smoke.yml` | PRs touching build files | Full image build + smoke test |
 | `build-image-testing.yml` | Push to `main`, dispatch | Testing image builds via centralized `projectbluefin/actions` workflow |
 | `post-testing-e2e.yml` | Testing build on `main` | Smoke+common continuous e2e gate |
 | `weekly-testing-promotion.yml` | Tuesday 06:00 UTC | Full e2e → retag to :stable/:latest |
@@ -46,7 +46,7 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 | `run-testsuite.yml` | Called by all e2e workflows | **Canonical testsuite wrapper — always use this, never e2e.yml directly** |
 | `nightly.yml` | 02:00 UTC daily | smoke+common+vanilla-gnome against :latest |
 | `vulnerability-scan.yml` | Testing build + weekly | Grype → SARIF to Security tab |
-| `renovate-automerge.yml` | PR Validation / PR Smoke success | Auto-merge Renovate/mergeraptor by risk tier |
+| `renovate-automerge.yml` | PR Validation success | Auto-merge all Renovate/mergeraptor PRs via `gh pr merge --auto --squash` (no high-risk/smoke distinction) |
 | `e2e-dispatch.yml` | `/e2e` comment (write+ only) | Manual e2e on PR |
 | `generate-release.yml` | Stable build, dispatch | GitHub Release + changelog |
 | `copr-health-monitor.yml` | Daily 07:00 UTC | COPR staleness check |
@@ -99,7 +99,7 @@ If `main` advanced during promotion, the workflow aborts on purpose.
 | `No SBOM referrer found` in release generation | testing stream skips SBOM; promoted images lack signed SBOMs | allow missing SBOMs for diff generation and use intersection-only comparisons |
 | promotion says no passing e2e for current SHA | `post-testing-e2e` has not passed the locked `main` commit | wait or rerun after e2e completes |
 | required check is skipped | path filter skipped the workflow | verify whether skipped is intentional for that workflow |
-| Renovate PR did not automerge | PR lookup missed mergeraptor author or wrong base branch | accept both `renovate[bot]` and `app/mergeraptor` in jq filter; verify branch targeting `testing` |
+| Renovate PR did not automerge | PR lookup missed mergeraptor author, or `testing` branch protection not set up | accept both `renovate[bot]` and `app/mergeraptor` in jq filter; ensure `testing` has branch protection with `validate` required check and `allow_auto_merge=true` at repo level |
 | Weekly promotion cannot find digest artifact | artifact expired before Tuesday promotion window | push fresh commit to `main` to regenerate artifact |
 | Cosign sign/verify fails | Sigstore outage or key rotation | check `check-cosign-key-rotation.yml` issues; retry after Sigstore recovers |
 
@@ -109,7 +109,8 @@ If `main` advanced during promotion, the workflow aborts on purpose.
 - A skipped workflow can still satisfy a required check if GitHub considers it skipped-by-filter
 - Stable release generation depends on SBOM assets existing for the images being diffed — testing stream skips SBOM generation; promoted images lack signed SBOMs until a separate SBOM pass runs
 - Bluefin docs-only changes often skip image builds due to path filters; that is usually expected
-- **Testsuite pin lives in `run-testsuite.yml` only** — all other workflows must call this wrapper; never call `projectbluefin/testsuite/.github/workflows/e2e.yml` directly. To audit: `grep -r "projectbluefin/testsuite" .github/workflows/` — any hit outside `run-testsuite.yml` is a bug.
+- **`testing` branch has branch protection** — required status check: `validate`. `allow_auto_merge` enabled at repo level. `gh pr merge --auto --squash` works. No merge queue.
+- **E2E runs on stable promotion only** — `pr-validation.yml` runs only the fast `validate` job (~2 min). E2E smoke runs in `post-testing-e2e.yml` (after push to `main`) and `weekly-testing-promotion.yml` before promotion to `:stable`.
 - **Vulnerability scans must use the build digest, not a mutable tag.** `vulnerability-scan.yml` downloads `image-digest-{stream_name}-{brand_name}-{image_flavor}` from the triggering `workflow_run` and passes `image@sha256:...` to the scanner to avoid TOCTOU. Artifact names for the default bluefin build: `image-digest-testing-bluefin-main`, `image-digest-testing-bluefin-nvidia-open`.
 - Weekly promotion uses retag-only (skopeo copy) for the canonical path; a parallel rebuild pathway also exists via branch push
 - Build callers do not pass `secrets: inherit` — `reusable-build.yml` only needs `GITHUB_TOKEN`, which is automatically available

--- a/docs/skills/renovate.md
+++ b/docs/skills/renovate.md
@@ -53,21 +53,25 @@ If a Renovate PR targets the wrong branch:
 2. retrigger Renovate
 3. correct or replace the already-open PRs
 
-## Review and merge flow
+## Automerge for Renovate/mergeraptor PRs
 
-```bash
-gh pr list --repo projectbluefin/bluefin --author 'app/renovate'
-gh pr view PR_NUMBER --repo projectbluefin/bluefin
-gh pr review PR_NUMBER --repo projectbluefin/bluefin --approve
-gh pr merge PR_NUMBER --repo projectbluefin/bluefin --squash
-```
+All Renovate and mergeraptor PRs automerge once `PR Validation — testsuite` passes:
+- No manual review needed for digest/pin/patch/minor bumps (configured in `renovate.json`)
+- `renovate-automerge.yml` runs `gh pr merge --auto --squash` — no high-risk/smoke distinction
+- Requires: `testing` branch protection with `validate` as required check + `allow_auto_merge=true` at repo level
+
+If auto-merge does not trigger:
+1. Confirm `testing` has branch protection: `gh api repos/projectbluefin/bluefin/branches/testing/protection`
+2. Confirm `allow_auto_merge` is set: `gh api repos/projectbluefin/bluefin --jq .allow_auto_merge`
+3. Re-run the failed `PR Validation` check to re-trigger the `workflow_run` event
 
 ## Common failure modes
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Renovate PRs target `main` | wrong `baseBranchPatterns` | set branch pattern to `testing` |
-| automerge skipped a passing PR | PR finder ignored `app/mergeraptor` | include both Renovate and mergeraptor authors |
+| automerge skipped a passing PR | `testing` has no branch protection, or PR finder missed `app/mergeraptor` | enable branch protection on `testing` with `validate` required check; include both authors |
+| `enablePullRequestAutoMerge` GraphQL error | repo `allow_auto_merge` not set | `gh api --method PATCH repos/projectbluefin/bluefin -f allow_auto_merge=true` |
 | validator rejects config | stale field name | check current Renovate schema and rename the field |
 | workflow asks for a PAT | wrong auth model | use GitHub App secrets, never PATs |
 
@@ -90,7 +94,7 @@ No additional Renovate config is needed beyond `config:best-practices` — it al
 
 ## Lessons learned
 
-- **`testing` has no branch protection** — `gh pr merge --auto` fails with "Protected branch rules not configured". Just use `--squash` directly. There is no merge queue on `testing`.
+- **`testing` has branch protection** — required check: `validate`; `allow_auto_merge=true` at repo level. `gh pr merge --auto --squash` works.
 - **Bulk-merging chore PRs** — iterate with `gh pr merge NNN --repo projectbluefin/bluefin --squash`. Skip DIRTY ones (conflicts) and trigger Renovate to rebase them.
-- **Conflicted Renovate PRs** — do not rebase by hand. Trigger the central Renovate run and it will rebase all conflicting PRs automatically within a few minutes.
+- **Conflicted Renovate PRs** — do not rebase by hand. Post `@renovate rebase` on the PR or trigger the central Renovate run and it will rebase all conflicting PRs automatically within a few minutes.
 - **Wrong base branch** — Renovate PRs that land on `main` are not validated and cannot be enqueued. Retarget with `gh pr edit NNN --base testing`, then merge normally.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -10,6 +10,26 @@
 - Conventional Commits required on every PR title/commit
 - AI-authored commits must include `Assisted-by: <Model> via <Tool>`
 
+## Git workflow for agents
+
+**Always branch from the remote `projectbluefin/testing`, never from local HEAD.** Local `testing` may carry unpushed commits from previous sessions that will silently pollute your PR.
+
+```bash
+# Correct way to start any new branch:
+git fetch projectbluefin
+git checkout -b my-feature projectbluefin/testing
+```
+
+**One clean squash commit per PR.** Use `git commit --amend` or `git rebase -i` before pushing to ensure the PR contains exactly one commit.
+
+**Always push to the `projectbluefin` remote**, never `origin` (`origin` points to `ublue-os/bluefin`):
+
+```bash
+git push projectbluefin my-feature
+```
+
+**Never `git push` or `git push origin`.** Always name the remote explicitly.
+
 ## Issue tracker
 
 > **All Bluefin issues go in [`projectbluefin/bluefin`](https://github.com/projectbluefin/bluefin/issues).**


### PR DESCRIPTION
Updates docs and skill files to reflect changes made this session:

- **PR validation**: `pr-validation.yml` now runs `validate-pr@v1` only (~2 min); E2E removed from PRs
- **E2E placement**: runs post-merge (`post-testing-e2e.yml`) and pre-promotion (`weekly-testing-promotion.yml`); not on PRs
- **Automerge**: `renovate-automerge.yml` simplified; all Renovate/mergeraptor PRs automerge after validate passes; no high-risk/smoke distinction
- **Branch protection**: `testing` now has branch protection (required check: `validate`) + `allow_auto_merge=true`; `gh pr merge --auto --squash` works
- **Git workflow for agents**: added explicit rules in `workflow.md` — always branch from `projectbluefin/testing`, never local HEAD; always push to `projectbluefin` remote
- **Renovate lessons**: fixed stale lesson (--auto now works); added automerge section with setup verification commands