### PR TITLE
ci: use sigstore/cosign-installer in promotion instead of curl

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -271,20 +271,14 @@ jobs:
           echo "Downloaded digest files:"
           find /tmp/all-digests -name "*.txt" | sort
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Verify cosign signatures before promotion
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Install cosign via sigstore installer (already available if run after a build)
-          # Fall back to downloading from GitHub releases if not available
-          if ! command -v cosign &>/dev/null; then
-            COSIGN_VERSION="v2.5.0"
-            curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
-              -o /usr/local/bin/cosign
-            chmod +x /usr/local/bin/cosign
-          fi
-
           REGISTRY="ghcr.io/${{ github.repository_owner }}"
           FAILED=0
 


### PR DESCRIPTION
## Problem

The `promote-to-latest-and-stable` job installed cosign via a raw `curl` call pinned to `v2.5.0`. The build workflow uses `sigstore/cosign-installer@v4.1.2` which installs cosign v3.0.6. The newer cosign bundle format produced by v3.x is not verified correctly by v2.x — causing signature verification to fail on every weekly promotion attempt.

This is the remaining failure mode after PR #417 fixed the `--certificate-identity-regexp`.

## Fix

Replace the `if ! command -v cosign` curl block with a proper:
```yaml
- name: Install cosign
  uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
```

This is the exact same SHA used in:
- `projectbluefin/actions` reusable-build.yml (build signing)
- `projectbluefin/bluefin-lts` scheduled-lts-release.yml (promotion verification)

## Testing

Pre-commit and actionlint pass. Ready to manually dispatch weekly-testing-promotion once the build for `2b3441ad` completes.