### PR TITLE
ci: validate scan-image reusable-build update

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@be94040994bdd8415fa10ecf3c0f039d93a6d639 # castrojo/actions-scan-image-validation
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What does this change?

Pin Bluefin testing builds to the actions branch that makes Trivy scan-image report-only and auto-files deduplicated critical CVE issues.

## Consumer validation

Consumer PR: https://github.com/projectbluefin/bluefin/pull/493
Consumer CI run: https://github.com/projectbluefin/bluefin/actions/runs/27352153793
Out-of-org consumer impact: N/A

- [x] Opened a draft consumer PR pinned to this branch SHA
- [ ] Linked a passing consumer CI run that exercised this change
- [x] Evaluated out-of-org consumers (ublue-os/aurora, ublue-os/bazzite) and documented the impact above

## Checklist

- [x] I am using an agent and I take responsibility for this PR (if AI-assisted)
- [x] Conventional commit message (feat:, fix:, chore:, etc.)
- [x] No hardcoded secrets or credentials
