### PR TITLE
fix(ci): land E2E gate fixes on main — workflow_run uses default branch

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -7,7 +7,7 @@ on:
   workflow_run:
     workflows: ["Testing Images"]
     types: [completed]
-    branches: [main]
+    branches: [main, testing]
 
 permissions: read-all
 
@@ -73,7 +73,8 @@ jobs:
     # run-upgrade-test removed from needs — lifecycle suite is non-blocking (see TODO above).
     needs: [e2e, run-e2e]
     if: >-
-      needs.run-e2e.result == 'success'
+      needs.run-e2e.result == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Post-Testing E2E"]
+    types: [completed]
+    branches: [testing]
 
 concurrency:
   group: promote-testing-to-main


### PR DESCRIPTION
## Why this targets main directly

`workflow_run` triggers in GitHub Actions always evaluate the workflow file from the **repository's default branch** (main). Merging these changes via `testing` first creates a circular dependency:
- Gate needs E2E evidence to promote testing → main
- E2E won't fire on testing builds until this fix is on main

So this PR bypasses the normal testing→main flow for these two CI-infrastructure files only. No image content is changed.

## Changes

Identical to the changes in #480 (which targets testing), but targeting main so the triggers activate immediately.

### `post-testing-e2e.yml`
```diff
-    branches: [main]
+    branches: [main, testing]
```
`promote-to-testing` job guarded to `head_branch == 'main'` to avoid double-promote.

### `promote-testing-to-main.yml`
```diff
+  workflow_run:
+    workflows: ["Post-Testing E2E"]
+    types: [completed]
+    branches: [testing]
```

## After merge
1. Next push to testing → Testing Images builds → post-testing-e2e fires (now fires on testing SHA)
2. E2E passes → promote-testing-to-main fires automatically via workflow_run
3. Gate finds E2E evidence → release/ready → merge queue enqueues → stable ships

## Test plan
- Verify `post-testing-e2e` fires for next testing branch build
- Verify `promote-testing-to-main` fires after E2E completes
- Verify PR #469 gate clears to `release/ready`