### PR TITLE
docs: update workflow and renovate skill with current process

### DIFF
--- a/docs/skills/renovate.md
+++ b/docs/skills/renovate.md
@@ -96,5 +96,5 @@ No additional Renovate config is needed beyond `config:best-practices` — it al
 
 - **`testing` has branch protection** — required check: `validate`; `allow_auto_merge=true` at repo level. `gh pr merge --auto --squash` works.
 - **Bulk-merging chore PRs** — iterate with `gh pr merge NNN --repo projectbluefin/bluefin --squash`. Skip DIRTY ones (conflicts) and trigger Renovate to rebase them.
-- **Conflicted Renovate PRs** — do not rebase by hand. Post `@renovate rebase` on the PR or trigger the central Renovate run and it will rebase all conflicting PRs automatically within a few minutes.
+- **Conflicted Renovate PRs** — do both at once: post `@renovate rebase` on each conflicted PR AND trigger the central Renovate run. The comment makes Renovate prioritize that PR; the run handles all of them in batch.
 - **Wrong base branch** — Renovate PRs that land on `main` are not validated and cannot be enqueued. Retarget with `gh pr edit NNN --base testing`, then merge normally.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -216,29 +216,37 @@ git push projectbluefin --delete <branch>-clean            # clean up temp branc
 
 Same fix as BEHIND — rebase or cherry-pick onto the latest `testing`.
 
-For Renovate/chore PRs with conflicts, trigger a central Renovate run to rebase them automatically:
+For Renovate/chore PRs with conflicts, do both steps together — post a rebase comment on each PR and trigger the central run:
 ```bash
+# Comment on each conflicted PR
+for pr in 101 102 103; do
+  gh pr comment $pr --repo projectbluefin/bluefin --body "@renovate rebase"
+done
+
+# Trigger the central Renovate run
 gh workflow run "Renovate Self-Hosted" --repo projectbluefin/renovate-config
 ```
 
+Renovate will rebase all conflicting PRs within a few minutes. Once they pass `validate`, the automerge workflow fires automatically.
+
 ### Auto-merge cannot be enabled
 
-`testing` has no branch protection. GitHub requires branch protection to enable auto-merge, so `gh pr merge --auto` will fail with "Protected branch rules not configured."
+`testing` has branch protection with `validate` as required check, and `allow_auto_merge` is enabled at the repo level. `gh pr merge --auto --squash` works.
 
-Just squash-merge directly instead:
+If you see "Protected branch rules not configured":
 ```bash
-gh pr merge <number> --repo projectbluefin/bluefin --squash
+# Verify branch protection exists
+gh api repos/projectbluefin/bluefin/branches/testing/protection
+# Verify allow_auto_merge is set
+gh api repos/projectbluefin/bluefin --jq .allow_auto_merge
 ```
 
-For a batch of chore/Renovate PRs:
-```bash
-for pr in 101 102 103; do
-  echo -n "PR #$pr: "
-  gh pr merge $pr --repo projectbluefin/bluefin --squash 2>&1
-done
-```
+### Docs-only changes
 
-PRs that show merge conflicts will need the Renovate rebase trigger above first.
+Docs changes (files under `docs/`, `*.md`) do not need to wait for CI. Open the PR then merge immediately:
+```bash
+gh pr merge <number> --repo projectbluefin/bluefin --squash --admin
+```
 
 ## PR comment policy
 


### PR DESCRIPTION
Fixes stale docs from today's session:

- **workflow.md**: stale 'no branch protection' section replaced — `testing` now has branch protection; auto-merge works
- **workflow.md**: DIRTY section updated to post `@renovate rebase` comments AND trigger central run together
- **workflow.md**: new Docs-only changes section — merge immediately with `--admin --squash`, no CI wait
- **skills/renovate.md**: conflicted PRs lesson updated to use both strategies simultaneously