### PR TITLE
fix: port several fixes from ublue-os/bluefin

### DIFF
--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -62,7 +62,7 @@ FEDORA_PACKAGES=(
     alsa-tools-firmware
     autofs
     bash-color-prompt
-    bcache-tools
+
     bootc
     borgbackup
     containerd
@@ -161,6 +161,7 @@ FEDORA_PACKAGES=(
     waypipe
     wireguard-tools
     wl-clipboard
+    wtype
     xdg-terminal-exec
     xprop
     yubikey-manager
@@ -242,5 +243,11 @@ remove_excluded_packages EXCLUDED_PACKAGES
 #    Workaround pkcs11-provider regression, see issue #1943
 #    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
 #fi
+
+# Create a standard symlink for the NVIDIA Vulkan ICD so AppImages and legacy games
+# that hardcode "nvidia_icd.json" can find the GPU. On non-NVIDIA systems this is a
+# dangling symlink, which the Vulkan loader safely ignores.
+mkdir -p /usr/share/vulkan/icd.d/
+ln -sf /usr/share/vulkan/icd.d/nvidia_icd.x86_64.json /usr/share/vulkan/icd.d/nvidia_icd.json
 
 echo "::endgroup::"

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/12-gnupg.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/12-gnupg.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+# Configure gpg-agent to find scdaemon, which moved to /usr/libexec in Fedora 43+
+if [[ -f /usr/libexec/scdaemon ]]; then
+    mkdir -p "${HOME}/.gnupg"
+    chmod 700 "${HOME}/.gnupg"
+    if ! grep -q "scdaemon-program" "${HOME}/.gnupg/gpg-agent.conf" 2>/dev/null; then
+        echo "scdaemon-program /usr/libexec/scdaemon" >> "${HOME}/.gnupg/gpg-agent.conf"
+    fi
+fi


### PR DESCRIPTION
Port four fixes from open PRs in ublue-os/bluefin.

Two upstream PRs were already applied here (wallpaper rewrite removal, bazaar CollectionID); this PR handles the remaining four.

## Changes

**Remove bcache-tools** (ref ublue-os/bluefin#4688)

The sole user who needed bcache support has removed their hardware. No other known users remain. Removes the package to reduce image size.

**Add wtype to FEDORA_PACKAGES** (ref ublue-os/bluefin#4176)

Required by the goose CLI. Without it goose prints: Warning: Failed to initialize Linux automation: Required dependency 'wtype' not found. ublue-os places this in their dx edition; this repo has no dx split so it goes into the base package list.

**Add nvidia_icd.json compatibility symlink** (ref ublue-os/bluefin#4752)

The NVIDIA Vulkan ICD from RPM Fusion ships as nvidia_icd.x86_64.json. Many AppImages and legacy game engines hardcode the filename nvidia_icd.json and fail to detect the discrete GPU when it is absent. The symlink is a dangling link on AMD/Intel systems; the Vulkan loader ignores dead symlinks safely.

**Add 12-gnupg.sh user-setup hook** (ref ublue-os/bluefin#4740)

scdaemon moved to /usr/libexec in Fedora 43+. Without this hook, users with smart cards find gpg-agent cannot locate scdaemon. The hook writes scdaemon-program /usr/libexec/scdaemon into ~/.gnupg/gpg-agent.conf on first login if the entry is not already present.