### PR TITLE
fix(ci): pin reusable-build to @v1 SHA — retire @fix/sha-skew validation ref

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@fix/sha-skew # validation branch: projectbluefin/actions
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What does this change?

Replaces the temporary `@fix/sha-skew` validation branch reference in `build-image-testing.yml` with the canonical `@v1` SHA.

## Why

`projectbluefin/actions#105` (`fix/sha-skew`) merged **2026-06-05T20:59:31Z**. The `@v1` tag now points to `6274199cfb6666180ac2fd0ad5a41bc8440e0929`, which includes all supply chain hardening work from actions#94-#105.

Keeping a validation branch reference in production is a risk — if the branch is ever force-pushed or deleted, the build silently breaks.

## Changes
- `.github/workflows/build-image-testing.yml`: `@fix/sha-skew` → `@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1`

## Validation
- [x] `just check`
- [x] No functional change — same SHA the branch points to