### PR TITLE
ci: consumer validate for actions#166 — DO NOT MERGE

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@d18542169d94ed2df1364e5e19dddffdd248307f # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@e5c3b429e75702a06d21e3b53bebce8f1408ce3e # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Consumer validation PR for actions#166

Tests: projectbluefin/actions#166 (P0 factory reliability fix)

This PR pins `reusable-build.yml` and `sign-and-publish` to the actions#166 branch SHA to validate:
1. Non-blocking scan (exit-code: '0') — builds continue when CVEs detected
2. cert identity regexp includes `dakota|common` — dakota can verify its own images

**This PR is NOT intended to merge.** It exists to provide consumer CI evidence for actions#166.

Once CI is green here, the run URL will be linked to actions#166 to satisfy the consumer validation gate.

DO NOT MERGE — close after actions#166 is merged.