### PR TITLE
chore: switch lifecycle automation to common-owned workflow

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -1,19 +1,23 @@
-name: bonedigger
+name: issue and PR lifecycle
+
 on:
   issues:
     types: [opened, labeled, closed]
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened]
   schedule:
     - cron: '0 9 * * *'
 
 permissions:
   issues: write
+  pull-requests: write
   contents: read
 
 jobs:
-  bonedigger:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@743f56403af826b148d2841524faa1edb68a4538
+  lifecycle:
+    uses: projectbluefin/common/.github/workflows/lifecycle.yml@c978e1ea5457a605da112b41b5e717b16d06e817
     with:
       brand_name: "Bluefin"
       brand_emoji: "🦖"


### PR DESCRIPTION
Switches the issue/PR lifecycle automation from bonedigger to the
new common-owned `lifecycle.yml` reusable workflow.

**What changes:**
- Issue widget, slash commands (/approve, /claim, /unclaim, /wontfix, /hold), and label guards now run from `projectbluefin/common`
- bonedigger scoped to ujust report filing only (separate PR to bonedigger)
- No behavior change for contributors — same commands, cleaner ownership

Part of: projectbluefin/common (local pending changes in this session)