### PR TITLE
ci: gate :testing tag behind post-build e2e (#518)

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@6274199cfb6666180ac2fd0ad5a41bc8440e0929 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@7e634a74009e630a76ca30877f3d77fab9e1c383 # feat/gate-testing-stream-tag
     permissions:
       contents: read
       packages: write
@@ -69,4 +69,5 @@ jobs:
           || '["main", "nvidia-open"]'
         }}
       stream_name: testing
+      publish_stream_tag: "false"
       pr_number: ${{ inputs.pr_number }}

--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -35,9 +35,9 @@ jobs:
           set -euo pipefail
           gh run download "${{ github.event.workflow_run.id }}" \
             --repo "${{ github.repository }}" \
-            --name "image-digest-testing-bluefin-main" \
+            --name "image-digest-testing-bluefin-main-x86_64" \
             --dir /tmp/digest
-          DIGEST=$(grep "=" /tmp/digest/main-bluefin.txt | head -1 | cut -d= -f2-)
+          DIGEST=$(grep "=" /tmp/digest/main-bluefin-x86_64.txt | head -1 | cut -d= -f2-)
           echo "image=ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "Testing image: ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}"
 
@@ -61,8 +61,57 @@ jobs:
       image: ${{ needs.e2e.outputs.image }}
       suites: lifecycle
 
-  report-failure:
+  promote-to-testing:
+    # Promote all tested flavors to :testing only after e2e passes.
+    # This ensures :testing always points to a digest that has passed gate e2e.
     needs: [e2e, run-e2e, run-upgrade-test]
+    if: >-
+      needs.run-e2e.result == 'success' &&
+      needs.run-upgrade-test.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      packages: write
+    steps:
+      - name: Download all testing image digests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh run download "${{ github.event.workflow_run.id }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "image-digest-testing-*" \
+            --dir /tmp/all-digests
+
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "$GH_TOKEN" | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Promote verified digests to :testing
+        run: |
+          set -euo pipefail
+          REGISTRY="ghcr.io/${{ github.repository_owner }}"
+          PROMOTED=0
+
+          while IFS= read -r -d '' f; do
+            # Each file contains: IMAGE_NAME=sha256:... (= format, one digest per image per arch)
+            while IFS='=' read -r image_name digest; do
+              [[ -z "${image_name}" || -z "${digest}" || "${image_name}" == *"|"* ]] && continue
+              SRC="docker://${REGISTRY}/${image_name}@${digest}"
+              DST="docker://${REGISTRY}/${image_name}:testing"
+              echo "Promoting ${image_name}@${digest} → :testing"
+              skopeo copy --all "${SRC}" "${DST}"
+              echo "  ✅ ${image_name}:testing updated"
+              PROMOTED=$((PROMOTED + 1))
+            done < "$f"
+          done < <(find /tmp/all-digests -name "*.txt" -print0)
+
+          echo "✅ Promoted ${PROMOTED} flavor(s) to :testing"
+
+  report-failure:
+    needs: [e2e, run-e2e, run-upgrade-test, promote-to-testing]
     if: failure() && needs.e2e.outputs.image != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

Implements [common#518](https://github.com/projectbluefin/common/issues/518): ensure `:testing` is never published before e2e passes.

### Before

`build-image-testing.yml` pushed `:testing` immediately at build time. `post-testing-e2e.yml` ran e2e **after** `:testing` was already live. Users pulling `:testing` could receive a broken image.

### After

1. **Build:** `publish_stream_tag: false` — pushes only `:sha` and version alias tags (e.g. `42-20260601.0`). Never pushes `:testing` at build time.
2. **Gate:** `post-testing-e2e.yml` adds a new `promote-to-testing` job that runs **only after** `run-e2e` and `run-upgrade-test` both succeed. It downloads all testing flavor digest artifacts and `skopeo copy`s each `@digest → :testing`.
3. `:testing` always points to a digest that passed `smoke,common` + lifecycle e2e.

Also fixes two bugs in the artifact download step:
- Corrects the artifact name from `image-digest-testing-bluefin-main` → `image-digest-testing-bluefin-main-x86_64` (includes architecture suffix, matching the actual artifact name emitted by `reusable-build.yml`)
- Corrects the file path in the digest parse step accordingly

### Dependencies

⚠️ **Requires [projectbluefin/actions#108](https://github.com/projectbluefin/actions/pull/108) to merge first.**

The SHA `7e634a74009e630a76ca30877f3d77fab9e1c383` points to the actions feature branch that adds `publish_stream_tag` input. Once actions#108 merges and maintainers advance `@v1` (or tag `@v2`), update the SHA in `build-image-testing.yml` to the new tag SHA.

## Closes

- Closes projectbluefin/common#518
- Part of projectbluefin/common#516