### PR TITLE
fix(ci): bump reusable-release to d290241 — remove secrets: inherit

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -35,7 +35,7 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-stable]
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@beb89cf1f8d2fa8b8be76e5ed5e3132457415212 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@d290241b8b7a6721be8855d1d94cdb8209652080 # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin
@@ -55,4 +55,3 @@ jobs:
           {"sbom_name": "bootc",            "label": "bootc"}
         ]
       docs_url: https://docs.projectbluefin.io/changelogs
-    secrets: inherit

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -348,7 +348,7 @@ jobs:
     name: Generate release notes
     needs: [promote-to-latest-and-stable]
     if: needs.promote-to-latest-and-stable.result == 'success'
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@beb89cf1f8d2fa8b8be76e5ed5e3132457415212 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@d290241b8b7a6721be8855d1d94cdb8209652080 # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin
@@ -368,7 +368,6 @@ jobs:
           {"sbom_name": "bootc",            "label": "bootc"}
         ]
       docs_url: https://docs.projectbluefin.io/changelogs
-    secrets: inherit
 
   close-failure-issue:
     name: Close stale failure issue on success


### PR DESCRIPTION
Final fix for the `github_token` reserved name + startup_failure chain.

## Changes
- Bump `reusable-release.yml` pin to `d290241b8b7a6721be8855d1d94cdb8209652080` (v1) in `weekly-testing-promotion.yml` and `build-image-stable.yml`
- Remove `secrets: inherit` from the `generate-release` job in both callers — `reusable-release.yml` now uses `github.token` directly so no secrets need to be passed

## Fix chain (projectbluefin/actions)
- [#128](https://github.com/projectbluefin/actions/pull/128): Replace `secrets.github_token` with `github.token`
- [#129](https://github.com/projectbluefin/actions/pull/129): Add empty `secrets: {}` (later found insufficient)
- [#130](https://github.com/projectbluefin/actions/pull/130): Remove secrets block entirely — cleanest solution

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI