### PR TITLE
fix: use app token for promotion PRs

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -13,8 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   promote:
@@ -26,6 +25,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.BLUEFINBOT_APP_ID }}
+          private-key: ${{ secrets.BLUEFINBOT_PRIVATE_KEY }}
 
       - name: Fetch branch refs
         run: git fetch origin main testing
@@ -59,7 +65,7 @@ jobs:
       - name: Find existing promotion PR
         id: existing-pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -86,7 +92,7 @@ jobs:
         id: upsert
         if: steps.compare.outputs.sync_needed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           EXISTING_PR_NUMBER: ${{ steps.existing-pr.outputs.pr_number }}
           MAIN_SHA: ${{ steps.compare.outputs.main_sha }}
           MAIN_TREE: ${{ steps.compare.outputs.main_tree }}
@@ -145,7 +151,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.compare.outputs.sync_needed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.upsert.outputs.pr_number }}
           AUTO_MERGE_ENABLED: ${{ steps.upsert.outputs.auto_merge_enabled }}
           MERGE_STATE_STATUS: ${{ steps.upsert.outputs.merge_state_status }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -137,7 +137,7 @@ Current automation works like this:
 1. A push to `testing` runs `promote-testing-to-main.yml`
 2. That workflow compares the `testing` and `main` tree hashes, upserts a single `testing` → `main` PR, and enables squash auto-merge
 3. The comparison is tree-based rather than `git log main..testing`, so squash merges do not cause already-promoted commits to be re-proposed
-4. Because the PR is created with `GITHUB_TOKEN`, it intentionally relies on `merge_group` gating rather than `pull_request` CI on PR creation
+4. The workflow uses the Bluefin bot GitHub App token so the `testing` → `main` PR fires normal `pull_request` CI before merge queue entry
 5. Once the promotion PR merges to `main`, `build-image-testing.yml` builds the testing images
 6. `post-testing-e2e.yml` waits for that build, downloads `image-digest-testing-bluefin-main`, and runs the `smoke,common` suites from `projectbluefin/testsuite`
 7. `weekly-testing-promotion.yml` (Tuesday 06:00 UTC) locks the current `main` SHA


### PR DESCRIPTION
## Summary
- switch `promote-testing-to-main.yml` from `GITHUB_TOKEN` to the Bluefin bot GitHub App token
- reduce default workflow permissions to read-only because PR writes now use the app token
- update the CI docs to note that promotion PRs fire normal `pull_request` checks before merge queue entry

## Why
PR #326 merged with `GITHUB_TOKEN`-based PR creation, which suppresses `pull_request` workflows. Bluefin main requires the `validate` status check, so the generated `testing` → `main` promotion PR would not receive the required check and could stall in the merge queue.

Follow-up for #326.