### PR TITLE
fix(ci): skip SBOM generation for testing stream to unblock builds

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@1c60f20d89dacc5b35f93f8d63e949316fc7a0ba # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@4daec0e04d5209bef2552c1895486af362ae4a82 # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

Testing builds have been failing for 3+ days due to SBOM generation (Syft) timing out runners. The `gen-sbom` step scans the entire container image (10+ minutes). The `sign-and-publish` step that uses the SBOM is already skipped for the testing stream, so this was pure waste.

## Fix

Pins `build-image-testing.yml` to **actions@4daec0e** (projectbluefin/actions#123, merged) which adds `&& inputs.stream_name != 'testing'` guards to all 4 SBOM steps.

No behavior change for stable/latest — SBOMs still generated and signed there.

## Validation

- actions PR: https://github.com/projectbluefin/actions/pull/123 ✅ merged
- Consumer CI run (build with fix): https://github.com/projectbluefin/bluefin/actions/runs/27073709720