### PR TITLE
fix: migrate custom-command-menu dconf to command1..N tuple format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: "Bug report"
 description: "Something is broken. You are the only person who can confirm it."
-labels: ["type/bug", "needs-triage"]
+labels: ["kind/bug", "status/triage"]
 type: "Bug"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: "Feature request"
 description: "Propose something new. Specific proposals ship. Vague ones wait."
-labels: ["type/feature", "status/discussing"]
+labels: ["kind/enhancement", "status/discussing"]
 type: "Feature"
 body:
   - type: markdown

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -1,5 +1,14 @@
 name: Testing Images
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Containerfile
+      - Justfile
+      - image-versions.yml
+      - build_files/**
+      - system_files/**
   merge_group:
   push:
     branches:

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -20,6 +20,12 @@ jobs:
     name: Open or update testing → main PR
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      sync_needed: ${{ steps.compare.outputs.sync_needed }}
+      testing_sha: ${{ steps.compare.outputs.testing_sha }}
+      pr_url: ${{ steps.upsert.outputs.pr_url || steps.existing-pr.outputs.pr_url }}
+      merge_state_status: ${{ steps.upsert.outputs.merge_state_status }}
+      mergeable: ${{ steps.upsert.outputs.mergeable }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -175,3 +181,48 @@ jobs:
             --squash
 
           echo "✅ Auto-merge enabled on PR #${PR_NUMBER}"
+
+  report-failure:
+    needs: [promote]
+    if: always() && failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const mergeStateStatus = '${{ needs.promote.outputs.merge_state_status }}' || 'unknown';
+            const mergeable = '${{ needs.promote.outputs.mergeable }}' || 'unknown';
+            const testingSha = '${{ needs.promote.outputs.testing_sha }}' || 'unknown';
+            const prUrl = '${{ needs.promote.outputs.pr_url }}';
+            const title = 'ci: testing→main promotion conflict';
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/ci,kind/bug',
+              state: 'open',
+            });
+            const dup = existing.data.find(i => i.title === title);
+            const body = `## Testing → Main Promotion Conflict\n\n**Run:** ${runUrl}\n**Merge state status:** ${mergeStateStatus}\n**Mergeable:** ${mergeable}\n**Testing SHA:** \`${testingSha}\`${prUrl ? `\n**PR:** ${prUrl}` : ''}\n\n_Automatically opened by promote-testing-to-main.yml_`;
+
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['area/ci', 'kind/bug'],
+              });
+            }

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -2,7 +2,7 @@ name: Weekly Testing Promotion
 
 on:
   schedule:
-    - cron: '0 6 * * 2' # Tuesday 06:00 UTC
+    - cron: '0 6 * * 2' # Tuesday 06:00 UTC (08:00 EEST)
   workflow_dispatch:
 
 concurrency:
@@ -12,11 +12,64 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Enforce a minimum 7-day floor between stable promotions to prevent churn.
+  # On workflow_dispatch the floor is bypassed so maintainers can force a
+  # promotion (e.g. after a hotfix or a failed previous run).
+  check-promotion-floor:
+    name: Check 7-day promotion floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      should_promote: ${{ steps.floor.outputs.should_promote }}
+    steps:
+      - name: Check days since last stable release
+        id: floor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Manual dispatch — bypassing promotion floor."
+            echo "should_promote=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_RELEASE=$(gh release list \
+            --repo "${{ github.repository }}" \
+            --limit 1 \
+            --json createdAt \
+            --jq '.[0].createdAt // empty')
+
+          if [[ -z "$LAST_RELEASE" ]]; then
+            echo "No previous release found — first promotion, proceeding."
+            echo "should_promote=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_TS=$(date -d "$LAST_RELEASE" +%s)
+          NOW_TS=$(date +%s)
+          DAYS_SINCE=$(( (NOW_TS - LAST_TS) / 86400 ))
+
+          echo "Last stable release: $LAST_RELEASE (${DAYS_SINCE} days ago)"
+
+          if [[ "$DAYS_SINCE" -lt 7 ]]; then
+            echo "Floor not met (${DAYS_SINCE}/7 days) — skipping promotion this cycle."
+            echo "should_promote=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Floor met (${DAYS_SINCE} days) — proceeding with promotion."
+            echo "should_promote=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Verify that post-testing-e2e.yml already ran smoke tests on the current
   # main HEAD since every push to main triggers it. If e2e hasn't passed
   # on the current HEAD (e.g., a new push just landed), fail fast rather than
   # promoting untested code.
   verify-e2e:
+    needs: [check-promotion-floor]
+    if: needs.check-promotion-floor.outputs.should_promote == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/system_files/shared/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
+++ b/system_files/shared/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
@@ -5,57 +5,14 @@ menulocation-setting=1
 show-arrow=false
 command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
-entryrow1a-setting='---$(hostname)'
-entryrow1b-setting=''
-entryrow1c-setting=''
-visible1-setting=true
-
-entryrow2a-setting='About'
-entryrow2b-setting='gnome-control-center system about'
-entryrow2c-setting=''
-visible2-setting=true
-
-entryrow3a-setting='System Monitor'
-entryrow3b-setting='/usr/bin/missioncenter-helper'
-entryrow3c-setting=''
-visible3-setting=true
-
-entryrow4a-setting='System Settings'
-entryrow4b-setting='gnome-control-center'
-entryrow4c-setting=''
-visible4-setting=true
-
-entryrow5a-setting='---Applications'
-entryrow5b-setting=''
-entryrow5c-setting=''
-visible5-setting=true
-
-entryrow6a-setting='Bazaar App Store'
-entryrow6b-setting='/usr/bin/flatpak run io.github.kolunmi.Bazaar'
-entryrow6c-setting=''
-visible6-setting=true
-
-entryrow7a-setting='Extensions'
-entryrow7b-setting='flatpak run com.mattjakeman.ExtensionManager'
-entryrow7c-setting=''
-visible7-setting=true
-
-entryrow8a-setting='Terminal'
-entryrow8b-setting='xdg-terminal-exec'
-entryrow8c-setting=''
-visible8-setting=true
-
-entryrow9a-setting='---Help'
-entryrow9b-setting=''
-entryrow9c-setting=''
-visible9-setting=true
-
-entryrow10a-setting='Documentation'
-entryrow10b-setting='xdg-open https://docs.projectbluefin.io/'
-entryrow10c-setting=''
-visible10-setting=true
-
-entryrow11a-setting='Ask Bluefin'
-entryrow11b-setting='xdg-open https://ask.projectbluefin.io'
-entryrow11c-setting=''
-visible11-setting=true
+command1=('---$(hostname)', '', '', true)
+command2=('About', 'gnome-control-center system about', '', true)
+command3=('System Monitor', '/usr/bin/missioncenter-helper', '', true)
+command4=('System Settings', 'gnome-control-center', '', true)
+command5=('---Applications', '', '', true)
+command6=('Bazaar App Store', '/usr/bin/flatpak run io.github.kolunmi.Bazaar', '', true)
+command7=('Extensions', 'flatpak run com.mattjakeman.ExtensionManager', '', true)
+command8=('Terminal', 'xdg-terminal-exec', '', true)
+command9=('---Help', '', '', true)
+command10=('Documentation', 'xdg-open https://docs.projectbluefin.io/', '', true)
+command11=('Ask Bluefin', 'xdg-open https://ask.projectbluefin.io', '', true)


### PR DESCRIPTION
## Summary

Migrates `system_files/shared/etc/dconf/db/distro.d/04-bluefin-custom-command-menu` from stale `entryrow*` keys to the correct `command1`...`commandN` tuple format.

## Problem

The `entryrow*` style keys are **not in the extension schema**. Settings using unknown keys don't survive a dconf reset or fresh install — menu items disappear for first-time users who reset dconf.

## Fix

Replaced all 11 `entryrow*a/b/c-setting` + `visibleN-setting` groups with `commandN=('label', 'command', 'icon', visible)` tuples matching the `(sssb)` schema type.

Closes #340

---
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI