### PR TITLE
fix(renovate): enable automerge + add image-versions.yml manager for common

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,20 @@
         '# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+\\w+: "(?<currentValue>[^"]+)"',
       ],
     },
+    {
+      // Discover container image digests from the images: block in image-versions.yml.
+      // Matches each  image: / tag: / digest:  entry so Renovate tracks all pinned
+      // digests directly from the YAML source of truth rather than Containerfile ARGs.
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^image-versions\\.yml$/',
+      ],
+      matchStrings: [
+        'image: (?<packageName>[^\\s]+)\\n\\s+tag: (?<currentValue>[^\\s]+)\\n\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)',
+      ],
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'docker',
+    },
     // Track GNOME extension submodules that pin to a release tag via the
     // `branch =` field in .gitmodules. Renovate's git-submodules manager
     // alone can't see new tags because tags don't move; this rewrites the
@@ -72,9 +86,12 @@
       "automerge": false
     },
     {
+      // common is a first-party trusted image; automerge digest updates immediately.
+      // No schedule — critical fixes must land without the default weekly delay.
       "matchUpdateTypes": ["pin", "digest", "pinDigest"],
       "matchDepNames": ["ghcr.io/projectbluefin/common"],
-      "automerge": false
+      "automerge": true,
+      "schedule": ["at any time"]
     },
     {
       "automerge": true,

--- a/docs/skills/renovate.md
+++ b/docs/skills/renovate.md
@@ -81,6 +81,35 @@ If auto-merge does not trigger:
 - Unversioned `renovate` in the validator command is intentional: it validates against the current schema
 - Passing a filename to `renovate-config-validator` can change how the file is interpreted; prefer repo auto-discovery unless you intentionally need another mode
 
+### common image tracking — critical
+
+`ghcr.io/projectbluefin/common` delivers first-party boot-critical fixes (e.g. `rechunker-group-fix` — reconstructs `/etc/gshadow`; missing it = black screens). These **must land without delay**.
+
+**Required `renovate.json5` configuration:**
+
+```json5
+// 1. Custom manager — discovers image: / tag: / digest: entries in image-versions.yml
+{
+  customType: 'regex',
+  managerFilePatterns: ['/^image-versions\\.yml$/'],
+  matchStrings: [
+    'image: (?<packageName>[^\\s]+)\\n\\s+tag: (?<currentValue>[^\\s]+)\\n\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)',
+  ],
+  datasourceTemplate: 'docker',
+  versioningTemplate: 'docker',
+},
+
+// 2. packageRule — automerge immediately, bypass default weekly schedule
+{
+  "matchUpdateTypes": ["pin", "digest", "pinDigest"],
+  "matchDepNames": ["ghcr.io/projectbluefin/common"],
+  "automerge": true,
+  "schedule": ["at any time"]
+},
+```
+
+**Never use `"automerge": false` or a weekly schedule for common.** The `config:best-practices` default schedule (branch creation only on Mondays) delayed a critical fix by 2 days (PR #457, 2026-06-08). See also bluefin-lts PR #123 where `"enabled": false` meant the same fix was silently dropped entirely.
+
 ## Shared actions version management
 
 When `projectbluefin/actions` is live, Renovate will track action versions automatically via the `github-actions` manager. The contract:


### PR DESCRIPTION
## Problem

The `rechunker-group-fix` (common#530) was a critical fix that broke people's computers if missed — yet it wasn't landing automatically. Two issues:

1. **`automerge: false` for common** — all Renovate PRs for common required manual merge. A maintainer had to notice and merge PR #457 manually on 2026-06-08.

2. **Weekly schedule from `config:best-practices`** — common PRs were only created on Mondays. A fix merged to common on Thursday wouldn't even get a PR until the following Monday.

The same issue also affected `projectbluefin/bluefin-lts` where Renovate had common **completely disabled** (separate PR #123 in that repo).

## Changes

### `automerge: true` + `schedule: at any time` for common

First-party trusted image — immutable digest pins — must land without delay. CI validates on the `testing` branch before merge.

### New regex custom manager for `image-versions.yml`

Adds an explicit `image: / tag: / digest:` block matcher so Renovate tracks container image digests directly from the YAML source of truth (belt-and-suspenders alongside Dockerfile ARG discovery).

### Skill docs updated

`docs/skills/renovate.md` documents the required Renovate config pattern for common and the hard rule: never use `automerge: false` or a weekly schedule for first-party trusted images.

## After this merges

When common next publishes a new image, Renovate will:
1. Open a PR within ~1 hour
2. CI builds and validates on `testing`
3. Auto-merges — no manual intervention needed