### PR TITLE
feat(fonts): remove font RPMs and nerd-fonts COPR from OCI image

### DIFF
--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -98,7 +98,6 @@ FEDORA_PACKAGES=(
     input-remapper
     intel-vaapi-driver
     iwd
-    jetbrains-mono-fonts-all
     just
     krb5-workstation
     libappindicator-gtk3
@@ -123,7 +122,6 @@ FEDORA_PACKAGES=(
     net-tools
     nvtop
     oddjob-mkhomedir
-    opendyslexic-fonts
     openrgb-udev-rules
     openssh-askpass
     pam-u2f
@@ -200,9 +198,6 @@ dnf5 -y install \
     "${FEDORA_PACKAGES[@]}" \
     tailscale \
     ffmpeg{,-libs} libavcodec @multimedia gstreamer1-plugins-{bad-free,bad-free-libs,good,base} lame{,-libs} libfdk-aac libjxl ffmpegthumbnailer
-
-# From che/nerd-fonts
-copr_install_isolated "che/nerd-fonts" "nerd-fonts"
 
 # From ublue-os/packages
 copr_install_isolated "ublue-os/packages" \


### PR DESCRIPTION
## Summary

Remove font packages from the OCI image in favour of Homebrew management.

## Changes

- Remove `jetbrains-mono-fonts-all` — covered by `font-jetbrains-mono-nerd-font` cask in common's `fonts.Brewfile`
- Remove `opendyslexic-fonts` — moved to `font-opendyslexic` Homebrew cask in common's `fonts.Brewfile`
- Remove `nerd-fonts` COPR (`che/nerd-fonts`) — all desired nerd font variants are explicitly listed in the Homebrew `fonts.Brewfile`; baking the full COPR package into the image is redundant and bloats the layer

## Fonts kept in the image

- `adwaita-fonts-all` — system UI default fonts (Adwaita Sans + Adwaita Mono)
- `google-noto-sans-cjk-fonts` + Balinese/Javanese/Sundanese variants — i18n script coverage

## Companion PR

projectbluefin/common#547 — sets `monospace-font-name="Adwaita Mono 11"` and adds `font-opendyslexic` to Homebrew fonts.Brewfile