### PR TITLE
test(ci): run all bats unit tests in PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt-get install -y bats
 
       - name: Run unit tests
-        run: bats tests/unit/package-lib_test.bats
+        run: bats tests/unit/
 
   testsuite:
     name: E2E smoke


### PR DESCRIPTION
## Summary

Expands the unit-tests job in `pr-validation.yml` to run the full `tests/unit/` directory instead of only `package-lib_test.bats`.

## Problem

`copr-helpers_test.bats` and `validate-repos_test.bats` exist and have full coverage but were never executed in CI — only `package-lib_test.bats` was wired up.

All 18 tests pass locally:
```
ok 1 copr_install_isolated: installs packages with isolated repo flow
ok 2 copr_install_isolated: propagates dnf5 install failure
ok 3 copr_install_isolated: empty package list returns error without calling dnf5
...
ok 18 check_repo_file: empty or malformed content without enabled repos stays disabled
```

## Change

`bats tests/unit/package-lib_test.bats` → `bats tests/unit/`

New test files automatically included as they are added.

Closes #300, #307, #312, #323, #330

---
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI