### PR TITLE
ci: validate shared generate-release-notes action

### DIFF
--- a/.github/workflows/consumer-validate-generate-release-notes.yml
+++ b/.github/workflows/consumer-validate-generate-release-notes.yml
@@ -51,7 +51,7 @@ jobs:
           EOF
 
       - name: Run shared generate-release-notes action
-        uses: projectbluefin/actions/bootc-build/generate-release-notes@2497c3a4534b67aa29a049f296240ebf8155c279 # consumer-validation
+        uses: projectbluefin/actions/bootc-build/generate-release-notes@2497c3a7e0a7bbeeb36ac10bc2b487e7812ab562 # consumer-validation
         with:
           tag: v0.0.0
           output-file: CHANGELOG.md

--- a/.github/workflows/consumer-validate-generate-release-notes.yml
+++ b/.github/workflows/consumer-validate-generate-release-notes.yml
@@ -1,6 +1,12 @@
 name: Consumer validate shared generate-release-notes action
 
 on:
+  pull_request:
+    branches:
+      - testing
+    paths:
+      - .github/workflows/consumer-validate-generate-release-notes.yml
+      - docs/skills/ci.md
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/consumer-validate-generate-release-notes.yml
+++ b/.github/workflows/consumer-validate-generate-release-notes.yml
@@ -1,0 +1,59 @@
+name: Consumer validate shared generate-release-notes action
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Create temporary semver tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git tag -f v0.0.0
+
+      - name: Write temporary git-cliff config
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > cliff-consumer-validation.toml <<'EOF'
+          [changelog]
+          body = """
+          {% for group, commits in commits | group_by(attribute=\"group\") %}
+          ### {{ group | upper_first }}
+          {% for commit in commits %}
+          - {{ commit.message | split(pat=\"\\n\") | first }}
+          {% endfor %}
+          {% endfor %}
+          """
+          trim = true
+
+          [git]
+          conventional_commits = true
+          filter_unconventional = false
+          split_commits = false
+          EOF
+
+      - name: Run shared generate-release-notes action
+        uses: projectbluefin/actions/bootc-build/generate-release-notes@2497c3a4534b67aa29a049f296240ebf8155c279 # consumer-validation
+        with:
+          tag: v0.0.0
+          output-file: CHANGELOG.md
+          config: cliff-consumer-validation.toml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert changelog exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s CHANGELOG.md

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -206,6 +206,8 @@ When you encounter a CI issue that involves duplicated inline steps, path-filter
 3. CI must pass on this draft PR before the actions PR merges
 4. After the actions PR merges, update this repo to the released `v1` SHA (keep the trailing `# v1` comment)
 
+**Release-action consumer validation pattern:** if the shared action under test expects a semver tag or a `cliff.toml` but this repo does not ship them, add a draft-only manual workflow on the validation branch that creates a temporary local semver tag plus a temporary cliff config before calling the pinned shared action SHA. Link that workflow run in the actions PR as consumer-validation evidence.
+
 Never duplicate an existing shared action inline — doing so creates a second Renovate pin that drifts independently.
 
 ## Hard rules for agents


### PR DESCRIPTION
## What does this change?

Adds a draft-only consumer validation workflow that exercises the shared projectbluefin/actions bootc-build/generate-release-notes action against the branch SHA under test.

The workflow creates a temporary local semver tag and temporary git-cliff config so bluefin can validate the shared action without changing its normal release flow.

## Why?

projectbluefin/actions requires a real consumer PR and CI run before merging action changes. Bluefin does not normally use the shared release-notes action, so this draft PR provides the required validation evidence.

## Checklist

- [x] Draft PR for consumer validation only
- [x] Targets testing
- [x] Uses a pinned projectbluefin/actions branch SHA in the validation workflow