### PR TITLE
fix(ci): harden weekly testing promotion

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -50,7 +50,7 @@ jobs:
             --workflow post-testing-e2e.yml \
             --branch main \
             --repo "${{ github.repository }}" \
-            --limit 20 \
+            --limit 50 \
             --json headSha,conclusion \
             --jq ".[] | select(.headSha == \"$LOCKED_SHA\") | .conclusion" \
             | head -1)
@@ -79,7 +79,7 @@ jobs:
             --workflow build-image-testing.yml \
             --branch main \
             --repo "${{ github.repository }}" \
-            --limit 20 \
+            --limit 50 \
             --json databaseId,headSha,conclusion \
             --jq ".[] | select(.headSha == \"$LOCKED_SHA\" and .conclusion == \"success\") | .databaseId" \
             | head -1)
@@ -155,6 +155,50 @@ jobs:
             --dir /tmp/all-digests
           echo "Downloaded digest files:"
           find /tmp/all-digests -name "*.txt" | sort
+
+      - name: Verify cosign signatures before promotion
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Install cosign via sigstore installer (already available if run after a build)
+          # Fall back to downloading from GitHub releases if not available
+          if ! command -v cosign &>/dev/null; then
+            COSIGN_VERSION="v2.5.0"
+            curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
+              -o /usr/local/bin/cosign
+            chmod +x /usr/local/bin/cosign
+          fi
+
+          REGISTRY="ghcr.io/${{ github.repository_owner }}"
+          FAILED=0
+
+          while IFS= read -r -d '' f; do
+            line=$(grep "=" "$f" | head -1)
+            IMAGE_NAME="${line%%=*}"
+            DIGEST="${line##*=}"
+            if [[ -z "$IMAGE_NAME" || -z "$DIGEST" ]]; then
+              echo "WARNING: Could not parse $f — skipping verification"
+              continue
+            fi
+            REF="${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+            echo "Verifying signature: ${REF}"
+            if ! cosign verify \
+              --certificate-identity-regexp "https://github.com/${{ github.repository }}/.github/workflows/" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${REF}" 2>/dev/null; then
+              echo "::error::Signature verification FAILED for ${IMAGE_NAME}@${DIGEST}"
+              FAILED=$((FAILED + 1))
+            else
+              echo "  ✅ Signature verified: ${IMAGE_NAME}"
+            fi
+          done < <(find /tmp/all-digests -name "*.txt" -print0)
+
+          if [[ "${FAILED}" -gt 0 ]]; then
+            echo "::error::${FAILED} image(s) failed signature verification — aborting promotion"
+            exit 1
+          fi
+          echo "✅ All signatures verified — proceeding with promotion"
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0


### PR DESCRIPTION
Fixes #218, closes #212 (partial — run-list limit only; retention fix is in projectbluefin/actions)

## Changes

### #218 — Verify cosign signatures before promotion
Adds a `cosign verify` step in `promote-to-latest-and-stable` that checks every digest artifact against the Sigstore keyless bundle before retagging to `:latest`/`:stable`. Prevents unsigned or incorrectly-signed images from reaching production.

### #212 (partial) — Increase gh run list limit 20 → 50
The `gh run list --limit 20` calls in `verify-e2e` and `find-build` steps are increased to 50. On high-churn weeks (many commits + retries), 20 runs could miss the relevant SHA, causing false-negative "no run found" failures.

Part of epic #209.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot