### PR TITLE
fix(ci): bump reusable-release SHA pin and add mergeability poll loop

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -190,10 +190,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.upsert.outputs.pr_number }}
-          MERGE_STATE_STATUS: ${{ steps.upsert.outputs.merge_state_status }}
-          MERGEABLE: ${{ steps.upsert.outputs.mergeable }}
         run: |
           set -euo pipefail
+
+          # GitHub may not have finished computing mergeability immediately after PR
+          # creation or update. Poll until both mergeable and mergeStateStatus resolve
+          # out of UNKNOWN before attempting to enqueue (fixes race condition in #419).
+          MERGEABLE="UNKNOWN"
+          MERGE_STATE_STATUS="UNKNOWN"
+          for i in $(seq 1 12); do
+            PR_JSON=$(gh pr view "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --json mergeable,mergeStateStatus)
+            MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
+            MERGE_STATE_STATUS=$(echo "$PR_JSON" | jq -r '.mergeStateStatus')
+            [ "$MERGEABLE" != "UNKNOWN" ] && break
+            echo "Waiting for mergeability check ($i/12) — mergeable=${MERGEABLE}, mergeStateStatus=${MERGE_STATE_STATUS}"
+            sleep 15
+          done
+          echo "Resolved: mergeable=${MERGEABLE}, mergeStateStatus=${MERGE_STATE_STATUS}"
 
           if [ "$MERGEABLE" = "CONFLICTING" ] || [ "$MERGE_STATE_STATUS" = "DIRTY" ]; then
             echo "ERROR: testing → main PR #${PR_NUMBER} is conflicted (mergeable=${MERGEABLE}, mergeStateStatus=${MERGE_STATE_STATUS})"

--- a/.github/workflows/scheduled-stable-release.yml
+++ b/.github/workflows/scheduled-stable-release.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   release:
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@023c4fcb2f7885ab348222e3eabe600f5b76a317
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@3390565c71befe1a6c9300d52f998d5246b9e6de
     with:
       stream_name: stable
       build_workflow: build-image-stable.yml


### PR DESCRIPTION
## Summary

Two CI fixes in one PR (both in `.github/workflows/`):

### 1. Fix scheduled-stable-release — closes #421, closes #386

Bumps the `projectbluefin/actions` SHA pin in `scheduled-stable-release.yml` from `023c4fcb` to `3390565c`.

**Root cause confirmed from run logs (27068223295):** The pinned version hardcoded `--workflow build-images.yml --branch main` in the "Find latest stable build run" step. That workflow was renamed to `build-image-stable.yml` and runs on the `stable` branch post-refactor. The query returned empty, jq returned `null`, which became `NaN` in the artifact download URL.

The current HEAD (`3390565c`) uses `${{ inputs.build_workflow }}` and `${{ inputs.build_branch }}` properly, reading the already-correct inputs `build-image-stable.yml` / `stable` that `scheduled-stable-release.yml` passes.

### 2. Fix promote-testing-to-main enqueue race — closes #419

Replaces the stale `mergeable`/`mergeStateStatus` snapshot (captured immediately after PR upsert) with a live poll loop that refreshes both fields up to 12×15s = 3 min before calling `enqueuePullRequest`.

**Root cause:** GitHub needs a few seconds after PR creation/update to compute mergeability. Firing the mutation at UNKNOWN state caused the error:
```
enqueuePullRequest failed: Pull request mergeability check has not yet completed
```

The poll also removes the stale env vars (`MERGE_STATE_STATUS`, `MERGEABLE`) from the step env block — all state comes from fresh API calls.

## Test plan

- [ ] `scheduled-stable-release.yml` dispatch — confirm "Find latest stable build run" logs show `build-image-stable.yml` on `stable`
- [ ] Next `promote-testing-to-main` run — confirm enqueue succeeds without UNKNOWN error