### PR TITLE
ci: validate actions Trivy secret scanning branch

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@fix/sha-skew # validation branch: projectbluefin/actions
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@134eb70d5e79636e3b19cd178b280f29b4dd5c57 # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What does this change?

Pins `projectbluefin/actions/.github/workflows/reusable-build.yml` in `build-image-testing.yml` to the `fix/trivy-secrets` branch SHA from `projectbluefin/actions`.

This consumer-validation PR exists only to exercise the updated `bootc-build/scan-image` Trivy secret scanning configuration before the shared actions PR merges.

## Validation

- [x] `just check`
- [x] `pre-commit run --all-files`
- [ ] `build-image-testing.yml` workflow_dispatch against this branch
