### PR TITLE
ci: validate reusable-promote-squash retry branch

### DIFF
--- a/.github/workflows/pr-release-gate.yml
+++ b/.github/workflows/pr-release-gate.yml
@@ -4,21 +4,24 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions: {}
 
 jobs:
   gate:
-    if: github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
     permissions:
       actions: read
       contents: read
       issues: write
       packages: read
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@feat/retry-e2e-promote # validation branch
     with:
       repo: ${{ github.repository }}
+      pr_number: ${{ github.event_name == 'workflow_dispatch' && '492' || github.event.pull_request.number }}
+      head_sha: ${{ github.event_name == 'workflow_dispatch' && '7baa828d81d6ccdac3c85d83d0eec1ab1d5c3cef' || github.event.pull_request.head.sha }}
       registry: ghcr.io/projectbluefin
       variants: >-
         [{"image":"bluefin"},{"image":"bluefin-nvidia"}]

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -18,12 +18,20 @@ concurrency:
   group: promote-testing-to-main
   cancel-in-progress: false
 
+# The called reusable workflow needs write access to push the squash branch,
+# open/update PRs, and write issues. Caller-level permissions set the maximum
+# grants available to the called workflow's jobs — too-narrow a grant here
+# causes startup_failure before any job runs.
 permissions:
-  contents: read
+  contents: write       # push squash promotion branch
+  pull-requests: write  # create / update / auto-merge the promotion PR
+  issues: write         # open / close failure-tracking issues
+  packages: read        # read image digests in release-gate checks
+  actions: read         # inspect workflow-run statuses in release-gate
 
 jobs:
   promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@72ee991c06c58b865c2419db0af8748eef70199b # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@feat/retry-e2e-promote # validation branch
     with:
       variants: >-
         [{"image":"bluefin"},{"image":"bluefin-nvidia"}]


### PR DESCRIPTION
Validate projectbluefin/actions feat/retry-e2e-promote by pinning promote-testing-to-main to that branch and dispatching the promotion workflow.