### PR TITLE
fix(ci): use GITHUB_TOKEN directly in promote-testing-to-main — remove GitHub App token

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -20,6 +20,9 @@ jobs:
     name: Open or update testing → main PR
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       sync_needed: ${{ steps.compare.outputs.sync_needed }}
       testing_sha: ${{ steps.compare.outputs.testing_sha }}
@@ -31,13 +34,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          client-id: ${{ secrets.BLUEFINBOT_APP_ID }}
-          private-key: ${{ secrets.BLUEFINBOT_PRIVATE_KEY }}
 
       - name: Fetch branch refs
         run: git fetch origin main testing
@@ -71,7 +67,7 @@ jobs:
       - name: Find existing promotion PR
         id: existing-pr
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -98,7 +94,7 @@ jobs:
         id: upsert
         if: steps.compare.outputs.sync_needed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           EXISTING_PR_NUMBER: ${{ steps.existing-pr.outputs.pr_number }}
           MAIN_SHA: ${{ steps.compare.outputs.main_sha }}
           MAIN_TREE: ${{ steps.compare.outputs.main_tree }}
@@ -157,7 +153,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.compare.outputs.sync_needed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.upsert.outputs.pr_number }}
           AUTO_MERGE_ENABLED: ${{ steps.upsert.outputs.auto_merge_enabled }}
           MERGE_STATE_STATUS: ${{ steps.upsert.outputs.merge_state_status }}


### PR DESCRIPTION
## Problem

`promote-testing-to-main.yml` was failing because `BLUEFINBOT_APP_ID` secret is not set, causing:
```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

## Fix

Remove the `create-github-app-token` step and all `BLUEFINBOT_*` secret dependencies entirely. `GITHUB_TOKEN` is sufficient for opening and updating the testing→main promotion PR.

Also adds the missing job-level `pull-requests: write` permission.

## Changes
- `.github/workflows/promote-testing-to-main.yml`: remove App token steps, use `github.token` directly

## Validation
- [x] `just check`
- [x] actionlint clean