### PR TITLE
ci: consumer validation — projectbluefin/actions#94 supply chain hardening

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -31,7 +31,7 @@ jobs:
     # Thin caller only: shared build orchestration belongs in projectbluefin/actions.
     # Keep repo-local edits here limited to triggers, permissions, and reusable-build inputs.
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'latest'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@38dc24b919e557a1204e26641887af792bf6cbad # v1
     with:
       stream_name: latest
       # FIXME: enable when ublue-os/akmods has ARM builds

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -24,7 +24,7 @@ jobs:
     # Thin caller only: shared build orchestration belongs in projectbluefin/actions.
     # Keep repo-local edits here limited to triggers, permissions, and reusable-build inputs.
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'stable'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@38dc24b919e557a1204e26641887af792bf6cbad # v1
     with:
       # kernel_pin: 6.17.12-300.fc43.x86_64 ## Pin to 6.17 for ZFS compatibility
       stream_name: stable

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -40,7 +40,7 @@ jobs:
       should_build: ${{ steps.detect.outputs.should_build }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: projectbluefin/actions/bootc-build/detect-changes@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+      - uses: projectbluefin/actions/bootc-build/detect-changes@38dc24b919e557a1204e26641887af792bf6cbad # v1
         id: detect
 
   build-image-testing:
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@38dc24b919e557a1204e26641887af792bf6cbad # v1
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup runner
         # Keep this workflow limited to Bluefin-specific PR image plumbing.
         # If setup/build/push logic becomes reusable, move it to projectbluefin/actions.
-        uses: projectbluefin/actions/bootc-build/setup-runner@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+        uses: projectbluefin/actions/bootc-build/setup-runner@38dc24b919e557a1204e26641887af792bf6cbad # v1
         with:
           storage-backend: btrfs
           update-podman: "true"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Validate
-        uses: projectbluefin/actions/bootc-build/validate-pr@352163f170c15bf65f936b150e6a13f2a5f7037b # projectbluefin/actions fix/precommit-sha-pin
+        uses: projectbluefin/actions/bootc-build/validate-pr@38dc24b919e557a1204e26641887af792bf6cbad # projectbluefin/actions fix/precommit-sha-pin
 
   unit-tests:
     name: Unit tests

--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   skill-drift:
     # Guardrail: CI/workflow changes must update the matching skill and docs in the same PR.
-    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@38dc24b919e557a1204e26641887af792bf6cbad # v1
     with:
       code-paths: '[".github/workflows/**", ".github/actions/**", "build_files/**", "Justfile", "recipes/**"]'
       skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'


### PR DESCRIPTION
## Consumer validation draft PR

This PR pins `projectbluefin/actions` to the `feat/supply-chain-hardening` branch SHA for consumer validation of projectbluefin/actions#94.

**Do not merge this PR directly.** Once actions#94 merges and the `@v1` tag advances, update the SHA pins to `@v1` and close this draft.

## What's being validated

- Trivy `scan-image` wired into `reusable-build.yml` between build and push
- `security-events: write` permission added to `build_container` job
- SLSA Build L2 provenance via `actions/attest-build-provenance`
- SBOM attestation via `actions/attest` with `sbom-path`
- Tightened cosign verify regexp
- `artifact-metadata` invalid permission scope removed

## Actions ref

`projectbluefin/actions` feat/supply-chain-hardening @ `38dc24b919e557a1204e26641887af792bf6cbad`