### PR TITLE
test(ci): validate actions pre-commit pinning

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Validate
-        uses: projectbluefin/actions/bootc-build/validate-pr@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+        uses: projectbluefin/actions/bootc-build/validate-pr@352163f5de4fed4b9b8a85e52dcaed2c4e18e321 # projectbluefin/actions fix/precommit-sha-pin
 
   unit-tests:
     name: Unit tests

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Validate
-        uses: projectbluefin/actions/bootc-build/validate-pr@352163f5de4fed4b9b8a85e52dcaed2c4e18e321 # projectbluefin/actions fix/precommit-sha-pin
+        uses: projectbluefin/actions/bootc-build/validate-pr@352163f170c15bf65f936b150e6a13f2a5f7037b # projectbluefin/actions fix/precommit-sha-pin
 
   unit-tests:
     name: Unit tests


### PR DESCRIPTION
## What does this change?\n\nPins PR validation to projectbluefin/actions@4c540e64747a1b7efc07839fc11b9d665be96821 so CI exercises the fix(deps): pin pre-commit hook revisions to full commit SHAs branch before merge.\n\n## Why?\n\nRequired consumer validation for projectbluefin/actions PR fix/precommit-sha-pin.\n\n- [x] Draft PR for validation only\n- [x] Targets testing branch