### PR TITLE
test: pin build-image-testing to actions fix/trivy-oci-archive-scan SHA

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@7e634a74009e630a76ca30877f3d77fab9e1c383 # feat/gate-testing-stream-tag
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@2d87fecc5716d0b750a7729ebbc72995f9e92b8a # fix/trivy-oci-archive-scan
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Consumer test PR for projectbluefin/actions#110.

Pins `reusable-build.yml` to `2d87fecc` to validate that exporting the image as `oci-archive` before the Trivy scan fixes the podman socket failure seen in https://github.com/projectbluefin/bluefin/actions/runs/27049528766

Do not merge — close after actions#110 merges and @v1 is advanced.