### PR TITLE
fix(ci): update COPR health monitor for new API response format

### DIFF
--- a/.github/workflows/copr-health-monitor.yml
+++ b/.github/workflows/copr-health-monitor.yml
@@ -50,7 +50,7 @@ jobs:
             build_ts=$(echo "${response}" | python3 -c "
           import json,sys
           d=json.load(sys.stdin)
-          b = d.get('latest_succeeded_build')
+          b = d.get('latest_succeeded_build') or (d.get('builds') or {}).get('latest_succeeded')
           print(b['submitted_on'] if b else 0)
           " 2>/dev/null || echo "0")
 


### PR DESCRIPTION
## Summary
- handle both legacy `latest_succeeded_build` and current `builds.latest_succeeded` COPR API response formats
- prevent false-positive stale build alerts for packages like `che/nerd-fonts`

## Testing
- `just check`
- `pre-commit run --all-files`

Closes #314