### PR TITLE
test(build): add bats unit tests for validate-repos.sh and copr-helpers.sh

### DIFF
--- a/tests/unit/copr-helpers_test.bats
+++ b/tests/unit/copr-helpers_test.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/copr-helpers.sh.
+# Run with: bats tests/unit/copr-helpers_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+COPR_HELPERS_LIB="${SCRIPT_DIR}/../../build_files/shared/copr-helpers.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/copr-helpers.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/bin"
+    DNF5_LOG="${TEST_ROOT}/dnf5.log"
+
+    mkdir -p "${STUB_BIN}"
+    export PATH="${STUB_BIN}:${PATH}"
+    export COPR_HELPERS_LIB
+    export DNF5_LOG
+    unset DNF5_FAIL_MATCH
+    unset DNF5_FAIL_CODE
+
+    cat > "${STUB_BIN}/dnf5" <<'EOF'
+#!/usr/bin/bash
+printf '%s\n' "$*" >> "${DNF5_LOG}"
+if [[ -n "${DNF5_FAIL_MATCH:-}" && "$*" == *"${DNF5_FAIL_MATCH}"* ]]; then
+    exit "${DNF5_FAIL_CODE:-1}"
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/dnf5"
+
+    # shellcheck source=../../build_files/shared/copr-helpers.sh
+    source "${COPR_HELPERS_LIB}"
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+@test "copr_install_isolated: installs packages with isolated repo flow" {
+    run copr_install_isolated atim/starship starship zsh
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing starship zsh from COPR atim/starship (isolated)"* ]]
+    [[ "$output" == *"Installed starship zsh from atim/starship"* ]]
+
+    mapfile -t calls < "${DNF5_LOG}"
+    [ "${#calls[@]}" -eq 3 ]
+    [ "${calls[0]}" = "-y copr enable atim/starship" ]
+    [ "${calls[1]}" = "-y copr disable atim/starship" ]
+    [ "${calls[2]}" = "-y install --enablerepo=copr:copr.fedorainfracloud.org:atim:starship starship zsh" ]
+}
+
+@test "copr_install_isolated: propagates dnf5 install failure" {
+    export DNF5_FAIL_MATCH=" install "
+    export DNF5_FAIL_CODE=23
+
+    run bash -c 'source "$COPR_HELPERS_LIB"; copr_install_isolated atim/starship starship'
+
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"Installing starship from COPR atim/starship (isolated)"* ]]
+    [[ "$output" != *"Installed starship from atim/starship"* ]]
+
+    mapfile -t calls < "${DNF5_LOG}"
+    [ "${#calls[@]}" -eq 3 ]
+}
+
+@test "copr_install_isolated: empty package list returns error without calling dnf5" {
+    run copr_install_isolated atim/starship
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ERROR: No packages specified for copr_install_isolated"* ]]
+    [ ! -f "${DNF5_LOG}" ]
+}

--- a/tests/unit/validate-repos_test.bats
+++ b/tests/unit/validate-repos_test.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/validate-repos.sh.
+# Run with: bats tests/unit/validate-repos_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+VALIDATE_REPOS_LIB="${SCRIPT_DIR}/../../build_files/shared/validate-repos.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/validate-repos.${BATS_TEST_NUMBER:-0}.$$"
+    mkdir -p "${TEST_ROOT}"
+
+    ENABLED_REPOS=()
+    VALIDATION_FAILED=0
+
+    eval "$(sed -n '/^check_repo_file() {/,/^}/p' "${VALIDATE_REPOS_LIB}")"
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+@test "check_repo_file: valid disabled repo file reports disabled" {
+    repo_file="${TEST_ROOT}/valid.repo"
+    output_file="${TEST_ROOT}/output.txt"
+    cat > "${repo_file}" <<'EOF'
+[test-repo]
+name=Test Repo
+enabled=0
+EOF
+
+    check_repo_file "${repo_file}" > "${output_file}"
+    output="$(<"${output_file}")"
+
+    [ "${VALIDATION_FAILED}" -eq 0 ]
+    [ "${#ENABLED_REPOS[@]}" -eq 0 ]
+    [[ "${output}" == *"Disabled: valid.repo"* ]]
+}
+
+@test "check_repo_file: enabled repo file marks validation failed and reports section" {
+    repo_file="${TEST_ROOT}/enabled.repo"
+    output_file="${TEST_ROOT}/output.txt"
+    cat > "${repo_file}" <<'EOF'
+[test-repo]
+name=Test Repo
+enabled=1
+EOF
+
+    check_repo_file "${repo_file}" > "${output_file}"
+    output="$(<"${output_file}")"
+
+    [ "${VALIDATION_FAILED}" -eq 1 ]
+    [ "${#ENABLED_REPOS[@]}" -eq 1 ]
+    [ "${ENABLED_REPOS[0]}" = "enabled.repo" ]
+    [[ "${output}" == *"ENABLED: enabled.repo"* ]]
+    [[ "${output}" == *"- [test-repo]"* ]]
+}
+
+@test "check_repo_file: missing file is skipped" {
+    missing_file="${TEST_ROOT}/missing.repo"
+    output_file="${TEST_ROOT}/output.txt"
+
+    check_repo_file "${missing_file}" > "${output_file}"
+    output="$(<"${output_file}")"
+
+    [ "${VALIDATION_FAILED}" -eq 0 ]
+    [ "${#ENABLED_REPOS[@]}" -eq 0 ]
+    [ -z "${output}" ]
+}
+
+@test "check_repo_file: empty or malformed content without enabled repos stays disabled" {
+    repo_file="${TEST_ROOT}/malformed.repo"
+    output_file="${TEST_ROOT}/output.txt"
+    cat > "${repo_file}" <<'EOF'
+this is not a repo file
+enabled = maybe
+EOF
+
+    check_repo_file "${repo_file}" > "${output_file}"
+    output="$(<"${output_file}")"
+
+    [ "${VALIDATION_FAILED}" -eq 0 ]
+    [ "${#ENABLED_REPOS[@]}" -eq 0 ]
+    [[ "${output}" == *"Disabled: malformed.repo"* ]]
+}


### PR DESCRIPTION
## Summary
- add bats coverage for `check_repo_file()` in `validate-repos.sh`
- add bats coverage for `copr_install_isolated()` in `copr-helpers.sh`
- verify success, failure, and empty-input paths with stubbed commands

## Test plan
- `just check && pre-commit run --all-files`
- `bats tests/unit/validate-repos_test.bats tests/unit/copr-helpers_test.bats`
- `bats tests/unit/`

Closes #300
Closes #307
Closes #312