### PR TITLE
ci: fix cosign cert identity regexp in promotion verify

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -299,7 +299,7 @@ jobs:
             REF="${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
             echo "Verifying signature: ${REF}"
             if ! cosign verify \
-              --certificate-identity-regexp "https://github.com/${{ github.repository }}/.github/workflows/" \
+              --certificate-identity-regexp "https://github.com/${{ github.repository_owner }}/(bluefin|bluefin-lts|aurora|actions)/.github/workflows/" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${REF}" 2>/dev/null; then
               echo "::error::Signature verification FAILED for ${IMAGE_NAME}@${DIGEST}"


### PR DESCRIPTION
## Production-down fix

Stable releases have been blocked for a week due to the wrong cosign `--certificate-identity-regexp`.

**Root cause:** `github.repository` expands to `projectbluefin/bluefin` but images are signed inside the `projectbluefin/actions` reusable workflow. The identity in the cert is:
```
https://github.com/projectbluefin/actions/.github/workflows/reusable-build.yml@...
```

**Fix:** Use `repository_owner + (bluefin|bluefin-lts|aurora|actions)` pattern.

This is a 1-line diff already validated in PR #414 (merged to `testing`). Targeting `main` directly under production-down protocol.

Admin merge: no CI required.