### PR TITLE
fix(packages): install yelp to handle help:// URIs in Nautilus

### DIFF
--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -82,6 +82,7 @@ FEDORA_PACKAGES=(
     git-credential-libsecret
     glow
     gnome-tweaks
+    yelp
     google-noto-sans-balinese-fonts
     google-noto-sans-cjk-fonts
     google-noto-sans-javanese-fonts
@@ -227,7 +228,6 @@ EXCLUDED_PACKAGES=(
     google-noto-sans-cjk-vf-fonts
     podman-docker
     totem-video-thumbnailer
-    yelp
 )
 
 # Remove excluded packages if they are installed


### PR DESCRIPTION
## Summary
- install `yelp` in the base Fedora package set
- stop excluding `yelp` from the image so Nautilus can open `help:` URIs
- restore the standard GNOME help viewer for the Templates tooltip Learn More action

## Test plan
- `just check`
- `pre-commit run --all-files`