### PR TITLE
ci(consistency): pin @main reusable-workflow refs to SHA

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
       packages: write
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       registry: ghcr.io/projectbluefin
       variants: >-
@@ -38,7 +38,7 @@ jobs:
       contents: write
       id-token: write
       packages: read
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin

--- a/.github/workflows/pr-release-gate.yml
+++ b/.github/workflows/pr-release-gate.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       packages: read
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       repo: ${{ github.repository }}
       registry: ghcr.io/projectbluefin

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -252,7 +252,7 @@ jobs:
       issues: write
       packages: read
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       repo: ${{ github.repository }}
       pr_number: ${{ needs.promote.outputs.pr_number }}

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-reminder.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-reminder.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       days_warn: 7
       days_escalate: 14


### PR DESCRIPTION
Tracks #585 / consolidation item C2 from `docs/factory/automation-audit/consistency-audit.md` (in `projectbluefin/common`).

Sister PR to projectbluefin/bluefin-lts#159 \u2014 same change, same SHA, same rationale, lands in lockstep so the two image repos stay in sync.

## What

Replace 5 `@main` references (4 unique reusable workflows) with the current `projectbluefin/actions` HEAD SHA `7f79969c2ff74c51ac7f385cb0a86414975308d7` (2026-06-10T21:56:23Z).

| File | Workflow |
|---|---|
| `execute-release.yml:23` | `reusable-execute-release` |
| `execute-release.yml:41` | `reusable-release` |
| `pr-release-gate.yml:19` | `reusable-release-gate` |
| `promote-testing-to-main.yml:255` | `reusable-release-gate` |
| `release-reminder.yml:16` | `reusable-release-reminder` |

## Why

Behavior changes in `projectbluefin/actions/main` currently propagate silently into bluefin on the next workflow run. After this change Renovate will open an explicit PR whenever those reusable workflows update.

The pre-commit `no-floating-tags` hook intentionally exempts `projectbluefin/*` refs (negative lookahead), so this pin is for audit hygiene and Renovate visibility \u2014 not gate compliance.

## Verification

- [x] Pre-commit ran clean on changed files
- [ ] CI green on this PR

Closes #585.