### PR TITLE
fix(ci): gate nvidia-open promotion on e2e smoke test

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -24,6 +24,7 @@ jobs:
       testing_sha: ${{ steps.lock-sha.outputs.sha }}
       build_run_id: ${{ steps.find-build.outputs.run_id }}
       image: ${{ steps.get-digest.outputs.image }}
+      nvidia_open_image: ${{ steps.get-nvidia-digest.outputs.image }}
     steps:
       - name: Lock main HEAD SHA
         id: lock-sha
@@ -98,13 +99,42 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          DIGEST_DIR="$RUNNER_TEMP/digest-main"
+          rm -rf "$DIGEST_DIR"
+          mkdir -p "$DIGEST_DIR"
           gh run download "${{ steps.find-build.outputs.run_id }}" \
             --repo "${{ github.repository }}" \
             --name "image-digest-testing-bluefin-main" \
-            --dir /tmp/digest
-          DIGEST=$(grep "=" /tmp/digest/main-bluefin.txt | head -1 | cut -d= -f2-)
+            --dir "$DIGEST_DIR"
+          DIGEST=$(grep "=" "$DIGEST_DIR/main-bluefin.txt" | head -1 | cut -d= -f2-)
           echo "image=ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "Promoting: ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}"
+
+      - name: Get nvidia-open digest for e2e gate
+        id: get-nvidia-digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          DIGEST_DIR="$RUNNER_TEMP/digest-nvidia"
+          rm -rf "$DIGEST_DIR"
+          mkdir -p "$DIGEST_DIR"
+          gh run download "${{ steps.find-build.outputs.run_id }}" \
+            --repo "${{ github.repository }}" \
+            --name "image-digest-testing-bluefin-nvidia-open-x86_64" \
+            --dir "$DIGEST_DIR" 2>/dev/null || {
+            echo "::warning::nvidia-open digest not found — skipping nvidia-open promotion gate"
+            echo "image=" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          DIGEST=$(grep -hoE 'sha256:[0-9a-f]{64}' "$DIGEST_DIR"/*.txt | head -1)
+          if [[ -z "$DIGEST" ]]; then
+            echo "::warning::Could not extract nvidia-open digest — skipping gate"
+            echo "image=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "image=ghcr.io/${{ github.repository_owner }}/bluefin-nvidia-open@${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Found nvidia-open digest: ${DIGEST}"
 
   e2e:
     needs: [verify-e2e]
@@ -116,8 +146,28 @@ jobs:
       image: ${{ needs.verify-e2e.outputs.image }}
       suites: developer,vanilla-gnome,software,common
 
+  e2e-nvidia-open:
+    needs: [verify-e2e]
+    if: needs.verify-e2e.outputs.nvidia_open_image != ''
+    permissions:
+      packages: write
+      contents: read
+    uses: ./.github/workflows/run-testsuite.yml
+    with:
+      image: ${{ needs.verify-e2e.outputs.nvidia_open_image }}
+      suites: smoke,common
+    secrets: inherit
+
   promote-to-latest-and-stable:
-    needs: [e2e, verify-e2e]
+    if: >-
+      always() &&
+      needs.verify-e2e.result == 'success' &&
+      needs.e2e.result == 'success' &&
+      (
+        needs.verify-e2e.outputs.nvidia_open_image == '' ||
+        needs.e2e-nvidia-open.result == 'success'
+      )
+    needs: [e2e, e2e-nvidia-open, verify-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -235,8 +285,8 @@ jobs:
           echo "Tested artifacts are now live — no rebuild was triggered."
 
   report-failure:
-    needs: [verify-e2e, e2e, promote-to-latest-and-stable]
-    if: failure() && needs.verify-e2e.outputs.image != ''
+    needs: [verify-e2e, e2e, e2e-nvidia-open, promote-to-latest-and-stable]
+    if: always() && failure() && needs.verify-e2e.outputs.image != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Summary
- add a `verify-e2e` output for the nvidia-open testing digest
- run a parallel `e2e-nvidia-open` smoke+common gate before promotion
- soft-skip the extra gate when older builds do not have the nvidia-open digest artifact

Fixes #211

## Validation
- `just check`
- `pre-commit run --all-files`