### PR TITLE
fix(desktop): route help:// URIs to online GNOME docs

### DIFF
--- a/system_files/shared/etc/xdg/mimeapps.list
+++ b/system_files/shared/etc/xdg/mimeapps.list
@@ -1,0 +1,2 @@
+[Default Applications]
+x-scheme-handler/help=gnome-help-browser.desktop

--- a/system_files/shared/usr/share/applications/gnome-help-browser.desktop
+++ b/system_files/shared/usr/share/applications/gnome-help-browser.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=GNOME Help
+Comment=Open GNOME help pages in the default web browser
+# Translates help:APP/PAGE → https://help.gnome.org/users/APP/stable/PAGE.html
+Exec=bash -c 'uri="$1"; path="${uri#help:}"; path="${path#//}"; app="${path%%/*}"; page="${path#*/}"; xdg-open "https://help.gnome.org/users/${app}/stable/${page}.html"' -- %u
+Type=Application
+MimeType=x-scheme-handler/help;
+NoDisplay=true
+Terminal=false


### PR DESCRIPTION
## Problem

`yelp` is deprecated and explicitly excluded from the image. Clicking any GNOME "Learn More" help button (e.g. the Nautilus Templates folder tooltip) produces a hard error because nothing handles `help://` URIs.

## Fix

- Add `gnome-help-browser.desktop` (NoDisplay, handles `x-scheme-handler/help`)
- Translates `help:APP/PAGE` → `https://help.gnome.org/users/APP/stable/PAGE.html`
- Set as system default via `/etc/xdg/mimeapps.list`

Clicking "Learn More" in Nautilus now opens the corresponding GNOME documentation page in the default browser.

Closes #306