### PR TITLE
fix(ci): update COPR health monitor to check uupd instead of ublue-update

### DIFF
--- a/.github/workflows/copr-health-monitor.yml
+++ b/.github/workflows/copr-health-monitor.yml
@@ -71,7 +71,7 @@ jobs:
 
           # COPRs used by build_files/base/03-packages.sh
           check_copr_package "che"      "nerd-fonts" "nerd-fonts"
-          check_copr_package "ublue-os" "packages"   "ublue-update"
+          check_copr_package "ublue-os" "packages"   "uupd"
 
           if [[ ${#FAILURES[@]} -gt 0 ]]; then
             echo "failed=true" >> "$GITHUB_OUTPUT"
@@ -111,6 +111,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `ci: COPR health check failed — ${new Date().toISOString().slice(0,10)}`,
-              body: `## COPR Health Check Failure\n\nThe daily COPR health monitor detected problems:\n\n\`\`\`\n${failures}\n\`\`\`\n\n## Impact\n\nBuild failures are likely if the affected COPR repo is unavailable or packages are stale.\n\n## COPRs checked\n- \`che/nerd-fonts\` — nerd-fonts\n- \`ublue-os/packages\` — ublue-update\n\n_Automated detection by copr-health-monitor.yml_`,
+              body: `## COPR Health Check Failure\n\nThe daily COPR health monitor detected problems:\n\n\`\`\`\n${failures}\n\`\`\`\n\n## Impact\n\nBuild failures are likely if the affected COPR repo is unavailable or packages are stale.\n\n## COPRs checked\n- \`che/nerd-fonts\` — nerd-fonts\n- \`ublue-os/packages\` — uupd\n\n_Automated detection by copr-health-monitor.yml_`,
               labels: ['area/copr', 'kind/bug', 'priority/p1'],
             });


### PR DESCRIPTION
## Summary

The daily COPR health monitor was checking for package `ublue-update` in `ublue-os/packages`, but the package was renamed to `uupd`. The API returns `No package with name ublue-update in copr packages` which caused the monitor to open a new p1 issue every day.

`build_files/base/03-packages.sh` already correctly installs `uupd` — this just syncs the monitor to match.

## Changes
- `.github/workflows/copr-health-monitor.yml`: check `uupd` instead of `ublue-update`
- Update the auto-generated issue body template to reference the correct package name

## Test plan
- [ ] CI passes
- Manually verified: `curl https://copr.fedorainfracloud.org/api_3/package?ownername=ublue-os&projectname=packages&packagename=uupd` returns a valid package response

Closes #375