### PR TITLE
ci: automate testing→main branch promotion

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -1,0 +1,171 @@
+name: Promote testing to main
+
+on:
+  push:
+    branches:
+      - testing
+  schedule:
+    - cron: '0 23 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: promote-testing-to-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    name: Open or update testing → main PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch branch refs
+        run: git fetch origin main testing
+
+      - name: Compare testing and main trees
+        id: compare
+        run: |
+          set -euo pipefail
+
+          MAIN_SHA=$(git rev-parse origin/main)
+          TESTING_SHA=$(git rev-parse origin/testing)
+          MAIN_TREE=$(git rev-parse 'origin/main^{tree}')
+          TESTING_TREE=$(git rev-parse 'origin/testing^{tree}')
+
+          if [ "$MAIN_TREE" = "$TESTING_TREE" ]; then
+            SYNC_NEEDED=false
+            echo "main and testing have identical trees — no promotion PR update needed"
+          else
+            SYNC_NEEDED=true
+            echo "testing differs from main — promotion PR should exist"
+          fi
+
+          {
+            echo "main_sha=${MAIN_SHA}"
+            echo "testing_sha=${TESTING_SHA}"
+            echo "main_tree=${MAIN_TREE}"
+            echo "testing_tree=${TESTING_TREE}"
+            echo "sync_needed=${SYNC_NEEDED}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing promotion PR
+        id: existing-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --base main \
+            --head testing \
+            --state open \
+            --json number,url \
+            --jq '.[0].number // empty')
+
+          if [ -n "$PR_NUMBER" ]; then
+            PR_URL=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json url --jq '.url')
+            echo "Found existing PR #${PR_NUMBER}: ${PR_URL}"
+          else
+            PR_URL=""
+            echo "No open testing → main PR found"
+          fi
+
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert promotion PR
+        id: upsert
+        if: steps.compare.outputs.sync_needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXISTING_PR_NUMBER: ${{ steps.existing-pr.outputs.pr_number }}
+          MAIN_SHA: ${{ steps.compare.outputs.main_sha }}
+          MAIN_TREE: ${{ steps.compare.outputs.main_tree }}
+          TESTING_SHA: ${{ steps.compare.outputs.testing_sha }}
+          TESTING_TREE: ${{ steps.compare.outputs.testing_tree }}
+          TRIGGER_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          TITLE="chore: promote testing to main"
+          PR_BODY=$(cat <<EOF
+          ## Automated testing → main promotion
+
+          This PR is managed by .github/workflows/promote-testing-to-main.yml.
+
+          - Trigger: ${TRIGGER_NAME}
+          - Testing SHA: ${TESTING_SHA}
+          - Main SHA: ${MAIN_SHA}
+          - Testing tree: ${TESTING_TREE}
+          - Main tree: ${MAIN_TREE}
+          - Workflow run: ${RUN_URL}
+
+          The workflow compares branch tree hashes so squash merges do not cause already-promoted commits to be re-proposed.
+          EOF
+          )
+
+          if [ -n "$EXISTING_PR_NUMBER" ]; then
+            gh pr edit "$EXISTING_PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body "$PR_BODY"
+            PR_NUMBER="$EXISTING_PR_NUMBER"
+          else
+            PR_URL=$(gh pr create \
+              --repo "${{ github.repository }}" \
+              --base main \
+              --head testing \
+              --title "$TITLE" \
+              --body "$PR_BODY")
+            PR_NUMBER="${PR_URL##*/}"
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json url,autoMergeRequest,mergeStateStatus,mergeable)
+
+          {
+            echo "pr_number=${PR_NUMBER}"
+            echo "pr_url=$(jq -r '.url' <<<"$PR_JSON")"
+            echo "auto_merge_enabled=$(jq -r 'if .autoMergeRequest then "true" else "false" end' <<<"$PR_JSON")"
+            echo "merge_state_status=$(jq -r '.mergeStateStatus' <<<"$PR_JSON")"
+            echo "mergeable=$(jq -r '.mergeable' <<<"$PR_JSON")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.compare.outputs.sync_needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.upsert.outputs.pr_number }}
+          AUTO_MERGE_ENABLED: ${{ steps.upsert.outputs.auto_merge_enabled }}
+          MERGE_STATE_STATUS: ${{ steps.upsert.outputs.merge_state_status }}
+          MERGEABLE: ${{ steps.upsert.outputs.mergeable }}
+        run: |
+          set -euo pipefail
+
+          if [ "$AUTO_MERGE_ENABLED" = "true" ]; then
+            echo "Auto-merge is already enabled on PR #${PR_NUMBER}"
+            exit 0
+          fi
+
+          if [ "$MERGEABLE" = "CONFLICTING" ] || [ "$MERGE_STATE_STATUS" = "DIRTY" ]; then
+            echo "ERROR: testing → main PR #${PR_NUMBER} is conflicted (mergeable=${MERGEABLE}, mergeStateStatus=${MERGE_STATE_STATUS})"
+            exit 1
+          fi
+
+          gh pr merge "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --auto \
+            --squash
+
+          echo "✅ Auto-merge enabled on PR #${PR_NUMBER}"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,6 +7,7 @@ Bluefin's CI is split between PR validation, image builds, post-build e2e, weekl
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `pr-validation.yml` | PRs to `testing`, `merge_group` | Fast validation via `validate-pr@v1`: `just check`, `shellcheck`, `hadolint`, `pre-commit`, **bats unit tests** — **E2E only on `merge_group`** |
+| `promote-testing-to-main.yml` | Push to `testing`, daily 23:00 UTC, manual dispatch | Upserts the long-lived `testing` → `main` promotion PR and enables squash auto-merge |
 | `build-image-testing.yml` | Push to `main`, `merge_group`, dispatch, workflow call | Builds testing images via centralized `projectbluefin/actions` workflow |
 | `post-testing-e2e.yml` | Successful `Testing Images` workflow on `main` push | Downloads the testing digest and runs smoke tests in `projectbluefin/testsuite` |
 | `weekly-testing-promotion.yml` | Tuesday 06:00 UTC, manual dispatch | Verifies e2e on current `main`, promotes `main` to `latest` + `stable`, triggers downstream builds |
@@ -125,20 +126,25 @@ This keeps PR feedback fast (~2-3 min) while still gating every merge to `testin
 
 ## How testing promotion works
 
-There are two different branch roles to keep straight:
+There are three different branch roles to keep straight:
 
 - **Contribution branch:** PRs land on `testing`
-- **Image promotion branch flow in current workflows:** `main` → `latest` / `stable`
+- **Testing image branch:** `main` builds the `:testing` stream
+- **Production promotion branch flow:** `main` → `latest` / `stable`
 
 Current automation works like this:
 
-1. A push to `main` runs `build-image-testing.yml`
-2. `post-testing-e2e.yml` waits for that build, downloads `image-digest-testing-bluefin-main`, and runs the `smoke,common` suites from `projectbluefin/testsuite`
-3. `weekly-testing-promotion.yml` (Tuesday 06:00 UTC) locks the current `main` SHA
-4. It verifies `post-testing-e2e` already passed for that exact SHA
-5. It reruns broader `developer,vanilla-gnome,software,common` suites against the locked digest
-6. If `main` did not advance during testing, it retags all testing digests → `:latest` and `:stable` via skopeo copy (no rebuild)
-7. Branch push triggers on `latest`/`stable` also rebuild from source (dual pathway — see #225)
+1. A push to `testing` runs `promote-testing-to-main.yml`
+2. That workflow compares the `testing` and `main` tree hashes, upserts a single `testing` → `main` PR, and enables squash auto-merge
+3. The comparison is tree-based rather than `git log main..testing`, so squash merges do not cause already-promoted commits to be re-proposed
+4. Because the PR is created with `GITHUB_TOKEN`, it intentionally relies on `merge_group` gating rather than `pull_request` CI on PR creation
+5. Once the promotion PR merges to `main`, `build-image-testing.yml` builds the testing images
+6. `post-testing-e2e.yml` waits for that build, downloads `image-digest-testing-bluefin-main`, and runs the `smoke,common` suites from `projectbluefin/testsuite`
+7. `weekly-testing-promotion.yml` (Tuesday 06:00 UTC) locks the current `main` SHA
+8. It verifies `post-testing-e2e` already passed for that exact SHA
+9. It reruns broader `developer,vanilla-gnome,software,common` suites against the locked digest
+10. If `main` did not advance during testing, it retags all testing digests → `:latest` and `:stable` via skopeo copy (no rebuild)
+11. Branch push triggers on `latest`/`stable` also rebuild from source (dual pathway — see #225)
 
 The weekly promotion workflow refuses to promote untested code. It uses SHA-locked digests throughout, not mutable tags.
 
@@ -163,6 +169,7 @@ grep -rn "projectbluefin/testsuite" .github/workflows/ | grep -v "run-testsuite.
 
 - `.github/renovate.json5` is configured with `baseBranchPatterns: ["testing"]`
 - `renovate-automerge.yml` searches for matching PRs with `--base testing`
+- `promote-testing-to-main.yml` is the bridge from Renovate's `testing` branch to the `main` branch that feeds testing image builds
 - Matches both `renovate[bot]` and `app/mergeraptor` — both login names appear in practice
 - Risk-tiered: PRs with `renovate/high-risk` label wait for PR Smoke Test; low-risk merge after PR Validation
 - If Renovate PRs stop auto-merging, verify the trigger workflow name matches (`PR Validation — testsuite` or `PR Smoke Test`) and that author filter includes both bot names
@@ -246,6 +253,7 @@ GitHub provides 10 GB per repo. With 4 flavor+image combinations each ~2-3 GB, t
 |---|---|---|
 | `pr-validation.yml` | PRs to `testing`, `merge_group` | Fast validation: `just check`, `shellcheck`, `pre-commit`, e2e smoke |
 | `pr-smoke.yml` | PRs touching build files | Full image build + smoke test |
+| `promote-testing-to-main.yml` | Push to `testing`, daily 23:00 UTC, dispatch | Upserts the long-lived `testing` → `main` PR and enables squash auto-merge |
 | `build-image-testing.yml` | Push to `main`, `merge_group`, dispatch | Builds testing images via `reusable-build.yml` |
 | `post-testing-e2e.yml` | Successful `Testing Images` on `main` push | Smoke+common e2e gate; opens issue on failure |
 | `weekly-testing-promotion.yml` | Tuesday 06:00 UTC, dispatch | Full e2e → retag testing digests to :latest/:stable |


### PR DESCRIPTION
## Summary
- add promote-testing-to-main.yml to upsert a single testing→main PR on pushes to testing, daily repair cron, and manual dispatch
- compare testing and main by tree hash so squash merges do not re-propose already-promoted commits
- enable squash auto-merge on the promotion PR and document the new bridge in docs/ci.md

## Validation
- just check
- pre-commit run --all-files