### PR TITLE
fix: add promotion conflict reporting and main PR builds

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -1,5 +1,14 @@
 name: Testing Images
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Containerfile
+      - Justfile
+      - image-versions.yml
+      - build_files/**
+      - system_files/**
   merge_group:
   push:
     branches:

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -20,6 +20,12 @@ jobs:
     name: Open or update testing → main PR
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      sync_needed: ${{ steps.compare.outputs.sync_needed }}
+      testing_sha: ${{ steps.compare.outputs.testing_sha }}
+      pr_url: ${{ steps.upsert.outputs.pr_url || steps.existing-pr.outputs.pr_url }}
+      merge_state_status: ${{ steps.upsert.outputs.merge_state_status }}
+      mergeable: ${{ steps.upsert.outputs.mergeable }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -175,3 +181,48 @@ jobs:
             --squash
 
           echo "✅ Auto-merge enabled on PR #${PR_NUMBER}"
+
+  report-failure:
+    needs: [promote]
+    if: always() && failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const mergeStateStatus = '${{ needs.promote.outputs.merge_state_status }}' || 'unknown';
+            const mergeable = '${{ needs.promote.outputs.mergeable }}' || 'unknown';
+            const testingSha = '${{ needs.promote.outputs.testing_sha }}' || 'unknown';
+            const prUrl = '${{ needs.promote.outputs.pr_url }}';
+            const title = 'ci: testing→main promotion conflict';
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/ci,kind/bug',
+              state: 'open',
+            });
+            const dup = existing.data.find(i => i.title === title);
+            const body = `## Testing → Main Promotion Conflict\n\n**Run:** ${runUrl}\n**Merge state status:** ${mergeStateStatus}\n**Mergeable:** ${mergeable}\n**Testing SHA:** \`${testingSha}\`${prUrl ? `\n**PR:** ${prUrl}` : ''}\n\n_Automatically opened by promote-testing-to-main.yml_`;
+
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['area/ci', 'kind/bug'],
+              });
+            }


### PR DESCRIPTION
## Summary
- add a report-failure issue upsert job to testing→main promotion
- include workflow run, merge state, and testing SHA in the conflict report
- trigger build-image-testing on main-bound PRs that touch build-affecting paths

## Test plan
- just check
- pre-commit run --all-files