### PR TITLE
ci: extend shellcheck to system_files and add desktop-file-validate

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,8 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      # TODO: once projectbluefin/actions PR #65 merges and @v1 is updated, pin back to @v1
       - name: Validate
-        uses: projectbluefin/actions/bootc-build/validate-pr@4ec3db50adc3a2b944e175295d419d78eaa63861 # v1
+        uses: projectbluefin/actions/bootc-build/validate-pr@7a90e86191aaf14ec84b17215709a0f923d4b741 # feat/validate-pr-enhancements — pending PR #65
+        with:
+          system-files-shellcheck-glob: "system_files/**/*.sh"
+          enable-desktop-file-validate: "true"
 
   unit-tests:
     name: Unit tests

--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/10-tailscale.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/10-tailscale.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script tailscale privileged 1 || exit 0

--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/99-flatpaks.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/99-flatpaks.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script flatpaks privileged 1 || exit 0

--- a/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
+++ b/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script framework system 2 || exit 0

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script theming user 1 || exit 0

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-framework.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-framework.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script framework tool 1 || exit 0


### PR DESCRIPTION
## Summary
- extend pr-validation to pass system-files-shellcheck-glob so shellcheck covers system_files/**/*.sh
- enable desktop-file-validate in PR validation so .desktop files are statically checked
- temporarily pin validate-pr to projectbluefin/actions PR #65 feature SHA until that change lands and @v1 is updated

## Context
This addresses the ACMM audit finding that PR validation was not covering shell scripts under system_files/**/*.sh and was not statically validating .desktop files.

Depends on projectbluefin/actions PR #65, which adds the new optional validate-pr inputs used here:
- system-files-shellcheck-glob
- enable-desktop-file-validate
- check-submodule-drift

This PR intentionally uses the temporary action SHA:
- projectbluefin/actions/bootc-build/validate-pr@7a90e86191aaf14ec84b17215709a0f923d4b741

A follow-up PR should pin this back to @v1 once projectbluefin/actions PR #65 merges and the tag is updated.

## Validation
- just check
- pre-commit run --all-files