### PR TITLE
fix(ci): bump reusable-release to beb89cf — add empty secrets block

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -35,7 +35,7 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-stable]
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@599328cbb21d05094f6851b6da32c85f3a5363de # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@beb89cf1f8d2fa8b8be76e5ed5e3132457415212 # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -348,7 +348,7 @@ jobs:
     name: Generate release notes
     needs: [promote-to-latest-and-stable]
     if: needs.promote-to-latest-and-stable.result == 'success'
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@599328cbb21d05094f6851b6da32c85f3a5363de # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@beb89cf1f8d2fa8b8be76e5ed5e3132457415212 # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin


### PR DESCRIPTION
Follow-up to #442. Bumps `reusable-release.yml` pin to `beb89cf1f8d2fa8b8be76e5ed5e3132457415212` (v1).

Fixed in [projectbluefin/actions#129](https://github.com/projectbluefin/actions/pull/129): GitHub requires a `secrets: {}` block in the callee when any caller uses `secrets: inherit`, or the calling workflow fails at startup.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI