### PR TITLE
ci: add local Renovate runner

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (log only, no PRs created or updated)'
+        type: boolean
+        default: false
+  schedule:
+    - cron: '0 */6 * * *'
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.dry_run == true && 'debug' || 'info' }}
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run == true && 'full' || '' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,6 +14,9 @@ concurrency:
   group: renovate
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   renovate:
     name: Renovate

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "local>projectbluefin/renovate-config"
   ],
-  "baseBranches": ["testing"],
+  "baseBranchPatterns": ["testing"],
   "packageRules": [
     {
       "description": "Automerge chore dep updates (digest, pin, patch, minor) when CI passes",


### PR DESCRIPTION
Fixes dependency on org-level Renovate app (currently broken, issue #487). Adds a self-hosted runner matching the bluefin-lts pattern: triggers every 6h and on workflow_dispatch, uses RENOVATE_TOKEN secret.

Part of factory automation audit gap fixes.