### PR TITLE
fix(ci): handle FORBIDDEN gracefully in promote-testing-to-main enqueue step

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -183,6 +183,8 @@ jobs:
             echo "⏳ PR #${PR_NUMBER} cannot be enqueued yet — required checks have not passed (mergeStateStatus=${MERGE_STATE_STATUS}). A maintainer can approve and enqueue once CI passes."
           elif echo "$RESULT" | grep -q "already in the merge queue"; then
             echo "PR #${PR_NUMBER} is already in the merge queue"
+          elif echo "$RESULT" | grep -qi "forbidden\|not accessible by integration"; then
+            echo "⚠️ PR #${PR_NUMBER} is open and ready. GITHUB_TOKEN cannot enqueue — a maintainer must approve then run: gh pr merge ${PR_NUMBER} --squash --admin"
           else
             echo "ERROR: enqueuePullRequest failed: ${RESULT}"
             exit 1


### PR DESCRIPTION
## What does this change?

The `enqueuePullRequest` GraphQL mutation returns `FORBIDDEN` when called with `GITHUB_TOKEN` — per GitHub docs, only users with write access can enqueue, and the token is a GitHub App installation token, not a user. Previously this caused `exit 1`, which triggered `report-failure` and filed a noisy bug issue on every promotion cycle.

This PR handles the FORBIDDEN case as a non-fatal warning with a clear maintainer instruction, matching the documented flow in AGENTS.md: a maintainer approves the PR then runs `gh pr merge <N> --squash --admin`.

## Validation
- [x] `just check`
- [x] `pre-commit run --all-files`