### PR TITLE
ci: align all reusable-build pins to actions v1 (trivy oci-archive fix)

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -31,7 +31,7 @@ jobs:
     # Thin caller only: shared build orchestration belongs in projectbluefin/actions.
     # Keep repo-local edits here limited to triggers, permissions, and reusable-build inputs.
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'latest'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@1c60f20d89dacc5b35f93f8d63e949316fc7a0ba # v1
     with:
       stream_name: latest
       # FIXME: enable when ublue-os/akmods has ARM builds

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -24,7 +24,7 @@ jobs:
     # Thin caller only: shared build orchestration belongs in projectbluefin/actions.
     # Keep repo-local edits here limited to triggers, permissions, and reusable-build inputs.
     if: github.event_name != 'workflow_dispatch' || github.ref_name == 'stable'
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@c4c25bda265a350b3f17982198eedb5a760ea7fd # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@1c60f20d89dacc5b35f93f8d63e949316fc7a0ba # v1
     with:
       # kernel_pin: 6.17.12-300.fc43.x86_64 ## Pin to 6.17 for ZFS compatibility
       stream_name: stable

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@7e634a74009e630a76ca30877f3d77fab9e1c383 # feat/gate-testing-stream-tag
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@1c60f20d89dacc5b35f93f8d63e949316fc7a0ba # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Bumps all three `reusable-build.yml` callers to `1c60f20` (actions `@v1`), which includes the Trivy OCI archive fix from projectbluefin/actions#110.

| Workflow | Old SHA | New SHA |
|---|---|---|
| `build-image-testing.yml` | `7e634a74` | `1c60f20` |
| `build-image-stable.yml` | `c4c25bda` | `1c60f20` |
| `build-image-latest-main.yml` | `c4c25bda` | `1c60f20` |

Replaces PR #376 (testing→main) which is stuck as CONFLICTING due to squash-merge history mismatch.