### PR TITLE
fix(ci): clean up promotion workflows — fix artifact name, stop comment spam, auto-close issues

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -135,11 +135,11 @@ jobs:
             });
             const dup = existing.data.find(i => i.title === title);
             if (dup) {
-              await github.rest.issues.createComment({
+              await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: dup.number,
-                body: `Failure recurred in run ${runUrl} for image \`${image}\``,
+                body: `## E2E Smoke Test Failure\n\n**Image:** \`${image}\`\n**Commit:** ${sha}\n**Run:** ${runUrl}\n**Suites:** smoke,common\n\n_Automatically opened by post-testing-e2e.yml_`,
               });
             } else {
               await github.rest.issues.create({

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -190,6 +190,37 @@ jobs:
             exit 1
           fi
 
+  close-failure-issue:
+    needs: [promote]
+    if: needs.promote.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Close open failure issue if present
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = 'ci: testing→main promotion conflict';
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/ci,kind/bug',
+              state: 'open',
+            });
+            const open = existing.data.find(i => i.title === title);
+            if (open) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.info(`Closed stale failure issue #${open.number}`);
+            }
+
   report-failure:
     needs: [promote]
     if: always() && failure()
@@ -208,6 +239,7 @@ jobs:
             const testingSha = '${{ needs.promote.outputs.testing_sha }}' || 'unknown';
             const prUrl = '${{ needs.promote.outputs.pr_url }}';
             const title = 'ci: testing→main promotion conflict';
+            const body = `## Testing → Main Promotion Conflict\n\n**Run:** ${runUrl}\n**Merge state status:** ${mergeStateStatus}\n**Mergeable:** ${mergeable}\n**Testing SHA:** \`${testingSha}\`${prUrl ? `\n**PR:** ${prUrl}` : ''}\n\n_Automatically opened by promote-testing-to-main.yml_`;
 
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -216,10 +248,8 @@ jobs:
               state: 'open',
             });
             const dup = existing.data.find(i => i.title === title);
-            const body = `## Testing → Main Promotion Conflict\n\n**Run:** ${runUrl}\n**Merge state status:** ${mergeStateStatus}\n**Mergeable:** ${mergeable}\n**Testing SHA:** \`${testingSha}\`${prUrl ? `\n**PR:** ${prUrl}` : ''}\n\n_Automatically opened by promote-testing-to-main.yml_`;
-
             if (dup) {
-              await github.rest.issues.createComment({
+              await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: dup.number,
@@ -231,6 +261,6 @@ jobs:
                 repo: context.repo.repo,
                 title,
                 body,
-                labels: ['area/ci', 'kind/bug'],
+                labels: ['area/ci', 'kind/bug', 'priority/p1'],
               });
             }

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -159,9 +159,9 @@ jobs:
           mkdir -p "$DIGEST_DIR"
           gh run download "${{ steps.find-build.outputs.run_id }}" \
             --repo "${{ github.repository }}" \
-            --name "image-digest-testing-bluefin-main" \
+            --name "image-digest-testing-bluefin-main-x86_64" \
             --dir "$DIGEST_DIR"
-          DIGEST=$(grep "=" "$DIGEST_DIR/main-bluefin.txt" | head -1 | cut -d= -f2-)
+          DIGEST=$(grep "=" "$DIGEST_DIR/main-bluefin-x86_64.txt" | head -1 | cut -d= -f2-)
           echo "image=ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "Promoting: ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}"
 
@@ -350,6 +350,38 @@ jobs:
     with:
       stream_name: '["stable"]'
 
+  close-failure-issue:
+    name: Close stale failure issue on success
+    needs: [promote-to-latest-and-stable]
+    if: needs.promote-to-latest-and-stable.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Close open failure issue if present
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = 'ci: weekly promotion e2e failure';
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/testing,kind/bug',
+              state: 'open',
+            });
+            const open = existing.data.find(i => i.title === title);
+            if (open) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.info(`Closed stale failure issue #${open.number}`);
+            }
+
   report-failure:
     needs: [verify-e2e, e2e, e2e-nvidia-open, promote-to-latest-and-stable]
     if: always() && failure() && needs.verify-e2e.outputs.image != ''
@@ -365,6 +397,7 @@ jobs:
             const image = '${{ needs.verify-e2e.outputs.image }}';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const title = 'ci: weekly promotion e2e failure';
+            const body = `## Weekly Promotion E2E Failure\n\n**Image:** \`${image}\`\n**Run:** ${runUrl}\n**Suites:** developer,vanilla-gnome,software,common\n\n_Automatically opened by weekly-testing-promotion.yml_`;
 
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -374,18 +407,18 @@ jobs:
             });
             const dup = existing.data.find(i => i.title === title);
             if (dup) {
-              await github.rest.issues.createComment({
+              await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: dup.number,
-                body: `Failure recurred in run ${runUrl} for image \`${image}\``,
+                body,
               });
             } else {
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title,
-                body: `## Weekly Promotion E2E Failure\n\n**Image:** \`${image}\`\n**Run:** ${runUrl}\n**Suites:** developer,vanilla-gnome,software,common\n\n_Automatically opened by weekly-testing-promotion.yml_`,
+                body,
                 labels: ['area/testing', 'kind/bug', 'priority/p1'],
               });
             }


### PR DESCRIPTION
## Summary

Fixes every known issue preventing clean promotions. Three workflows touched.

### weekly-testing-promotion.yml

- **Root cause fix:** `get-digest` was downloading `image-digest-testing-bluefin-main` but PR #369 renamed the artifact to `image-digest-testing-bluefin-main-x86_64`. `post-testing-e2e.yml` was updated in #369 but `weekly-testing-promotion.yml` was not. This is why **no weekly promotion has ever succeeded** — the `verify-e2e` job fails immediately trying to download a non-existent artifact.
- `report-failure`: edit issue body instead of adding a new comment on recurrence
- Add `close-failure-issue` job: auto-closes the open failure issue when `promote-to-latest-and-stable` succeeds

### promote-testing-to-main.yml

- `report-failure`: edit issue body instead of adding a new comment on recurrence
- Add `priority/p1` label to newly created failure issues (was missing, hence #368 needed manual labeling)
- Add `close-failure-issue` job: auto-closes `ci: testing→main promotion conflict` (issue #368) when `promote` job succeeds

### post-testing-e2e.yml

- `report-failure`: edit issue body instead of adding a comment on recurrence (per-SHA titles mean dups are rare, but fixes the pattern for consistency)

## Testing

- `just check && pre-commit run --all-files` — all passed

## Related

- Closes #368
- Relates to projectbluefin/common#516 (promotion pipeline consistency epic)