### PR TITLE
fix(ci): scan immutable build digest in vulnerability workflow

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -36,26 +36,33 @@ jobs:
       matrix:
         include:
           - image_name: bluefin
-            artifact_suffix: bluefin-main
+            artifact_name: image-digest-testing-bluefin-main-x86_64
           - image_name: bluefin-nvidia-open
-            artifact_suffix: bluefin-nvidia-open
+            artifact_name: image-digest-testing-bluefin-nvidia-open-x86_64
     steps:
       - name: Download build digest
         if: github.event_name == 'workflow_run'
         id: get-digest
         env:
           GH_TOKEN: ${{ github.token }}
+          ARTIFACT_DIR: ${{ runner.temp }}/digest
         run: |
           set -euo pipefail
-          gh run download "${{ github.event.workflow_run.id }}" \
+          mkdir -p "${ARTIFACT_DIR}"
+          if ! gh run download "${{ github.event.workflow_run.id }}" \
             --repo "${{ github.repository }}" \
-            --name "image-digest-testing-${{ matrix.artifact_suffix }}" \
-            --dir /tmp/digest
-          DIGEST=$(grep -oP 'sha256:[0-9a-f]{64}' /tmp/digest/*.txt | head -1)
-          if [[ -z "${DIGEST}" ]]; then
-            echo "::error::Could not parse a valid digest from build artifact"
-            exit 1
+            --name "${{ matrix.artifact_name }}" \
+            --dir "${ARTIFACT_DIR}"; then
+            echo "Digest artifact unavailable; falling back to testing tag"
+            exit 0
           fi
+
+          DIGEST=$(grep -RhoE 'sha256:[0-9a-f]{64}' "${ARTIFACT_DIR}" | head -1 || true)
+          if [[ -z "${DIGEST}" ]]; then
+            echo "Digest artifact downloaded but no valid digest was found; falling back to testing tag"
+            exit 0
+          fi
+
           echo "ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve image ref
@@ -66,6 +73,8 @@ jobs:
             REF="${{ inputs.image_ref }}"
           elif [[ -n "${{ steps.get-digest.outputs.ref }}" ]]; then
             REF="${{ steps.get-digest.outputs.ref }}"
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            REF="ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:testing"
           else
             # schedule or workflow_dispatch without an explicit ref: resolve tag to immutable digest
             TAG="ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:testing"


### PR DESCRIPTION
Fixes #221

## Problem
The vulnerability scan TOCTOU race: workflow scans the :testing mutable tag, which can be replaced between build completion and Grype pull. Security findings cannot be reliably correlated to the commit that introduced them.

## Fix
Download the build digest artifact from the triggering workflow run and scan by an immutable sha256 digest instead of the mutable tag. Falls back to the tag if the artifact is unavailable (for example, retention expired).

Part of epic #209.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot