### PR TITLE
fix(ci): generate SBOM inline with Syft in generate-release

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -64,28 +64,27 @@ jobs:
           fi
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      # The build workflow uploads one SBOM artifact per image variant.
-      # We use the main (non-nvidia) variant as the canonical SBOM for the release.
-      # TODO(#424): testing-stream builds skip SBOM generation, so this artifact
-      # is absent on the weekly-promotion path. continue-on-error prevents a hard
-      # failure; the create-release step is guarded to only run when the SBOM is
-      # present. Remove continue-on-error once #424 is resolved.
-      - name: Download SBOM artifact
-        id: download-sbom
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      # Generate SBOM inline from the promoted :stable image using Syft.
+      # The reusable-build skips SBOM for the testing stream (by design), so
+      # the weekly-promotion path has no artifact to download. Syft runs against
+      # the exact image that was just retagged to :stable, giving us a fresh SBOM
+      # without requiring a rebuild. Uses the same Syft version as reusable-build.yml.
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          name: sbom-bluefin
-          path: sbom-current
+          syft-version: v1.44.0
 
-      - name: Warn if SBOM unavailable
-        if: steps.download-sbom.outcome != 'success'
+      - name: Generate SBOM from promoted image
+        env:
+          STREAM: ${{ matrix.version }}
         run: |
-          echo "::warning::SBOM artifact not found — release will be created without SBOM attachment."
-          echo "::warning::See https://github.com/projectbluefin/bluefin/issues/424 for tracking."
+          set -euo pipefail
+          mkdir -p sbom-current
+          syft "ghcr.io/projectbluefin/bluefin:${STREAM}" \
+            -o spdx-json=sbom-current/bluefin.sbom.json
+          echo "SBOM generated: $(wc -c < sbom-current/bluefin.sbom.json) bytes"
 
       - name: Create release
-        if: steps.download-sbom.outcome == 'success'
         uses: projectbluefin/actions/bootc-build/create-release@622073d27a051f1eed7b874b9b71710141a5e60e
         with:
           sbom-path:            sbom-current/bluefin.sbom.json
@@ -111,31 +110,3 @@ jobs:
             ]
           docs-url:             https://docs.projectbluefin.io/changelogs
           github-token:         ${{ secrets.GITHUB_TOKEN }}
-
-      # Fallback: create a minimal release when SBOM is unavailable (weekly promotion path).
-      # TODO(#424): remove once SBOM generation is enabled for the testing→stable path.
-      - name: Create release (no SBOM)
-        if: steps.download-sbom.outcome != 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.meta.outputs.tag }}
-          TITLE: ${{ steps.meta.outputs.title }}
-          DIGEST: ${{ steps.digest.outputs.digest }}
-        run: |
-          set -euo pipefail
-          cat > /tmp/release-notes.md <<'NOTES'
-          ## Release
-
-          Image digest and verification instructions below.
-
-          > SBOM not attached on this release — see #424 for tracking.
-          > Full release card will be restored once SBOM generation is re-enabled for the promotion path.
-          NOTES
-          # Append digest line (can't use variable expansion inside heredoc single-quotes)
-          echo "" >> /tmp/release-notes.md
-          echo "**Image:** \`ghcr.io/projectbluefin/bluefin@${DIGEST}\`" >> /tmp/release-notes.md
-          sed -i "s|## Release|## ${TITLE}|" /tmp/release-notes.md
-          gh release create "${TAG}" \
-            --repo "${{ github.repository }}" \
-            --title "${TITLE}" \
-            --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

Closes #424

Replaces the `continue-on-error` workaround from #425 with proper inline SBOM generation using Syft.

### Problem

`generate-release.yml` downloaded the `sbom-bluefin` artifact uploaded during the build. This works for `scheduled-stable-release.yml` (which calls `reusable-release.yml` to find the `build-image-stable.yml` run). But the **weekly promotion path** (`weekly-testing-promotion.yml` → `generate-release.yml`) retags testing→stable without rebuilding, and the testing-stream build skips SBOM generation by design — so there is no artifact to download.

### Fix

Install Syft (v1.44.0 — matching `projectbluefin/actions` reusable-build.yml) and run it directly against the promoted `:stable` image. This gives us a correct SBOM of exactly the image that was promoted, without requiring a rebuild.

Removes:
- `actions/download-artifact` step with `continue-on-error: true`
- "Warn if SBOM unavailable" step  
- "Create release (no SBOM)" fallback step (45 lines of workaround)

Adds:
- `anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610` (Syft v1.44.0)
- Inline `syft ghcr.io/projectbluefin/bluefin:stable -o spdx-json=...` step
- "Create release" is now unconditional (no `if:` guard)

## Test plan

- [ ] Dispatch `generate-release.yml` manually — confirm Syft runs and `create-release` produces a release with SBOM attached
- [ ] Next Tuesday promotion — confirm full release card (not the minimal fallback) is created