### PR TITLE
docs: remove stale ublue-os/bluefin origin remote references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,8 @@ Non-compliance = rejection.
 - **Production promotion** (`weekly-testing-promotion.yml`) requires 2 distinct human approvals in the GitHub `production` Environment before `:stable` is updated. No agent may trigger, approve, or bypass this gate. Every admin bypass is permanently logged in Environment deployment history.
 - **`.github/workflows/`, `Justfile`, and `build_files/` are CODEOWNERS-protected** — PRs touching these paths require maintainer review.
 
-  > **⚠️ Git remote trap — confirmed incident 2026-06-01:** In this repo, `origin`
-  > points to `ublue-os/bluefin` (the forbidden org). A bare `git push` or
-  > `git push origin` silently violates this rule. **Always push explicitly:**
+  > **⚠️ Git remote trap:** A pre-push hook blocks any push to a remote named
+  > `origin` regardless of its URL. **Always push explicitly:**
   > `git push projectbluefin <branch>`. Verify with `git remote -v` before any push.
 
 ## PR comment policy

--- a/docs/build.md
+++ b/docs/build.md
@@ -2,7 +2,7 @@
 
 ## Git hook setup
 
-After cloning, install the pre-push guard to prevent accidentally pushing to `origin` (which points to `ublue-os/bluefin`):
+After cloning, install the pre-push guard that blocks accidental `git push origin`:
 
 ```bash
 bash .github/scripts/install-hooks.sh

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -22,13 +22,13 @@ git checkout -b my-feature projectbluefin/testing
 
 **One clean squash commit per PR.** Use `git commit --amend` or `git rebase -i` before pushing to ensure the PR contains exactly one commit.
 
-**Always push to the `projectbluefin` remote**, never `origin` (`origin` points to `ublue-os/bluefin`):
+**Always push to the `projectbluefin` remote**, not `origin` — a pre-push hook blocks `git push origin` by name:
 
 ```bash
 git push projectbluefin my-feature
 ```
 
-**Never `git push` or `git push origin`.** Always name the remote explicitly.
+**Never `git push` or `git push origin`.** The pre-push hook enforces `projectbluefin` as the required remote name.
 
 ## Issue tracker
 


### PR DESCRIPTION
## Summary

The `origin` remote now maps to `projectbluefin/bluefin` (fixed after the 2026-06-01 incident). Remove the stale description that said `origin` pointed to `ublue-os/bluefin`.

## Changes

- **AGENTS.md**: Rewrite remote trap warning — the pre-push hook blocks the remote *name* `origin`, not a specific URL
- **docs/workflow.md**: Remove `origin points to ublue-os/bluefin` parenthetical; clarify the hook enforces the `projectbluefin` remote name
- **docs/build.md**: Remove the stale URL explanation from the hook setup line

The hook behaviour and the rule (`git push projectbluefin <branch>`) are unchanged.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI