### PR TITLE
docs(agents): document floating-tag pre-commit guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Non-compliance = rejection.
 
 - Read [`docs/SKILL.md`](docs/SKILL.md) before modifying anything.
 - Run `just check && pre-commit run --all-files` before every commit.
+- **Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
 - Use Conventional Commits for every commit and PR title.
 - Every AI-authored commit must include `Assisted-by: <Model> via <Tool>`.
 - Keep open PR count at 4 or fewer.


### PR DESCRIPTION
## Summary
- document the no-floating-action-tags pre-commit hook in AGENTS.md
- note that third-party floating action tags are blocked while projectbluefin-managed refs are exempt

## Test plan
- just check
- pre-commit run --all-files