### PR TITLE
fix(security): remove dead SCORECARD_TOKEN PAT comment

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,9 +46,6 @@ jobs:
           # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
           # - you want to enable the Branch-Protection check on a *public* repository, or
           # - you are installing Scorecard on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers
           #   - Allows the repository to include the Scorecard badge.


### PR DESCRIPTION
## Summary

Removes the commented-out `SCORECARD_TOKEN` PAT reference from `scorecard.yml`.

The `repo_token` line was already disabled and the instructions above it suggest creating a PAT — which is unnecessary for public repos and contrary to the factory PAT-ban policy.

**No functional change** — the workflow has always used the default `github.token`.

Assisted-by: Claude Sonnet 4.5 via pi