### PR TITLE
fix(ci): validate promote gate recovery

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@72ee991c06c58b865c2419db0af8748eef70199b # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@cb9520fd62098d194b31ec672fbbfbea0586e876 # fix/promote-retry-recovery
     with:
       variants: >-
         [{"image":"bluefin"},{"image":"bluefin-nvidia"}]


### PR DESCRIPTION
## What does this change?

Consumer validation for projectbluefin/actions fix/promote-retry-recovery. Pins promote-testing-to-main to the actions branch SHA so the bluefin promotion workflow exercises stale-e2e recovery and promotion-blocked issue handling.

## Checklist

- [x] I am using an agent and I take responsibility for this PR (if AI-assisted)
- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
