### PR TITLE
chore(ci): validate actions timeout pin

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -22,6 +22,7 @@ permissions:
   packages: write
   id-token: write
   attestations: write
+  security-events: write
   artifact-metadata: write
 
 jobs:
@@ -30,7 +31,7 @@ jobs:
     # Thin caller only: shared build orchestration belongs in projectbluefin/actions.
     # Keep repo-local edits here limited to triggers, permissions, and reusable-build inputs.
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'latest'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
     with:
       stream_name: latest
       # FIXME: enable when ublue-os/akmods has ARM builds

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -15,6 +15,7 @@ permissions:
   packages: write
   id-token: write
   attestations: write
+  security-events: write
   artifact-metadata: write
 
 jobs:
@@ -23,7 +24,7 @@ jobs:
     # Thin caller only: shared build orchestration belongs in projectbluefin/actions.
     # Keep repo-local edits here limited to triggers, permissions, and reusable-build inputs.
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'stable'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
     with:
       # kernel_pin: 6.17.12-300.fc43.x86_64 ## Pin to 6.17 for ZFS compatibility
       stream_name: stable

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,12 +53,13 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
+      security-events: write
       artifact-metadata: write
     with:
       image_flavors: >-


### PR DESCRIPTION
## What does this change?\n\n- Pins Bluefin's reusable-build workflow calls to projectbluefin/actions@c4c25bda265a350b3f17982198eedb5a760ea7fd\n- Exercises the actions branch that adds explicit job timeouts and pins ubuntu-24.04 runners\n\n## Why\n\nThis PR exists to provide required consumer validation coverage for projectbluefin/actions PR projectbluefin/actions#TBD.\n\n## Validation\n\n- [x] just check\n- [x] pre-commit run --all-files\n\n## Notes\n\n- Validation-only PR; do not merge until the corresponding actions change is reviewed