### PR TITLE
test(build): add bats unit tests for 17-cleanup.sh and 18-workarounds.sh

### DIFF
--- a/tests/unit/17-cleanup_test.bats
+++ b/tests/unit/17-cleanup_test.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/base/17-cleanup.sh.
+# Run with: bats tests/unit/17-cleanup_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+CLEANUP_SCRIPT="${SCRIPT_DIR}/../../build_files/base/17-cleanup.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/17-cleanup.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+
+    mkdir -p "${STUB_BIN}"
+    mkdir -p "${TEST_ROOT}/usr/share/applications"
+    mkdir -p "${TEST_ROOT}/usr/lib/modules"
+
+    export PATH="${STUB_BIN}:${PATH}"
+
+    # Stub commands that require a real system environment
+    for cmd in systemctl flatpak; do
+        cat > "${STUB_BIN}/${cmd}" <<'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+        chmod +x "${STUB_BIN}/${cmd}"
+    done
+
+    # Default rpm stub: no kernel installed (all module dirs are orphans)
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+exit 1
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    # Patch absolute paths to use TEST_ROOT, stub source of disable-repos.sh,
+    # and use PATH-based rpm
+    PATCHED_SCRIPT="${TEST_ROOT}/17-cleanup-patched.sh"
+    sed \
+        -e "s|/usr/share/applications/|${TEST_ROOT}/usr/share/applications/|g" \
+        -e "s|/usr/lib/modules/|${TEST_ROOT}/usr/lib/modules/|g" \
+        -e "s|/usr/bin/rpm|rpm|g" \
+        -e "s|source /ctx/build_files/shared/disable-repos.sh|disable_third_party_repos() { :; }|g" \
+        "${CLEANUP_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+    export PATCHED_SCRIPT TEST_ROOT STUB_BIN
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Desktop file hiding
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "17-cleanup: Hidden=true is appended after [Desktop Entry] in fish.desktop" {
+    printf '[Desktop Entry]\nName=Fish\nExec=fish\n' \
+        > "${TEST_ROOT}/usr/share/applications/fish.desktop"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q "Hidden=true" "${TEST_ROOT}/usr/share/applications/fish.desktop"
+}
+
+@test "17-cleanup: Hidden=true is appended to htop.desktop when present" {
+    printf '[Desktop Entry]\nName=Htop\n' \
+        > "${TEST_ROOT}/usr/share/applications/htop.desktop"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q "Hidden=true" "${TEST_ROOT}/usr/share/applications/htop.desktop"
+}
+
+@test "17-cleanup: nvtop.desktop without [Desktop Entry] is not modified" {
+    printf 'Name=Nvtop\nExec=nvtop\n' \
+        > "${TEST_ROOT}/usr/share/applications/nvtop.desktop"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    # No [Desktop Entry] header means sed changes nothing
+    ! grep -q "Hidden=true" "${TEST_ROOT}/usr/share/applications/nvtop.desktop"
+}
+
+@test "17-cleanup: desktop file hiding is skipped when file does not exist" {
+    # fish.desktop absent — script must not error on missing file
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+}
+
+@test "17-cleanup: all three known desktop files are hidden when present" {
+    for name in fish htop nvtop; do
+        printf '[Desktop Entry]\nName=%s\n' "${name}" \
+            > "${TEST_ROOT}/usr/share/applications/${name}.desktop"
+    done
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    for name in fish htop nvtop; do
+        grep -q "Hidden=true" "${TEST_ROOT}/usr/share/applications/${name}.desktop"
+    done
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# systemctl / flatpak stubs (smoke test — confirms script reaches completion)
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "17-cleanup: script completes successfully with all stubs in place" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+}
+
+@test "17-cleanup: systemctl is invoked for required services" {
+    # Capture systemctl calls via a logging stub
+    cat > "${STUB_BIN}/systemctl" <<'EOF'
+#!/usr/bin/bash
+echo "systemctl $*" >> "${STUB_BIN}/systemctl.log"
+exit 0
+EOF
+    export STUB_BIN
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q "enable podman-auto-update.timer" "${STUB_BIN}/systemctl.log"
+    grep -q "enable ublue-system-setup.service" "${STUB_BIN}/systemctl.log"
+    grep -q "disable rpm-ostreed-automatic.timer" "${STUB_BIN}/systemctl.log"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# orphan kernel module cleanup
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "17-cleanup: orphan kernel module dir is removed when no RPM installed" {
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64" ]
+    [[ "$output" == *"Removing orphan"* ]]
+}
+
+@test "17-cleanup: kernel module dir is preserved when RPM is installed" {
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64"
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -d "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64" ]
+}
+
+@test "17-cleanup: only orphan dirs are removed, installed kernel dirs preserved" {
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-orphan.fc42.x86_64"
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-installed.fc42.x86_64"
+
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+if [[ "$*" == *"installed"* ]]; then
+    exit 0
+fi
+exit 1
+EOF
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_ROOT}/usr/lib/modules/6.12.0-orphan.fc42.x86_64" ]
+    [ -d "${TEST_ROOT}/usr/lib/modules/6.12.0-installed.fc42.x86_64" ]
+}

--- a/tests/unit/18-workarounds_test.bats
+++ b/tests/unit/18-workarounds_test.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/base/18-workarounds.sh.
+# Run with: bats tests/unit/18-workarounds_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+WORKAROUNDS_SCRIPT="${SCRIPT_DIR}/../../build_files/base/18-workarounds.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/18-workarounds.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+
+    mkdir -p "${STUB_BIN}"
+    mkdir -p "${TEST_ROOT}/usr/share/ublue-os/bling"
+    mkdir -p "${TEST_ROOT}/usr/share/ublue-os/bluefin-cli"
+    mkdir -p "${TEST_ROOT}/usr/share/doc/just"
+    mkdir -p "${TEST_ROOT}/usr/lib/modules"
+
+    export PATH="${STUB_BIN}:${PATH}"
+
+    # Default rpm stub: no kernel installed (all module dirs are orphans)
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+exit 1
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    # Patch absolute paths to use TEST_ROOT, and use PATH-based rpm
+    PATCHED_SCRIPT="${TEST_ROOT}/18-workarounds-patched.sh"
+    sed \
+        -e "s|/usr/share/ublue-os/|${TEST_ROOT}/usr/share/ublue-os/|g" \
+        -e "s|/usr/share/doc/just/|${TEST_ROOT}/usr/share/doc/just/|g" \
+        -e "s|/usr/lib/modules/|${TEST_ROOT}/usr/lib/modules/|g" \
+        -e "s|/usr/bin/rpm|rpm|g" \
+        "${WORKAROUNDS_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+    export PATCHED_SCRIPT TEST_ROOT
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# bling copy
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "18-workarounds: bling.sh is copied to bluefin-cli" {
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.sh"
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.fish"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_ROOT}/usr/share/ublue-os/bluefin-cli/bling.sh" ]
+    [ -f "${TEST_ROOT}/usr/share/ublue-os/bluefin-cli/bling.fish" ]
+}
+
+@test "18-workarounds: bluefin-cli directory is created if absent" {
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.sh"
+    rmdir "${TEST_ROOT}/usr/share/ublue-os/bluefin-cli"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -d "${TEST_ROOT}/usr/share/ublue-os/bluefin-cli" ]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# just README removal
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "18-workarounds: locale README files (README.*.md) are removed from just docs" {
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.sh"
+    touch "${TEST_ROOT}/usr/share/doc/just/README.md"
+    touch "${TEST_ROOT}/usr/share/doc/just/README.es.md"
+    touch "${TEST_ROOT}/usr/share/doc/just/README.zh.md"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    # README.*.md only matches locale variants (README.es.md, README.zh.md), not README.md
+    [ ! -f "${TEST_ROOT}/usr/share/doc/just/README.es.md" ]
+    [ ! -f "${TEST_ROOT}/usr/share/doc/just/README.zh.md" ]
+    # Plain README.md does not match README.*.md glob and must be preserved
+    [ -f "${TEST_ROOT}/usr/share/doc/just/README.md" ]
+}
+
+@test "18-workarounds: non-README files in just docs are preserved" {
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.sh"
+    touch "${TEST_ROOT}/usr/share/doc/just/README.md"
+    touch "${TEST_ROOT}/usr/share/doc/just/CHANGELOG"
+    touch "${TEST_ROOT}/usr/share/doc/just/LICENSE"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_ROOT}/usr/share/doc/just/CHANGELOG" ]
+    [ -f "${TEST_ROOT}/usr/share/doc/just/LICENSE" ]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# orphan kernel module cleanup
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "18-workarounds: orphan kernel module dir is removed when no RPM installed" {
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.sh"
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64" ]
+    [[ "$output" == *"Removing orphan"* ]]
+}
+
+@test "18-workarounds: kernel module dir is preserved when RPM is installed" {
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.sh"
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64"
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -d "${TEST_ROOT}/usr/lib/modules/6.12.0-200.fc42.x86_64" ]
+}
+
+@test "18-workarounds: only orphan dirs are removed, installed kernel dirs preserved" {
+    touch "${TEST_ROOT}/usr/share/ublue-os/bling/bling.sh"
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-orphan.fc42.x86_64"
+    mkdir -p "${TEST_ROOT}/usr/lib/modules/6.12.0-installed.fc42.x86_64"
+
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+if [[ "$*" == *"installed"* ]]; then
+    exit 0
+fi
+exit 1
+EOF
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_ROOT}/usr/lib/modules/6.12.0-orphan.fc42.x86_64" ]
+    [ -d "${TEST_ROOT}/usr/lib/modules/6.12.0-installed.fc42.x86_64" ]
+}


### PR DESCRIPTION
Closes #307, closes #312.

## What

Adds BATS unit tests for two previously-untested build shell scripts:

### `tests/unit/17-cleanup_test.bats` (10 tests)
- Desktop file hiding: verifies `Hidden=true` is injected after `[Desktop Entry]` for `fish`, `htop`, and `nvtop`
- Handles missing desktop files gracefully (no error)
- Smoke test: script completes with all stubs in place
- Systemctl logging: confirms `podman-auto-update.timer`, `ublue-system-setup.service`, and `rpm-ostreed-automatic.timer` disable are invoked
- Orphan kernel module cleanup: removes dirs with no matching `kernel-core` RPM, preserves dirs that have one

### `tests/unit/18-workarounds_test.bats` (7 tests)
- Bling files copied to `bluefin-cli` (including directory creation)
- Locale README removal: `README.*.md` glob removes `README.es.md` etc., preserves plain `README.md` and non-README files
- Orphan kernel module cleanup (same logic as above, tested independently)

## How

Both files follow existing BATS conventions from `19-initramfs_test.bats`:
- Sandbox in `.bats-sandbox/`
- Stub executables in `stub-bin/` prepended to `PATH`
- `sed` rewrites absolute paths (`/usr/share/`, `/usr/lib/modules/`) to test-root equivalents
- `teardown()` cleans up the sandbox
- For `17-cleanup.sh`: stubs `systemctl`, `flatpak`, `rpm`; replaces `source /ctx/...` with an inline no-op stub for `disable_third_party_repos`

## Validation
- All 67 unit tests pass (`bats tests/unit/`)
- `just check && pre-commit run --all-files` passes