### PR TITLE
fix(ci): scope workflow permissions to job level, drop secrets:inherit

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -17,18 +17,15 @@ on:
         default: ""
         type: string
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write
-  attestations: write
-  artifact-metadata: write
+permissions: {}
 
 jobs:
   detect-changes:
     name: Detect changed paths
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       image_flavors: ${{ steps.detect.outputs.image_flavors }}
       should_build: ${{ steps.detect.outputs.should_build }}
@@ -46,7 +43,12 @@ jobs:
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
     uses: projectbluefin/actions/.github/workflows/reusable-build.yml@13e3593568d87cfe075a86e3995930e350f8c5ea # v1
-    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     with:
       image_flavors: >-
         ${{

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -9,6 +9,8 @@ concurrency:
   group: weekly-testing-promotion
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   # Verify that post-testing-e2e.yml already ran smoke tests on the current
   # main HEAD since every push to main triggers it. If e2e hasn't passed


### PR DESCRIPTION
## Summary

Two hardening changes to reduce the blast radius of any compromised workflow step.

### `weekly-testing-promotion.yml` — fixes #219

Add explicit `permissions: {}` at the workflow level. All jobs already
declare their own minimal permissions; this makes the deny-all default
explicit rather than relying on repository defaults.

### `build-image-testing.yml` — fixes #220

- Move the workflow-level `permissions:` block down to the
  `build-image-testing` job, which is the only job that actually needs
  `id-token: write`, `attestations: write`, `artifact-metadata: write`, and
  `packages: write`.
- Add `permissions: contents: read` to `detect-changes` (only does a
  checkout + composite action).
- Remove `secrets: inherit` — `reusable-build.yml` only references
  `secrets.GITHUB_TOKEN` which is automatically available in every job
  without inheritance.

## Changes
- `.github/workflows/weekly-testing-promotion.yml`: +`permissions: {}` workflow level
- `.github/workflows/build-image-testing.yml`: permissions moved to job level, `secrets: inherit` removed