### PR TITLE
fix(ci): bump reusable-release SHA — drop reserved github_token secret

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -35,7 +35,7 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-stable]
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@fcd2a6bac15f2037df2e62572eef7a70fd25759f # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@599328cbb21d05094f6851b6da32c85f3a5363de # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -348,7 +348,7 @@ jobs:
     name: Generate release notes
     needs: [promote-to-latest-and-stable]
     if: needs.promote-to-latest-and-stable.result == 'success'
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@fcd2a6bac15f2037df2e62572eef7a70fd25759f # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@599328cbb21d05094f6851b6da32c85f3a5363de # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin


### PR DESCRIPTION
Bump `reusable-release.yml` pin to `599328cbb21d05094f6851b6da32c85f3a5363de` (v1).

## Problem
GitHub now rejects `github_token` as a `workflow_call` secret name (collides with system-reserved `GITHUB_TOKEN`). This caused `weekly-testing-promotion.yml` and `build-image-stable.yml` to fail at dispatch.

## Fix
Fixed upstream in [projectbluefin/actions#128](https://github.com/projectbluefin/actions/pull/128). This PR bumps the SHA pin in both callers.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI