### PR TITLE
feat: sealed image build path for next branch

### DIFF
--- a/.github/workflows/build-image-next.yml
+++ b/.github/workflows/build-image-next.yml
@@ -1,0 +1,34 @@
+name: Next Images (sealed)
+on:
+  pull_request:
+    branches:
+      - next
+    paths-ignore:
+      - ".github/workflows/*validate*.yml"
+      - "**.md"
+      - "system_files/shared/etc/bazaar/**"
+  push:
+    branches:
+      - next
+    paths-ignore:
+      - ".github/workflows/*validate*.yml"
+      - "**.md"
+      - "system_files/shared/etc/bazaar/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+
+jobs:
+  build-image-next:
+    name: Build Next Images (sealed)
+    if: github.event_name != 'workflow_dispatch' || github.ref_name == 'next'
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@13e3593568d87cfe075a86e3995930e350f8c5ea # v1
+    secrets: inherit
+    with:
+      stream_name: next
+      architecture: '["x86_64"]'

--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,9 @@ ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/silverblue"
 # BASE_IMAGE_REF is resolved to BASE_IMAGE:FEDORA_MAJOR_VERSION@digest after cosign verify.
 # Defaults to tag-only for local builds where digest is not resolved.
 ARG BASE_IMAGE_REF="${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}"
+# Set to "1" on the next branch to build on the sealed Fedora Atomic Desktop base
+# (systemd-boot + UKI + composefs). Empty or "0" preserves the legacy GRUB/rpm-ostree path.
+ARG SEALED=""
 ARG COMMON_IMAGE="ghcr.io/projectbluefin/common:latest"
 ARG COMMON_IMAGE_SHA=""
 ARG BREW_IMAGE="ghcr.io/ublue-os/brew:latest"
@@ -32,6 +35,7 @@ ARG IMAGE_VENDOR="projectbluefin"
 ARG KERNEL="6.10.10-200.fc40.x86_64"
 ARG UBLUE_IMAGE_TAG="stable"
 ARG IMAGE_FLAVOR=""
+ARG SEALED=""
 
 # Stage 1 — Package installs only (cache key: build_files/)
 # Runs the package-install layer (`03-packages.sh`, `04-install-kernel-akmods.sh`,
@@ -45,6 +49,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=secret,id=GITHUB_TOKEN \
     --mount=type=tmpfs,dst=/boot \
     bash -euo pipefail -c ' \
+        export SEALED="${SEALED:-}" && \
         dnf5 config-manager setopt keepcache=1 && \
         dnf5 config-manager setopt install_weak_deps=0 && \
         dnf5 -y swap fedora-logos generic-logos && \
@@ -77,6 +82,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=secret,id=GITHUB_TOKEN \
     --mount=type=tmpfs,dst=/boot \
     bash -euo pipefail -c ' \
+        export SEALED="${SEALED:-}" && \
         rsync -rvK /ctx/system_files/shared/ / && \
         mkdir -p /tmp/scripts/helpers && \
         install -Dm0755 /ctx/build_files/shared/utils/ghcurl /tmp/scripts/helpers/ghcurl && \

--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,7 @@ tags := '(
     [stable]=stable
     [latest]=latest
     [testing]=testing
+    [next]=next
 )'
 export SUDOIF := if `id -u` == "0" { "" } else { "sudo" }
 export PODMAN := if path_exists("/usr/bin/podman") == "true" { env("PODMAN", "/usr/bin/podman") } else if path_exists("/usr/bin/docker") == "true" { env("PODMAN", "docker") } else { env("PODMAN", "exit 1 ; ") }
@@ -132,6 +133,12 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
         akmods_flavor="main"
     fi
 
+    # Sealed image flag — the next stream builds on the sealed Fedora Atomic Desktop base
+    SEALED=""
+    if [[ "${tag}" == "next" ]]; then
+        SEALED="1"
+    fi
+
     # Fedora Version
     if [[ {{ ghcr }} == "0" ]]; then
         rm -f /tmp/manifest.json
@@ -141,9 +148,18 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # Resolve and pin the base image digest first (TOCTOU fix)
     BASE_IMAGE_MAX_RETRIES=5
     BASE_IMAGE_RETRY_DELAY=10
+
+    # The next stream uses the sealed Fedora Atomic Desktop base instead of
+    # the standard Silverblue base. These are test images and are not signed
+    # with official Fedora keys, so cosign verification is skipped.
+    if [[ "${SEALED}" == "1" ]]; then
+        sealed_base_image="ghcr.io/travier/fedora-atomic-desktops-sealed/silverblue"
+    fi
+    resolve_image="${sealed_base_image:-quay.io/fedora-ostree-desktops/silverblue}"
+
     last_digest_error=""
     for attempt in $(seq 1 ${BASE_IMAGE_MAX_RETRIES}); do
-        if inspect_output=$(skopeo inspect --retry-times 3 docker://quay.io/fedora-ostree-desktops/silverblue:"${fedora_version}" 2>&1); then
+        if inspect_output=$(skopeo inspect --retry-times 3 docker://"${resolve_image}":"${fedora_version}" 2>&1); then
             base_image_digest=$(jq -r '.Digest // empty' <<<"${inspect_output}")
             if [[ -n "${base_image_digest:-}" ]]; then
                 break
@@ -154,7 +170,7 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
         fi
 
         if [[ "${attempt}" -eq "${BASE_IMAGE_MAX_RETRIES}" ]]; then
-            echo "ERROR: Could not resolve silverblue digest after ${BASE_IMAGE_MAX_RETRIES} attempts. Refusing to build without a pinned, verified base image."
+            echo "ERROR: Could not resolve ${resolve_image} digest after ${BASE_IMAGE_MAX_RETRIES} attempts. Refusing to build without a pinned, verified base image."
             echo "Last error: ${last_digest_error}"
             exit 1
         fi
@@ -162,12 +178,15 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
         echo "NOTICE: Digest resolution attempt ${attempt}/${BASE_IMAGE_MAX_RETRIES} failed, retrying in ${BASE_IMAGE_RETRY_DELAY}s..."
         sleep "${BASE_IMAGE_RETRY_DELAY}"
     done
-    base_image_ref="quay.io/fedora-ostree-desktops/silverblue:${fedora_version}@${base_image_digest}"
+    base_image_ref="${resolve_image}:${fedora_version}@${base_image_digest}"
 
     # Verify Base Image with cosign — FATAL in CI, skippable locally for dev convenience.
     # A verification failure means the base image cannot be trusted; continuing would launder
     # a potentially compromised image through the Bluefin signing pipeline.
-    if [[ "${SKIP_BASE_VERIFY:-}" == "1" && "${CI:-}" != "true" ]]; then
+    # Sealed test images are not signed with official Fedora keys — skip verification.
+    if [[ "${SEALED}" == "1" ]]; then
+        echo "NOTICE: Sealed test images are not cosign-signed — skipping base image verification"
+    elif [[ "${SKIP_BASE_VERIFY:-}" == "1" && "${CI:-}" != "true" ]]; then
         echo "WARNING: Skipping base image verification (SKIP_BASE_VERIFY=1, local dev only)"
     else
         {{ just }} verify-container "silverblue:${fedora_version}@${base_image_digest}" quay.io/fedora-ostree-desktops "{{ justfile_directory() }}/keys/fedora-ostree.pub" || {
@@ -234,6 +253,9 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
         BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")
     fi
     BUILD_ARGS+=("--build-arg" "UBLUE_IMAGE_TAG=${tag}")
+    if [[ "${SEALED}" == "1" ]]; then
+        BUILD_ARGS+=("--build-arg" "SEALED=1")
+    fi
     if [[ "${PODMAN}" =~ docker && "${TERM}" == "dumb" ]]; then
         BUILD_ARGS+=("--progress" "plain")
     fi
@@ -591,7 +613,10 @@ fedora_version image="bluefin" tag="latest" flavor="main" $kernel_pin="":
     set -eou pipefail
     {{ just }} validate {{ image }} {{ tag }} {{ flavor }}
     if [[ ! -f /tmp/manifest.json ]]; then
-        if [[ "{{ tag }}" =~ stable ]]; then
+        if [[ "{{ tag }}" == "next" ]]; then
+            # Sealed images: inspect the sealed Silverblue base to resolve Fedora version
+            skopeo inspect --retry-times 3 docker://ghcr.io/travier/fedora-atomic-desktops-sealed/silverblue:44 > /tmp/manifest.json
+        elif [[ "{{ tag }}" =~ stable ]]; then
             # CoreOS does not uses cosign
             skopeo inspect --retry-times 3 docker://quay.io/fedora/fedora-coreos:stable > /tmp/manifest.json
         elif [[ "{{ tag }}" == "testing" ]]; then

--- a/build_files/base/00-image-info.sh
+++ b/build_files/base/00-image-info.sh
@@ -59,8 +59,11 @@ fi
 echo "IMAGE_ID=\"${IMAGE_NAME}\"" >> /usr/lib/os-release
 echo "IMAGE_VERSION=\"${VERSION}\"" >> /usr/lib/os-release
 
-# Fix issues caused by ID no longer being fedora
-sed -i "s|^EFIDIR=.*|EFIDIR=\"fedora\"|" /usr/sbin/grub2-switch-to-blscfg
+# Fix issues caused by ID no longer being fedora.
+# Sealed images use systemd-boot, not GRUB — the script may not exist.
+if [[ "${SEALED:-}" != "1" ]]; then
+    sed -i "s|^EFIDIR=.*|EFIDIR=\"fedora\"|" /usr/sbin/grub2-switch-to-blscfg
+fi
 
 # Ship placeholder values — refreshed at runtime by bluefin-stats-refresh.timer
 echo "…" > /usr/share/ublue-os/fastfetch-user-count

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -12,7 +12,10 @@ systemctl enable brew-setup.service
 systemctl enable dconf-update.service
 systemctl enable flatpak-nuke-fedora.service
 systemctl enable input-remapper.service
-systemctl enable rpm-ostree-countme.service
+# rpm-ostree-countme is absent on sealed images (no rpm-ostree)
+if [[ "${SEALED:-}" != "1" ]]; then
+    systemctl enable rpm-ostree-countme.service
+fi
 systemctl enable tailscaled.service
 systemctl enable ublue-system-setup.service
 
@@ -31,8 +34,10 @@ systemctl enable uupd.timer
 # Refresh community stats (user count, Bazaar downloads) for fastfetch
 systemctl enable bluefin-stats-refresh.timer
 
-#disable the old rpm-ostreed-automatic.timer
-systemctl disable rpm-ostreed-automatic.timer
+# rpm-ostreed-automatic.timer is absent on sealed images (no rpm-ostree)
+if [[ "${SEALED:-}" != "1" ]]; then
+    systemctl disable rpm-ostreed-automatic.timer
+fi
 
 # Hide Desktop Files. Hidden removes mime associations
 for file in fish htop nvtop; do

--- a/build_files/base/19-initramfs.sh
+++ b/build_files/base/19-initramfs.sh
@@ -4,10 +4,15 @@ echo "::group:: ===$(basename "$0")==="
 
 set -oue pipefail
 
-KERNEL_SUFFIX=""
-QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')"
-export DRACUT_NO_XATTR=1
-/usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
-chmod 0600 "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+# Sealed images bundle the initramfs inside the UKI — skip the manual dracut rebuild.
+if [[ "${SEALED:-}" == "1" ]]; then
+    echo "Sealed build: skipping initramfs rebuild (UKI owns the boot chain)"
+else
+    KERNEL_SUFFIX=""
+    QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')"
+    export DRACUT_NO_XATTR=1
+    /usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+    chmod 0600 "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+fi
 
 echo "::endgroup::"

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -75,9 +75,12 @@ UNWANTED_PACKAGES=(
     fedora-third-party
     firefox
     gnome-software
-    gnome-software-rpm-ostree
     podman-docker
 )
+# gnome-software-rpm-ostree is already absent on sealed images (no rpm-ostree)
+if [[ "${SEALED:-}" != "1" ]]; then
+    UNWANTED_PACKAGES+=("gnome-software-rpm-ostree")
+fi
 
 for package in "${UNWANTED_PACKAGES[@]}"; do
     if rpm -q "${package}" >/dev/null 2>&1; then
@@ -97,11 +100,14 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
 fi
 
 IMPORTANT_UNITS=(
-    rpm-ostree-countme.timer
     tailscaled.service
     ublue-system-setup.service
     uupd.timer
   )
+# rpm-ostree-countme is absent on sealed images (no rpm-ostree)
+if [[ "${SEALED:-}" != "1" ]]; then
+    IMPORTANT_UNITS+=("rpm-ostree-countme.timer")
+fi
 
 for unit in "${IMPORTANT_UNITS[@]}"; do
     if ! systemctl is-enabled "$unit" 2>/dev/null | grep -q "^enabled$"; then


### PR DESCRIPTION
## Summary

Implements the first phase of #4 — adds a `SEALED` build arg and `next` tag that switches Bluefin to build on the sealed Fedora Atomic Desktop base (systemd-boot + UKI + composefs) instead of the standard Silverblue GRUB/rpm-ostree base.

Follows the plan outlined in epic #11.

## What changed

| File | Change |
|---|---|
| `Containerfile` | New `SEALED` build arg, exported to both build stages |
| `Justfile` | `next` tag; sealed base image resolution; skip cosign for test images; `SEALED=1` build arg |
| `00-image-info.sh` | Skip GRUB `grub2-switch-to-blscfg` fix (sealed uses systemd-boot) |
| `17-cleanup.sh` | Skip `rpm-ostree-countme` enable and `rpm-ostreed-automatic` disable |
| `19-initramfs.sh` | Skip manual dracut rebuild (UKI owns the boot chain) |
| `20-tests.sh` | Skip `rpm-ostree-countme.timer` and `gnome-software-rpm-ostree` assertions |
| `build-image-next.yml` | New CI workflow for `next` branch |

## Design decisions

- All sealed-specific guards use `${SEALED:-}` checks so the same scripts work for both paths
- Kernel/akmods flow unchanged — sealed images still need Bluefin custom kernel
- `10-framework.sh` unchanged — already uses `grubby` (works with systemd-boot)
- `next` excluded from Build All Images orchestrator to prevent accidental promotion

## Future work (per epic #11)

- Resealing investigation
- GPU variant matrix
- Boot validation testing
- User migration path

Closes #4