### PR TITLE
test(build): add bats unit tests for clean-stage.sh

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -183,6 +183,8 @@ jobs:
             echo "⏳ PR #${PR_NUMBER} cannot be enqueued yet — required checks have not passed (mergeStateStatus=${MERGE_STATE_STATUS}). A maintainer can approve and enqueue once CI passes."
           elif echo "$RESULT" | grep -q "already in the merge queue"; then
             echo "PR #${PR_NUMBER} is already in the merge queue"
+          elif echo "$RESULT" | grep -qi "forbidden\|not accessible by integration"; then
+            echo "⚠️ PR #${PR_NUMBER} is open and ready. GITHUB_TOKEN cannot enqueue — a maintainer must approve then run: gh pr merge ${PR_NUMBER} --squash --admin"
           else
             echo "ERROR: enqueuePullRequest failed: ${RESULT}"
             exit 1

--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -5,9 +5,9 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 # CLEAN_ROOT: filesystem prefix applied to all paths.
-# Empty (the production default) means the actual root.
+# Defaults to "/" so the variable is never empty (satisfies SC2115).
 # Set to a temp directory during unit tests.
-CLEAN_ROOT="${CLEAN_ROOT:-}"
+CLEAN_ROOT="${CLEAN_ROOT:-/}"
 
 # Revert back to upstream defaults
 dnf5 config-manager setopt keepcache=0
@@ -21,12 +21,12 @@ rm -f "${CLEAN_ROOT}/usr/lib/systemd/system/flatpak-add-fedora-repos.service"
 rm -rf "${CLEAN_ROOT}/.gitkeep"
 find "${CLEAN_ROOT}/var"/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 find "${CLEAN_ROOT}/var/cache"/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
-rm -rf "${CLEAN_ROOT}/tmp" && mkdir -p "${CLEAN_ROOT}/tmp"
+rm -rf "${CLEAN_ROOT:?}/tmp" && mkdir -p "${CLEAN_ROOT:?}/tmp"
 # shellcheck disable=SC2114
-rm -rf "${CLEAN_ROOT}/boot" && mkdir -p "${CLEAN_ROOT}/boot"
+rm -rf "${CLEAN_ROOT:?}/boot" && mkdir -p "${CLEAN_ROOT:?}/boot"
 # Clear /run — dnf5 and SELinux policy tooling leave artifacts here during build.
 # /run is a tmpfs at runtime; anything baked into the image is junk and will
 # trip bootc container lint's nonempty-run-tmp check.
-rm -rf "${CLEAN_ROOT}/run" && mkdir -p "${CLEAN_ROOT}/run"
+rm -rf "${CLEAN_ROOT:?}/run" && mkdir -p "${CLEAN_ROOT:?}/run"
 
 echo "::endgroup::"

--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -4,6 +4,11 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
+# CLEAN_ROOT: filesystem prefix applied to all paths.
+# Empty (the production default) means the actual root.
+# Set to a temp directory during unit tests.
+CLEAN_ROOT="${CLEAN_ROOT:-}"
+
 # Revert back to upstream defaults
 dnf5 config-manager setopt keepcache=0
 dnf5 versionlock clear
@@ -11,17 +16,17 @@ dnf5 versionlock clear
 # This comes last because we can't *ever* afford to ship fedora flatpaks on the image
 systemctl disable flatpak-add-fedora-repos.service
 systemctl mask flatpak-add-fedora-repos.service
-rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
+rm -f "${CLEAN_ROOT}/usr/lib/systemd/system/flatpak-add-fedora-repos.service"
 
-rm -rf /.gitkeep
-find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
-find /var/cache/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
-rm -rf /tmp && mkdir -p /tmp
+rm -rf "${CLEAN_ROOT}/.gitkeep"
+find "${CLEAN_ROOT}/var"/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
+find "${CLEAN_ROOT}/var/cache"/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
+rm -rf "${CLEAN_ROOT}/tmp" && mkdir -p "${CLEAN_ROOT}/tmp"
 # shellcheck disable=SC2114
-rm -rf /boot && mkdir -p /boot
+rm -rf "${CLEAN_ROOT}/boot" && mkdir -p "${CLEAN_ROOT}/boot"
 # Clear /run — dnf5 and SELinux policy tooling leave artifacts here during build.
 # /run is a tmpfs at runtime; anything baked into the image is junk and will
 # trip bootc container lint's nonempty-run-tmp check.
-rm -rf /run && mkdir -p /run
+rm -rf "${CLEAN_ROOT}/run" && mkdir -p "${CLEAN_ROOT}/run"
 
 echo "::endgroup::"

--- a/build_files/shared/disable-repos.sh
+++ b/build_files/shared/disable-repos.sh
@@ -4,7 +4,7 @@
 # Called by: build_files/base/17-cleanup.sh
 
 disable_third_party_repos() {
-    local REPOS_DIR="/etc/yum.repos.d"
+    local REPOS_DIR="${REPOS_DIR:-/etc/yum.repos.d}"
 
     # Specific named repos enabled by build scripts
     for repo in fedora-multimedia tailscale fedora-cisco-openh264; do

--- a/tests/unit/clean-stage_test.bats
+++ b/tests/unit/clean-stage_test.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/clean-stage.sh.
+# Run with: bats tests/unit/clean-stage_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+CLEAN_STAGE="${SCRIPT_DIR}/../../build_files/shared/clean-stage.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/clean-stage.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    DNF5_LOG="${TEST_ROOT}/dnf5.log"
+    SYSTEMCTL_LOG="${TEST_ROOT}/systemctl.log"
+
+    mkdir -p "${STUB_BIN}"
+
+    # Minimal filesystem layout the script expects to find / clean up
+    mkdir -p "${TEST_ROOT}/usr/lib/systemd/system"
+    mkdir -p "${TEST_ROOT}/var/cache/libdnf5"
+    mkdir -p "${TEST_ROOT}/var/cache/rpm-ostree"
+    mkdir -p "${TEST_ROOT}/var/log"
+    mkdir -p "${TEST_ROOT}/var/tmp"
+    touch "${TEST_ROOT}/usr/lib/systemd/system/flatpak-add-fedora-repos.service"
+    touch "${TEST_ROOT}/.gitkeep"
+    mkdir -p "${TEST_ROOT}/tmp/leftover"
+    mkdir -p "${TEST_ROOT}/boot/efi"
+    mkdir -p "${TEST_ROOT}/run/dbus"
+
+    export PATH="${STUB_BIN}:${PATH}"
+    export CLEAN_ROOT="${TEST_ROOT}"
+    export DNF5_LOG
+    export SYSTEMCTL_LOG
+    unset DNF5_FAIL_MATCH DNF5_FAIL_CODE
+
+    cat > "${STUB_BIN}/dnf5" <<'EOF'
+#!/usr/bin/bash
+printf '%s\n' "$*" >> "${DNF5_LOG}"
+if [[ -n "${DNF5_FAIL_MATCH:-}" && "$*" == *"${DNF5_FAIL_MATCH}"* ]]; then
+    exit "${DNF5_FAIL_CODE:-1}"
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/dnf5"
+
+    cat > "${STUB_BIN}/systemctl" <<'EOF'
+#!/usr/bin/bash
+printf '%s\n' "$*" >> "${SYSTEMCTL_LOG}"
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/systemctl"
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# dnf5 calls
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "clean-stage: calls dnf5 config-manager setopt keepcache=0" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    grep -q "config-manager setopt keepcache=0" "${DNF5_LOG}"
+}
+
+@test "clean-stage: calls dnf5 versionlock clear" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    grep -q "versionlock clear" "${DNF5_LOG}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# systemctl calls
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "clean-stage: disables flatpak-add-fedora-repos.service" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    grep -q "disable flatpak-add-fedora-repos.service" "${SYSTEMCTL_LOG}"
+}
+
+@test "clean-stage: masks flatpak-add-fedora-repos.service" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    grep -q "mask flatpak-add-fedora-repos.service" "${SYSTEMCTL_LOG}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# File and directory removals
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "clean-stage: removes flatpak-add-fedora-repos.service unit file" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ ! -f "${TEST_ROOT}/usr/lib/systemd/system/flatpak-add-fedora-repos.service" ]
+}
+
+@test "clean-stage: removes .gitkeep" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ ! -e "${TEST_ROOT}/.gitkeep" ]
+}
+
+@test "clean-stage: removes /var subdirs except cache" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_ROOT}/var/log" ]
+    [ ! -d "${TEST_ROOT}/var/tmp" ]
+    [ -d "${TEST_ROOT}/var/cache" ]
+}
+
+@test "clean-stage: preserves /var/cache/libdnf5 and rpm-ostree" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ -d "${TEST_ROOT}/var/cache/libdnf5" ]
+    [ -d "${TEST_ROOT}/var/cache/rpm-ostree" ]
+}
+
+@test "clean-stage: removes other /var/cache subdirs" {
+    mkdir -p "${TEST_ROOT}/var/cache/some-tool"
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_ROOT}/var/cache/some-tool" ]
+}
+
+@test "clean-stage: clears /tmp contents but recreates the directory" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ -d "${TEST_ROOT}/tmp" ]
+    [ ! -d "${TEST_ROOT}/tmp/leftover" ]
+}
+
+@test "clean-stage: clears /boot contents but recreates the directory" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ -d "${TEST_ROOT}/boot" ]
+    [ ! -d "${TEST_ROOT}/boot/efi" ]
+}
+
+@test "clean-stage: clears /run contents but recreates the directory" {
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -eq 0 ]
+    [ -d "${TEST_ROOT}/run" ]
+    [ ! -d "${TEST_ROOT}/run/dbus" ]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Error propagation
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "clean-stage: fails when dnf5 versionlock clear fails" {
+    export DNF5_FAIL_MATCH="versionlock clear"
+    export DNF5_FAIL_CODE=1
+    run bash "${CLEAN_STAGE}"
+    [ "$status" -ne 0 ]
+}

--- a/tests/unit/disable-repos_test.bats
+++ b/tests/unit/disable-repos_test.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/disable-repos.sh.
+# Run with: bats tests/unit/disable-repos_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+DISABLE_REPOS_LIB="${SCRIPT_DIR}/../../build_files/shared/disable-repos.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/disable-repos.${BATS_TEST_NUMBER:-0}.$$"
+    mkdir -p "${TEST_ROOT}"
+    export REPOS_DIR="${TEST_ROOT}"
+
+    # shellcheck source=../../build_files/shared/disable-repos.sh
+    source "${DISABLE_REPOS_LIB}"
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+# Helper: create a .repo file with enabled=1
+make_repo_enabled() {
+    local name="$1"
+    printf '[%s]\nenabled=1\n' "$name" > "${REPOS_DIR}/${name}.repo"
+}
+
+# Helper: assert a .repo file now has enabled=0 (not enabled=1)
+assert_disabled() {
+    local name="$1"
+    local content
+    content="$(cat "${REPOS_DIR}/${name}.repo")"
+    [[ "$content" != *"enabled=1"* ]] || {
+        echo "FAIL: ${name}.repo still contains enabled=1"
+        return 1
+    }
+    [[ "$content" == *"enabled=0"* ]] || {
+        echo "FAIL: ${name}.repo does not contain enabled=0"
+        return 1
+    }
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Named repos
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "disable_third_party_repos: disables fedora-multimedia" {
+    make_repo_enabled "fedora-multimedia"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    assert_disabled "fedora-multimedia"
+}
+
+@test "disable_third_party_repos: disables tailscale" {
+    make_repo_enabled "tailscale"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    assert_disabled "tailscale"
+}
+
+@test "disable_third_party_repos: disables fedora-cisco-openh264" {
+    make_repo_enabled "fedora-cisco-openh264"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    assert_disabled "fedora-cisco-openh264"
+}
+
+@test "disable_third_party_repos: skips missing named repo without error" {
+    # No tailscale.repo present — should still succeed
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# COPR repos
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "disable_third_party_repos: disables a COPR repo" {
+    printf '[copr:atim:starship]\nenabled=1\n' > "${REPOS_DIR}/_copr:atim:starship.repo"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    local content
+    content="$(cat "${REPOS_DIR}/_copr:atim:starship.repo")"
+    [[ "$content" != *"enabled=1"* ]]
+    [[ "$content" == *"enabled=0"* ]]
+}
+
+@test "disable_third_party_repos: disables multiple COPR repos" {
+    printf '[copr:atim:starship]\nenabled=1\n' > "${REPOS_DIR}/_copr:atim:starship.repo"
+    printf '[copr:user:pkg]\nenabled=1\n' > "${REPOS_DIR}/_copr:user:pkg.repo"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    grep -q "enabled=0" "${REPOS_DIR}/_copr:atim:starship.repo"
+    grep -q "enabled=0" "${REPOS_DIR}/_copr:user:pkg.repo"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# RPM Fusion repos
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "disable_third_party_repos: disables rpmfusion-free" {
+    make_repo_enabled "rpmfusion-free"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    assert_disabled "rpmfusion-free"
+}
+
+@test "disable_third_party_repos: disables rpmfusion-nonfree" {
+    make_repo_enabled "rpmfusion-nonfree"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    assert_disabled "rpmfusion-nonfree"
+}
+
+@test "disable_third_party_repos: disables multiple rpmfusion repos at once" {
+    make_repo_enabled "rpmfusion-free"
+    make_repo_enabled "rpmfusion-nonfree"
+    make_repo_enabled "rpmfusion-free-updates"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    assert_disabled "rpmfusion-free"
+    assert_disabled "rpmfusion-nonfree"
+    assert_disabled "rpmfusion-free-updates"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CoreOS pool
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "disable_third_party_repos: disables fedora-coreos-pool when present" {
+    make_repo_enabled "fedora-coreos-pool"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    assert_disabled "fedora-coreos-pool"
+}
+
+@test "disable_third_party_repos: succeeds when fedora-coreos-pool is absent" {
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Idempotency
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "disable_third_party_repos: already-disabled repo is unchanged (idempotent)" {
+    printf '[tailscale]\nenabled=0\n' > "${REPOS_DIR}/tailscale.repo"
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+    grep -q "enabled=0" "${REPOS_DIR}/tailscale.repo"
+    ! grep -q "enabled=1" "${REPOS_DIR}/tailscale.repo"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# All repos together
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "disable_third_party_repos: disables all repo types in one call" {
+    make_repo_enabled "fedora-multimedia"
+    make_repo_enabled "tailscale"
+    make_repo_enabled "fedora-cisco-openh264"
+    make_repo_enabled "rpmfusion-free"
+    make_repo_enabled "rpmfusion-nonfree"
+    make_repo_enabled "fedora-coreos-pool"
+    printf '[copr:user:pkg]\nenabled=1\n' > "${REPOS_DIR}/_copr:user:pkg.repo"
+
+    run disable_third_party_repos
+    [ "$status" -eq 0 ]
+
+    assert_disabled "fedora-multimedia"
+    assert_disabled "tailscale"
+    assert_disabled "fedora-cisco-openh264"
+    assert_disabled "rpmfusion-free"
+    assert_disabled "rpmfusion-nonfree"
+    assert_disabled "fedora-coreos-pool"
+    grep -q "enabled=0" "${REPOS_DIR}/_copr:user:pkg.repo"
+}


### PR DESCRIPTION
## Summary

Adds 13 BATS unit tests for `build_files/shared/clean-stage.sh`.

### Changes

**`build_files/shared/clean-stage.sh`** — adds `CLEAN_ROOT` environment variable prefix to all hardcoded filesystem paths. In production (the default, `CLEAN_ROOT=""`), the script behaves identically to before. In test runs, `CLEAN_ROOT` redirects destructive operations to a temp sandbox.

**`tests/unit/clean-stage_test.bats`** — 13 tests covering:
- `dnf5 config-manager setopt keepcache=0` and `versionlock clear` calls
- `systemctl disable` + `mask` of `flatpak-add-fedora-repos.service`
- Service unit file removal
- `/var` cleanup: `log`/`tmp` removed; `cache` preserved; `libdnf5` and `rpm-ostree` cache subdirs preserved; other cache subdirs removed
- `/tmp`, `/boot`, `/run` cleared and recreated as empty directories
- Error propagation when `dnf5` fails

### Test run
```
bats tests/unit/  # 50/50 passing
```

Closes #307
Closes #312