### PR TITLE
ci: bump testsuite SHA to cdc9891 (7 infrastructure fixes — factory unblock)

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@f7d8bd9d3bf41d265b9a4cbf11cc5d1e3e35bb44 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9392c9ec9e048a24f406e3fcde7a92c33f9e18f6 # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@fcbfd6aef2f3688056fbc758f9693f4f0953f2e5 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@51b2c54f3c28bf34675f95e2a14eeb5e52d89829 # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e7f46eac7266809401d22db3f9f14e87ccfb8d63 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@fcbfd6aef2f3688056fbc758f9693f4f0953f2e5 # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9c7490f24fd9240f0dab048a331da3abdb226238 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@3e8cc0d959810f7d59ce3364234b728ed779354c # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@51b2c54f3c28bf34675f95e2a14eeb5e52d89829 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@cdc9891c0da58fa385d4b06194d1d79e384d45bd # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@3e8cc0d959810f7d59ce3364234b728ed779354c # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@f7d8bd9d3bf41d265b9a4cbf11cc5d1e3e35bb44 # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@cdc9891c0da58fa385d4b06194d1d79e384d45bd # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9c7490f24fd9240f0dab048a331da3abdb226238 # main
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
## Problem

E2E smoke tests fail with exit code 1 despite all scenarios passing. Root cause: `qecore-headless` tries `sudo systemctl stop gdm` after the test script finishes. Inside the runner container (no systemd PID 1), this raises `CalledProcessError`, which propagates as an unhandled exception, causing Python to exit 1 and masking a clean test run.

## Fix

Bump the testsuite SHA from `e7f46eac` to `fcbfd6a`, which includes:

- **fix(runner): wrap stop_display_manager in try/except** — the direct fix
- **fix(smoke): ignore fwupd-refresh.service in QEMU VMs**
- **fix(e2e): query real AT-SPI bus address**
- **fix(smoke): rpm-ostree --apply-live fallback + bootc lock fixes**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>