### PR TITLE
ci: consumer validation draft — actions#162 (check-token-health in reusable-renovate)

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -41,7 +41,7 @@ jobs:
       should_build: ${{ steps.detect.outputs.should_build }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: projectbluefin/actions/bootc-build/detect-changes@3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e # v1
+      - uses: projectbluefin/actions/bootc-build/detect-changes@b4bc89e1c2226af837b2083ba4eea27a095345af # v1
         id: detect
 
   build-image-testing:
@@ -54,7 +54,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@b4bc89e1c2226af837b2083ba4eea27a095345af # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Consumer validation draft PR

This is a **draft consumer validation PR** for [projectbluefin/actions#162](https://github.com/projectbluefin/actions/pull/162).

Actions PR adds `check-token-health` as the first step in `reusable-renovate.yml` to detect expired/revoked tokens before running Renovate.

**What this PR does:** Pins `reusable-build.yml` and `detect-changes` to the actions branch SHA `b4bc89e1c2226af837b2083ba4eea27a095345af` to exercise the actions repo at that commit and verify it does not break the bluefin consumer.

Close and discard once actions#162 is merged and `@v1` is advanced.

Assisted-by: claude-sonnet-4.6 via pi