### PR TITLE
ci: bump testsuite SHA to e2b36dc (all env + ptyxis quarantine + screenshot fixes)

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@20fb066e50c81d62d15cf84633d36c260c4115db # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e2b36dc75ad91a6da7321c3ce86d3e1d250f5c4a # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e7f46eac7266809401d22db3f9f14e87ccfb8d63 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@20fb066e50c81d62d15cf84633d36c260c4115db # main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e2b36dc75ad91a6da7321c3ce86d3e1d250f5c4a # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e7f9c65095a0cbf62689a8cd64a471ee4824630c # main
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
## Summary

Updates the testsuite SHA to `e2b36dc` — the latest stable main with all critical E2E infrastructure fixes that unblock the factory.

## Included fixes

| PR | Fix |
|---|---|
| [#354](https://github.com/projectbluefin/testsuite/pull/354) | Fix qecore-headless Patches 4/4b/6 — gnome-session UID env vars |
| [#355](https://github.com/projectbluefin/testsuite/pull/355) | Patch 8: IOError path seeds full container env (fixes bazzite/lts/dakota) |
| [#357](https://github.com/projectbluefin/testsuite/pull/357) | `continue-on-error` on screenshot step (no more false-negative failures) |
| [#362](https://github.com/projectbluefin/testsuite/pull/362) | Ptyxis SSH-launch shim — AT-SPI app launch via SSH |
| [#364](https://github.com/projectbluefin/testsuite/pull/364) | `setuptools<81` pin — fixes pip install in Python 3.14 runner |
| [#369](https://github.com/projectbluefin/testsuite/pull/369) | Quarantine ptyxis AT-SPI restart scenarios (fixes developer suite) |

## Validation

Nightly run [27016363870](https://github.com/projectbluefin/testsuite/actions/runs/27016363870):
- smoke ✅ bluefin:testing, bluefin:stable, nvidia-open:testing, nvidia-open:stable
- common ✅ bluefin:testing, bluefin:stable, nvidia-open:testing, nvidia-open:stable

## Remaining known failures (pre-existing, not introduced)
- `bluefin:lts` — ZFS /var dataset prevents extension load
- `gdx:stream10` common — Homebrew removed from new gdx image (image regression)
- bazzite/gnomeos — pre-existing, separate triage