### PR TITLE
docs(ci): document stable branch's local reusable-build.yml exception

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -68,11 +68,13 @@ Renovate tracks SHA pins automatically (`config:best-practices` includes `github
 
 ### Build workflow
 
-The shared image build engine is at `.github/workflows/reusable-build.yml` in `projectbluefin/actions`. The internal copy has been deleted — all three stream callers delegate to the centralised workflow:
+The shared image build engine is at `.github/workflows/reusable-build.yml` in `projectbluefin/actions`. The `testing` and `main` stream callers delegate to it:
 
 ```yaml
 uses: projectbluefin/actions/.github/workflows/reusable-build.yml@<SHA>
 ```
+
+> **⚠️ `stable` branch exception:** The `stable` branch maintains its **own local copy** of `.github/workflows/reusable-build.yml` (a diverged legacy version). `build-image-stable.yml` calls `uses: ./.github/workflows/reusable-build.yml` (self-referential). Fixes landed in `projectbluefin/actions` do NOT automatically apply to `stable`. When CI breaks on `stable`, hotfix directly on the `stable` branch — cherry-picking from `testing` will conflict because `testing` does not have that file.
 
 - Matrix: `bluefin`
 - Flavors: `main`, `nvidia-open`


### PR DESCRIPTION
## Summary

Documents the critical architecture difference for the `stable` branch: it maintains its own local copy of `.github/workflows/reusable-build.yml` (a diverged legacy version) rather than using the shared `projectbluefin/actions` workflow like `testing`/`main`.

This was the root cause of days of broken stable builds — the shared workflow received sigstore permission fixes and other improvements that never propagated to `stable`. Future agents need this warning to avoid debugging in the wrong place.

## Changes

- Corrected the inaccurate "all three stream callers delegate to the centralised workflow" statement
- Added a warning callout explaining the stable exception, its self-referential call pattern, and that direct hotfixes are required

## Test plan

Documentation-only change. No build impact.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot