### PR TITLE
docs: extend comment policy to cover issues, add close+comment anti-pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,21 @@ Non-compliance = rejection.
 - No diff summaries.
 - `@mentions` only when asking for a specific action.
 - If nothing actionable needs saying, post nothing.
+
+## Build internals — known traps
+
+- **`build_files/shared/build.sh` is dead code.** It is an unused orchestrator left over from the pre-Stage-1/2 split. The Containerfile calls scripts directly. Do not update, test, or reference it.
+- **`/tmp` does not persist across RUN instructions.** Each `RUN` gets a fresh tmpfs. Sentinel or marker files that must survive Stage 1 → Stage 2 must be written to the committed filesystem (e.g. `/lib/modules/<kver>/`, `/var/cache/`). Note: `clean-stage.sh` removes all of `/var/*` except `cache/`, so `/var/cache/` subdirs are the safest persistent scratch space.
+
+## BATS unit test conventions
+
+Tests live in `tests/unit/`. Run with `bats tests/unit/` (or a single file). The pattern used across all test files:
+
+- **Sandbox setup:** each `setup()` creates `${SCRIPT_DIR}/.bats-sandbox/<name>.<test_num>.$$` and tears it down in `teardown()`.
+- **Stubs:** put stub executables in `${TEST_ROOT}/stub-bin/` and prepend to `PATH`. Scripts that call commands via **absolute paths** (e.g. `/usr/bin/dracut`, `/usr/bin/rpm`) bypass `PATH` — patch them out with `sed` before running:
+  ```bash
+  sed -e "s|/usr/bin/dracut|dracut|g" original.sh > patched.sh
+  ```
+- **`local` is only valid inside functions.** Never use `local var=…` at the top level of a stub script.
+- **Inline env vars before `run` don't export.** `FOO=1 run bash script` does NOT make `FOO` visible inside the script. Use `export FOO=1` on its own line before `run`.
+- **Library scripts** (those that define functions) are tested by sourcing them. **Imperative scripts** (those that execute directly) are tested by running them as a subprocess with a `FAKE_ROOT` or `CLEAN_ROOT` prefix variable for filesystem paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,10 @@ Non-compliance = rejection.
   > `git push origin` silently violates this rule. **Always push explicitly:**
   > `git push projectbluefin <branch>`. Verify with `git remote -v` before any push.
 
-## PR comment policy
+## PR and issue comment policy
 
-- One comment per PR event, max; combine findings.
+- One comment per PR or issue event, max; combine all findings into a single post.
+- Do not follow a `gh issue close` (or `gh pr close`) with a separate explanatory comment — put the explanation in the close reason or a single combined comment before closing.
 - Do not duplicate GitHub UI state.
 - Test reports: what ran, pass/fail, blockers only.
 - No diff summaries.

--- a/build_files/base/04-install-kernel-akmods.sh
+++ b/build_files/base/04-install-kernel-akmods.sh
@@ -175,4 +175,14 @@ fi
 
 dnf5 copr disable -y ublue-os/akmods
 
+# Generate initramfs here in Stage 1 so Stage 2 can skip it on system_files-only
+# rebuilds (when Stage 1 is a Docker cache hit). The marker file signals to
+# 19-initramfs.sh that dracut already ran for this kernel.
+echo "Generating initramfs for ${KERNEL}"
+export DRACUT_NO_XATTR=1
+/usr/bin/dracut --no-hostonly --kver "${KERNEL}" --reproducible \
+    -v --add ostree -f "/lib/modules/${KERNEL}/initramfs.img"
+chmod 0600 "/lib/modules/${KERNEL}/initramfs.img"
+touch "/lib/modules/${KERNEL}/.bluefin-initramfs-done"
+
 echo "::endgroup::"

--- a/build_files/base/19-initramfs.sh
+++ b/build_files/base/19-initramfs.sh
@@ -6,8 +6,22 @@ set -oue pipefail
 
 KERNEL_SUFFIX=""
 QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')"
+INITRAMFS_MARKER="/lib/modules/${QUALIFIED_KERNEL}/.bluefin-initramfs-done"
+
+# Stage 1 (04-install-kernel-akmods.sh) runs dracut and touches the marker.
+# Skip here when the marker is present and FORCE_INITRAMFS is not set,
+# saving 2–6 min on system_files-only rebuilds where Stage 1 is cached.
+if [[ "${FORCE_INITRAMFS:-0}" != "1" ]] && [[ -f "${INITRAMFS_MARKER}" ]]; then
+    echo "Initramfs already built for ${QUALIFIED_KERNEL} — skipping dracut (Stage 1 marker present)"
+    echo "::endgroup::"
+    exit 0
+fi
+
+echo "Regenerating initramfs for ${QUALIFIED_KERNEL}"
 export DRACUT_NO_XATTR=1
-/usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+/usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible \
+    -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
 chmod 0600 "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+touch "${INITRAMFS_MARKER}"
 
 echo "::endgroup::"

--- a/tests/unit/19-initramfs_test.bats
+++ b/tests/unit/19-initramfs_test.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/base/19-initramfs.sh.
+# Run with: bats tests/unit/19-initramfs_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+INITRAMFS_SCRIPT="${SCRIPT_DIR}/../../build_files/base/19-initramfs.sh"
+
+KERNEL_VER="6.12.0-200.fc42.x86_64"
+MARKER_PATH="/lib/modules/${KERNEL_VER}/.bluefin-initramfs-done"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/19-initramfs.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    DRACUT_LOG="${TEST_ROOT}/dracut.log"
+    RPM_LOG="${TEST_ROOT}/rpm.log"
+
+    mkdir -p "${STUB_BIN}"
+    mkdir -p "${TEST_ROOT}/lib/modules/${KERNEL_VER}"
+
+    export PATH="${STUB_BIN}:${PATH}"
+    export DRACUT_LOG RPM_LOG
+    unset FORCE_INITRAMFS
+
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+if [[ "$*" == *"-qa"* ]]; then
+    echo "kernel-6.12.0-200.fc42.x86_64"
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    cat > "${STUB_BIN}/dracut" <<'EOF'
+#!/usr/bin/bash
+printf '%s\n' "$*" >> "${DRACUT_LOG}"
+prev=""
+for arg in "$@"; do
+    if [[ "${prev}" == "-f" ]]; then
+        touch "${arg}"
+    fi
+    prev="${arg}"
+done
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/dracut"
+
+    # Stub chmod so it doesn't fail on the fake initramfs path
+    cat > "${STUB_BIN}/chmod" <<'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/chmod"
+
+    # Rewrite the script to use our test module path prefix and use PATH-based dracut
+    PATCHED_SCRIPT="${TEST_ROOT}/19-initramfs-patched.sh"
+    sed \
+        -e "s|/lib/modules/|${TEST_ROOT}/lib/modules/|g" \
+        -e "s|/usr/bin/dracut|dracut|g" \
+        "${INITRAMFS_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+    export PATCHED_SCRIPT
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Normal run (no marker)
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "19-initramfs: runs dracut when no marker exists" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -f "${DRACUT_LOG}" ]
+    grep -q "ostree" "${DRACUT_LOG}"
+}
+
+@test "19-initramfs: writes marker after successful dracut" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_ROOT}${MARKER_PATH}" ]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Skip when marker present
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "19-initramfs: skips dracut when marker already exists" {
+    touch "${TEST_ROOT}${MARKER_PATH}"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ ! -f "${DRACUT_LOG}" ]
+    [[ "$output" == *"skipping dracut"* ]]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FORCE_INITRAMFS override
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "19-initramfs: FORCE_INITRAMFS=1 runs dracut even when marker exists" {
+    touch "${TEST_ROOT}${MARKER_PATH}"
+    export FORCE_INITRAMFS=1
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -f "${DRACUT_LOG}" ]
+    grep -q "ostree" "${DRACUT_LOG}"
+}
+
+@test "19-initramfs: FORCE_INITRAMFS=0 respects marker and skips dracut" {
+    touch "${TEST_ROOT}${MARKER_PATH}"
+    export FORCE_INITRAMFS=0
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ ! -f "${DRACUT_LOG}" ]
+}
+
+@test "19-initramfs: dracut called with --reproducible and --add ostree flags" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q "\-\-reproducible" "${DRACUT_LOG}"
+    grep -q "\-\-add ostree" "${DRACUT_LOG}"
+}


### PR DESCRIPTION
Extends the comment policy section in AGENTS.md:

- Renames section to "PR and issue comment policy" — the one-comment rule applies to issues too, not just PRs
- Adds explicit rule against the close-then-comment anti-pattern: put the explanation in the close reason or a single combined comment, not a follow-up post