### PR TITLE
chore: consumer validation — actions#138 restore Trivy scan

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@bd1d83a3eb3a55d63f71069cd9234d6a8d93f4b5 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@ecec4e27bd2ef035aca2ee047ab83bf63e5e6568 # fix/restore-trivy-scan
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — Consumer Validation Only

This draft PR pins `reusable-build.yml` to the `fix/restore-trivy-scan` branch SHA in [projectbluefin/actions#138](https://github.com/projectbluefin/actions/pull/138) to exercise the re-enabled Trivy CVE + secret scan in CI.

**Actions PR:** https://github.com/projectbluefin/actions/pull/138

## What this tests

- `Export image for scanning` step: `sudo podman save --format docker-archive` with `localhost/IMAGE:TAG` reference
- `Scan image for vulnerabilities` via `scan-image` composite action with `input:` parameter
- SARIF upload to GitHub Security tab
- PR scan in report-only mode (exit-code 0)

## Pass criteria

CI workflow passes. SARIF output visible in Security tab.

---
*Consumer validation PR — close after actions#138 merges.*