### PR TITLE
fix(ci): promotion gate never stalls — e2e fires on testing builds + feedback trigger

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -7,7 +7,7 @@ on:
   workflow_run:
     workflows: ["Testing Images"]
     types: [completed]
-    branches: [main]
+    branches: [main, testing]
 
 permissions: read-all
 
@@ -73,7 +73,8 @@ jobs:
     # run-upgrade-test removed from needs — lifecycle suite is non-blocking (see TODO above).
     needs: [e2e, run-e2e]
     if: >-
-      needs.run-e2e.result == 'success'
+      needs.run-e2e.result == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Post-Testing E2E"]
+    types: [completed]
+    branches: [testing]
 
 concurrency:
   group: promote-testing-to-main


### PR DESCRIPTION
## Summary

Two changes that together ensure the `promote-testing-to-main` gate self-clears without human intervention:

### 1. `post-testing-e2e.yml` — fire on testing branch builds too

The promotion gate looks up e2e evidence by `testing_sha` (tip of the testing branch). But `post-testing-e2e.yml` only triggered when `Testing Images` ran on `main`. Any divergence between testing and main meant the gate could never find evidence — permanently blocked.

```diff
-    branches: [main]
+    branches: [main, testing]
```

The `promote-to-testing` job is guarded to `head_branch == 'main'` so it doesn't double-promote on testing builds.

### 2. `promote-testing-to-main.yml` — feedback trigger

Without this, the gate only re-ran on the next push to testing or midnight cron. A successful e2e at 3am would sit unnoticed until the next Renovate merge.

```diff
+  workflow_run:
+    workflows: ["Post-Testing E2E"]
+    types: [completed]
+    branches: [testing]
```

## Test plan
- After merge, next push to `testing` (Renovate or manual) should:
  1. Trigger `Testing Images` on `testing`
  2. `post-testing-e2e` fires on the testing SHA
  3. On completion, `promote-testing-to-main` fires automatically
  4. Gate finds e2e run for that SHA → `release/ready` → enqueues

## Related
- projectbluefin/actions#149 (gate selector fix)
- projectbluefin/bluefin-lts companion PR