### PR TITLE
fix(ci): disable SBOM in sign-and-publish for testing stream

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@4daec0e04d5209bef2552c1895486af362ae4a82 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@d18542169d94ed2df1364e5e19dddffdd248307f # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

PR #393 skipped the outer SBOM steps for testing. However `sign-and-publish` also runs Syft internally with `generate-sbom: true`. This still timed out runners on testing builds.

## Fix

Pins to actions@d185421 (projectbluefin/actions#124) which passes `generate-sbom: false` to `sign-and-publish` for testing stream. Signing still runs — only the Syft scan is disabled.

## Verification

Ready to dispatch once merged.