### PR TITLE
ci: consumer validation for actions#133 (chunka v0.6.0 upgrade)

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -53,7 +53,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@d18542169d94ed2df1364e5e19dddffdd248307f # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@df2977779e6f1b385098704de9f492053fd57681 # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Consumer validation PR

Pins `reusable-build.yml` to [projectbluefin/actions#133](https://github.com/projectbluefin/actions/pull/133) branch SHA `df2977779e6f1b385098704de9f492053fd57681` to validate:

- chunkah v0.5.0 → v0.6.0 upgrade (output format change: `oci-archive:out.ociarchive` → `oci:out`)
- `force-compression` input wired correctly
- Renovate custom manager + vendor-chunka-files.yml automation

**Do not merge.** Close when actions#133 lands on main and @v1 is updated.

---
This is a test-only PR opened as consumer validation evidence per [consumer-validation.md](https://github.com/projectbluefin/actions/blob/main/docs/skills/consumer-validation.md).