### PR TITLE
feat(ci): add sync-main-to-testing workflow

### DIFF
--- a/.github/workflows/sync-main-to-testing.yml
+++ b/.github/workflows/sync-main-to-testing.yml
@@ -18,6 +18,6 @@ concurrency:
 jobs:
   sync:
     name: Keep testing up-to-date with main
-    uses: projectbluefin/actions/.github/workflows/reusable-sync-branches.yml@5d18cb213a1bea0e81128a857103bf13b1d64431 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-sync-branches.yml@1b6ae6a57f589db7175c3748ff93337ba63457ce # v1
     permissions:
       contents: write

--- a/.github/workflows/sync-main-to-testing.yml
+++ b/.github/workflows/sync-main-to-testing.yml
@@ -1,0 +1,23 @@
+name: Sync main → testing
+
+# After each squash-merge promotion (testing→main), the squash commit lands
+# on main but not in testing, leaving testing BEHIND. This workflow merges
+# main back into testing automatically so the next promotion PR is not blocked.
+#
+# Reusable logic lives in projectbluefin/actions. This is a thin caller.
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: sync-main-to-testing
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Keep testing up-to-date with main
+    uses: projectbluefin/actions/.github/workflows/reusable-sync-branches.yml@5d18cb213a1bea0e81128a857103bf13b1d64431 # v1
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sync-main-to-testing.yml` — a thin caller that fires on every push to `main` and merges main back into testing via the shared `projectbluefin/actions` reusable workflow.

### Why

Every squash-merge of the `testing→main` promotion PR leaves testing BEHIND main by the squash commit. This caused PR #388 to open in a blocked state. Same issue was manually patched in `5a598da0` and will keep recurring without a structural fix.

### Depends on

projectbluefin/actions#117 — the reusable workflow must merge and `@v1` must advance before this PR's SHA pin is valid.

## Test plan

- [ ] After actions#117 merges and `@v1` moves, update SHA pin to new `main` HEAD
- [ ] Merge a test change to `main` and confirm the sync workflow fires and testing is updated