### PR TITLE
chore(ci): validate actions strict-mode branch

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -40,7 +40,7 @@ jobs:
       should_build: ${{ steps.detect.outputs.should_build }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: projectbluefin/actions/bootc-build/detect-changes@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+      - uses: projectbluefin/actions/bootc-build/detect-changes@56565203c203a13900be303db131b6326f7583cb # fix/strict-mode
         id: detect
 
   build-image-testing:
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@56565203c203a13900be303db131b6326f7583cb # fix/strict-mode
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup runner
         # Keep this workflow limited to Bluefin-specific PR image plumbing.
         # If setup/build/push logic becomes reusable, move it to projectbluefin/actions.
-        uses: projectbluefin/actions/bootc-build/setup-runner@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+        uses: projectbluefin/actions/bootc-build/setup-runner@56565203c203a13900be303db131b6326f7583cb # fix/strict-mode
         with:
           storage-backend: btrfs
           update-podman: "true"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Validate
-        uses: projectbluefin/actions/bootc-build/validate-pr@352163f170c15bf65f936b150e6a13f2a5f7037b # projectbluefin/actions fix/precommit-sha-pin
+        uses: projectbluefin/actions/bootc-build/validate-pr@56565203c203a13900be303db131b6326f7583cb # fix/strict-mode
 
   unit-tests:
     name: Unit tests


### PR DESCRIPTION
## What does this change?\n\nPins shared `projectbluefin/actions` references to `56565203c203a13900be303db131b6326f7583cb` from the actions strict-mode branch.\n\nThis draft PR exists only to validate the shared actions branch in real Bluefin CI before the actions PR merges.\n\n## Validation target\n\n- Actions branch: `projectbluefin/actions@56565203c203a13900be303db131b6326f7583cb`\n- Actions branch name: `fix/strict-mode`\n