### PR TITLE
docs: install-hooks step, remote trap warning, 2-human gate, skill-drift CI docs, iso.md fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Bluefin bugs are data donations.
 Non-compliance = rejection.
 
 - Read [`docs/SKILL.md`](docs/SKILL.md) before modifying anything.
+- **After cloning, run `bash .github/scripts/install-hooks.sh` once** to install the pre-push hook that blocks accidental pushes to `origin` (ublue-os/bluefin).
 - Run `just check && pre-commit run --all-files` before every commit.
 - **Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
 - Use Conventional Commits for every commit and PR title.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,14 @@ Install the tools used by the local validation flow before opening a PR:
 
 `just check` validates Justfile syntax and related script checks. `pre-commit run --all-files` runs the repository linting and formatting hooks.
 
+## After cloning
+
+```bash
+bash .github/scripts/install-hooks.sh   # Install pre-push hook (run once after cloning)
+```
+
+> **⚠️ Git remote trap:** In this repo, `origin` points to `ublue-os/bluefin` — the archived upstream where direct pushes are forbidden. The pre-push hook installed above blocks accidental pushes to `origin`. Always push via: `git push projectbluefin <branch>`. Verify with `git remote -v` before any push.
+
 ## Branch and stream workflow
 
 ### I want to submit a fix or feature — what do I do?
@@ -40,6 +48,8 @@ Every Tuesday at 06:00 UTC the `weekly-testing-promotion` workflow:
 2. Runs the full developer + vanilla-gnome e2e suite
 3. Fast-forwards `latest` and `stable` branches to `testing`
 4. Triggers the `stable` and `latest` image builds
+
+> **Security gate:** Promotion to `:stable` requires **2 distinct human approvals** in the GitHub `production` Environment before any retag happens. No agent or automated system can bypass this gate — every admin bypass is permanently logged in Environment deployment history.
 
 Changes land in `testing` → promoted to `stable`/`latest` weekly on CI green.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,10 +10,11 @@ Bluefin's CI is split between PR validation, image builds, post-build e2e, weekl
 | `promote-testing-to-main.yml` | Push to `testing`, daily 23:00 UTC, manual dispatch | Upserts the long-lived `testing` → `main` promotion PR and enables squash auto-merge |
 | `sync-main-to-testing.yml` | Push to `main` | Merges `main` back into `testing` after each squash-merge promotion to prevent the next PR from opening `BEHIND` |
 | `build-image-testing.yml` | Push to `main`, `merge_group`, dispatch, workflow call | Builds testing images via centralized `projectbluefin/actions` workflow |
-| `post-testing-e2e.yml` | Successful `Testing Images` workflow on `main` push | Downloads the testing digest and runs smoke tests in `projectbluefin/testsuite` |
+| `post-testing-e2e.yml` | Successful `Testing Images` workflow on `main` push | Downloads the testing digest and runs smoke+lifecycle suites; `run-upgrade-test` job from `projectbluefin/actions` is a hard gate — all three jobs must pass before promotion can proceed |
 | `weekly-testing-promotion.yml` | Tuesday 06:00 UTC, manual dispatch | Verifies e2e on current `main`, retaggs tested digests to `:stable`, generates release |
 | `renovate-automerge.yml` | Successful `PR Validation — testsuite` | Enables squash auto-merge (`gh pr merge --auto --squash`) for Renovate/mergeraptor PRs |
 | `bonedigger.yml` | Issue events, issue comments, daily schedule | Runs the Bluefin 🦖 issue lifecycle bot |
+| `skill-drift.yml` | PRs to `main` | Checks whether code paths (`build_files/`, `Justfile`, `recipes/`, `.github/workflows/`) have drifted from skill docs (`docs/skills/`, `AGENTS.md`). Fails if docs are out of sync. **Fix:** update `docs/skills/` to reflect your code change |
 
 ## Centralized actions (`projectbluefin/actions`)
 
@@ -384,4 +385,5 @@ GitHub provides 10 GB per repo. With 4 flavor+image combinations each ~2-3 GB, t
 | `cherry-pick-to-stable.yml` | PR closed with `cherry-pick` label | Backports to `stable` via GitHub App token |
 | `bonedigger.yml` | Issue events, daily | Issue lifecycle bot |
 | `moderator.yml` | Issues/comments opened | AI spam + AI-content detection |
+| `skill-drift.yml` | PRs to `main` | Skill/code sync check; fails if `build_files/`, `Justfile`, or workflow files changed without updating `docs/skills/`. Fix by updating `docs/skills/` to match your code changes |
 | `validate-renovate.yml` | Renovate config PRs | Validates renovate.json5 syntax |

--- a/docs/skills/iso.md
+++ b/docs/skills/iso.md
@@ -2,7 +2,7 @@
 
 ## When to use
 
-- Working with `projectbluefin/bluefin-iso`
+- Working with `projectbluefin/dakota-iso`
 - Building or promoting installation ISOs
 - Troubleshooting ISO promotion or prerelease behavior
 
@@ -14,7 +14,7 @@
 
 ## First rule
 
-**ISO building and promotion happens in the separate `projectbluefin/bluefin-iso` repo/workflows.**
+**ISO building and promotion happens in the separate `projectbluefin/dakota-iso` repo/workflows.**
 
 ## Safety rules
 
@@ -35,12 +35,12 @@ container image built in image repo
 
 Build a stable ISO workflow manually:
 ```bash
-gh workflow run build-iso-stable.yml --repo projectbluefin/bluefin-iso
+gh workflow run build-iso-stable.yml --repo projectbluefin/dakota-iso
 ```
 
 Promote a safe variant:
 ```bash
-gh workflow run promote-iso.yml --repo projectbluefin/bluefin-iso -f variant=stable
+gh workflow run promote-iso.yml --repo projectbluefin/dakota-iso -f variant=stable
 ```
 
 If applicable, generate or inspect release notes from the image repo first:


### PR DESCRIPTION
Addresses hive advisory findings from [projectbluefin/common#557](https://github.com/projectbluefin/common/issues/557).

### CONTRIBUTING.md
- Added "After cloning" section with `bash .github/scripts/install-hooks.sh` — the pre-push hook blocking `origin` pushes wasn't installed by default; first-time contributors hit this trap
- Added git remote trap warning prominently (previously only in AGENTS.md and docs/build.md)
- Added 2-human-approval gate documentation in the stream promotion section — contributors had no visibility into the security gate that governs `:stable` promotion

### AGENTS.md
- Added `install-hooks.sh` step to mandatory gates — hook is useless if it's never installed

### docs/ci.md
- Updated `post-testing-e2e.yml` entry: now documents the `run-upgrade-test` gate from `projectbluefin/actions` that was added in PR #275; previously only mentioned smoke suite
- Added `skill-drift.yml` row to both workflow tables — this PR-blocking check was completely absent from docs, causing contributor confusion on unexpected CI failures

### docs/skills/iso.md
- Fixed all 4 references: `projectbluefin/bluefin-iso` → `projectbluefin/dakota-iso` (the repo doesn't exist; agents running these commands get 404s)