### PR TITLE
fix(factory): pin @main floating refs to SHA and adopt thin-caller promote

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   execute:
-    if: >-
+    if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
     permissions:
@@ -20,7 +20,7 @@ jobs:
       issues: write
       packages: write
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
     with:
       registry: ghcr.io/projectbluefin
       variants: >-
@@ -38,7 +38,7 @@ jobs:
       contents: write
       id-token: write
       packages: read
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin

--- a/.github/workflows/pr-release-gate.yml
+++ b/.github/workflows/pr-release-gate.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       packages: read
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
     with:
       repo: ${{ github.repository }}
       registry: ghcr.io/projectbluefin

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -1,5 +1,11 @@
 name: Promote testing to main
 
+# Thin caller — logic lives in projectbluefin/actions/reusable-promote-squash.yml
+# Replaces the previous 343-line promote-testing-to-main.yml.
+#
+# Key improvement: squash branch is always rebuilt fresh on every run —
+# no staleness, no conflict drift, no merge friction.
+
 on:
   push:
     branches:
@@ -12,332 +18,25 @@ concurrency:
   group: promote-testing-to-main
   cancel-in-progress: false
 
+# The called reusable workflow needs write access to push the squash branch,
+# open/update PRs, and write issues. Caller-level permissions set the maximum
+# grants available to the called workflow's jobs.
 permissions:
-  contents: read
+  contents: write       # push squash promotion branch
+  pull-requests: write  # create / update / auto-merge the promotion PR
+  issues: write         # open / close failure-tracking issues
+  packages: read        # read image digests in release-gate checks
+  actions: read         # inspect workflow-run statuses in release-gate
 
 jobs:
   promote:
-    name: Open or update testing → main PR
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      sync_needed: ${{ steps.compare.outputs.sync_needed }}
-      testing_sha: ${{ steps.compare.outputs.testing_sha }}
-      pr_number: ${{ steps.upsert.outputs.pr_number }}
-      pr_url: ${{ steps.upsert.outputs.pr_url || steps.existing-pr.outputs.pr_url }}
-      merge_state_status: ${{ steps.upsert.outputs.merge_state_status }}
-      mergeable: ${{ steps.upsert.outputs.mergeable }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 0
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Fetch branch refs
-        run: git fetch origin main testing
-
-      - name: Compare testing and main trees
-        id: compare
-        run: |
-          set -euo pipefail
-
-          MAIN_SHA=$(git rev-parse origin/main)
-          TESTING_SHA=$(git rev-parse origin/testing)
-          MAIN_TREE=$(git rev-parse 'origin/main^{tree}')
-          TESTING_TREE=$(git rev-parse 'origin/testing^{tree}')
-
-          if [ "$MAIN_TREE" = "$TESTING_TREE" ]; then
-            SYNC_NEEDED=false
-            echo "main and testing have identical trees — no promotion PR update needed"
-          else
-            SYNC_NEEDED=true
-            echo "testing differs from main — promotion PR should exist"
-          fi
-
-          {
-            echo "main_sha=${MAIN_SHA}"
-            echo "testing_sha=${TESTING_SHA}"
-            echo "main_tree=${MAIN_TREE}"
-            echo "testing_tree=${TESTING_TREE}"
-            echo "sync_needed=${SYNC_NEEDED}"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create or update squash promotion branch
-        id: squash-branch
-        if: steps.compare.outputs.sync_needed == 'true'
-        env:
-          PROMOTION_BRANCH: auto/promote-testing-to-main
-        run: |
-          set -euo pipefail
-
-          # Rebuild when testing's tree changed OR main has advanced past the squash branch's parent.
-          CURRENT_TREE=$(git rev-parse "origin/${PROMOTION_BRANCH}^{tree}" 2>/dev/null || echo "none")
-          CURRENT_PARENT=$(git rev-parse "origin/${PROMOTION_BRANCH}^1" 2>/dev/null || echo "none")
-          TESTING_TREE="${{ steps.compare.outputs.testing_tree }}"
-          MAIN_SHA="${{ steps.compare.outputs.main_sha }}"
-
-          if [ "$CURRENT_TREE" = "$TESTING_TREE" ] && [ "$CURRENT_PARENT" = "$MAIN_SHA" ]; then
-            echo "Squash branch is up to date — skipping update"
-          else
-            echo "Updating squash promotion branch…"
-            git checkout -B "$PROMOTION_BRANCH" origin/main
-            git merge --squash origin/testing
-            git commit -m "chore: promote testing to main"
-            git push --force origin "$PROMOTION_BRANCH"
-            echo "✅ Squash branch updated: 1 commit, exact testing tree"
-          fi
-
-          echo "branch=${PROMOTION_BRANCH}" >> "$GITHUB_OUTPUT"
-
-      - name: Find existing promotion PR
-        id: existing-pr
-        if: steps.compare.outputs.sync_needed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PROMOTION_BRANCH: ${{ steps.squash-branch.outputs.branch }}
-        run: |
-          set -euo pipefail
-
-          PR_NUMBER=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --base main \
-            --head "$PROMOTION_BRANCH" \
-            --state open \
-            --json number,url \
-            --jq '.[0].number // empty')
-
-          if [ -n "$PR_NUMBER" ]; then
-            PR_URL=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json url --jq '.url')
-            echo "Found existing PR #${PR_NUMBER}: ${PR_URL}"
-          else
-            PR_URL=""
-            echo "No open promotion PR found"
-          fi
-
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
-
-      - name: Upsert promotion PR
-        id: upsert
-        if: steps.compare.outputs.sync_needed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EXISTING_PR_NUMBER: ${{ steps.existing-pr.outputs.pr_number }}
-          PROMOTION_BRANCH: ${{ steps.squash-branch.outputs.branch }}
-          MAIN_SHA: ${{ steps.compare.outputs.main_sha }}
-          MAIN_TREE: ${{ steps.compare.outputs.main_tree }}
-          TESTING_SHA: ${{ steps.compare.outputs.testing_sha }}
-          TESTING_TREE: ${{ steps.compare.outputs.testing_tree }}
-          TRIGGER_NAME: ${{ github.event_name }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          TITLE="chore: promote testing to main"
-          PR_BODY=$(cat <<EOF
-          ## Automated testing → main promotion
-
-          This PR is managed by .github/workflows/promote-testing-to-main.yml.
-
-          - Trigger: ${TRIGGER_NAME}
-          - Testing SHA: ${TESTING_SHA}
-          - Main SHA: ${MAIN_SHA}
-          - Testing tree: ${TESTING_TREE}
-          - Main tree: ${MAIN_TREE}
-          - Workflow run: ${RUN_URL}
-
-          The workflow squashes all pending testing commits into one so this PR
-          always shows a clean single-commit diff, regardless of squash-merge history.
-          EOF
-          )
-
-          if [ -n "$EXISTING_PR_NUMBER" ]; then
-            gh pr edit "$EXISTING_PR_NUMBER" \
-              --repo "${{ github.repository }}" \
-              --title "$TITLE" \
-              --body "$PR_BODY"
-            PR_NUMBER="$EXISTING_PR_NUMBER"
-          else
-            PR_URL=$(gh pr create \
-              --repo "${{ github.repository }}" \
-              --base main \
-              --head "$PROMOTION_BRANCH" \
-              --title "$TITLE" \
-              --body "$PR_BODY")
-            PR_NUMBER="${PR_URL##*/}"
-          fi
-
-          PR_JSON=$(gh pr view "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --json url,mergeStateStatus,mergeable)
-
-          {
-            echo "pr_number=${PR_NUMBER}"
-            echo "pr_url=$(jq -r '.url' <<<"$PR_JSON")"
-            echo "merge_state_status=$(jq -r '.mergeStateStatus' <<<"$PR_JSON")"
-            echo "mergeable=$(jq -r '.mergeable' <<<"$PR_JSON")"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Enqueue in merge queue
-        if: steps.compare.outputs.sync_needed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.upsert.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-
-          # GitHub may not have finished computing mergeability immediately after PR
-          # creation or update. Poll until both mergeable and mergeStateStatus resolve
-          # out of UNKNOWN before attempting to enqueue (fixes race condition in #419).
-          MERGEABLE="UNKNOWN"
-          MERGE_STATE_STATUS="UNKNOWN"
-          for i in $(seq 1 12); do
-            PR_JSON=$(gh pr view "$PR_NUMBER" \
-              --repo "${{ github.repository }}" \
-              --json mergeable,mergeStateStatus)
-            MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
-            MERGE_STATE_STATUS=$(echo "$PR_JSON" | jq -r '.mergeStateStatus')
-            [ "$MERGEABLE" != "UNKNOWN" ] && break
-            echo "Waiting for mergeability check ($i/12) — mergeable=${MERGEABLE}, mergeStateStatus=${MERGE_STATE_STATUS}"
-            sleep 15
-          done
-          echo "Resolved: mergeable=${MERGEABLE}, mergeStateStatus=${MERGE_STATE_STATUS}"
-
-          if [ "$MERGEABLE" = "CONFLICTING" ] || [ "$MERGE_STATE_STATUS" = "DIRTY" ]; then
-            echo "ERROR: testing → main PR #${PR_NUMBER} is conflicted (mergeable=${MERGEABLE}, mergeStateStatus=${MERGE_STATE_STATUS})"
-            exit 1
-          fi
-
-          # main uses a merge queue (ruleset 17070404) — auto-merge is not supported.
-          # Enqueue via GraphQL enqueuePullRequest mutation.
-          NODE_ID=$(gh pr view "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --json id --jq .id)
-
-          RESULT=$(gh api graphql -f query="mutation {
-            enqueuePullRequest(input: { pullRequestId: \"${NODE_ID}\" }) {
-              mergeQueueEntry { id position }
-            }
-          }" 2>&1) && RC=0 || RC=$?
-
-          if [ "$RC" -eq 0 ]; then
-            POSITION=$(echo "$RESULT" | jq -r '.data.enqueuePullRequest.mergeQueueEntry.position // "unknown"')
-            echo "✅ PR #${PR_NUMBER} enqueued in merge queue at position ${POSITION}"
-          elif echo "$RESULT" | grep -q "Required status check"; then
-            echo "⏳ PR #${PR_NUMBER} cannot be enqueued yet — required checks have not passed (mergeStateStatus=${MERGE_STATE_STATUS}). A maintainer can approve and enqueue once CI passes."
-          elif echo "$RESULT" | grep -q "already in the merge queue"; then
-            echo "PR #${PR_NUMBER} is already in the merge queue"
-          elif echo "$RESULT" | grep -qi "forbidden\|not accessible by integration"; then
-            echo "⚠️ PR #${PR_NUMBER} is open and ready. GITHUB_TOKEN cannot enqueue — a maintainer must approve then run: gh pr merge ${PR_NUMBER} --squash --admin"
-          else
-            echo "ERROR: enqueuePullRequest failed: ${RESULT}"
-            exit 1
-          fi
-
-  gate:
-    name: Release gate checks
-    needs: [promote]
-    if: needs.promote.outputs.sync_needed == 'true'
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-      packages: read
-      pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
     with:
-      repo: ${{ github.repository }}
-      pr_number: ${{ needs.promote.outputs.pr_number }}
-      head_sha: ${{ needs.promote.outputs.testing_sha }}
-      registry: ghcr.io/projectbluefin
       variants: >-
         [{"image":"bluefin"},{"image":"bluefin-nvidia"}]
-      cosign_identity_regexp: ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
-      target_tag: testing
+      cosign_identity_regexp: >-
+        ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
       run_e2e: true
       e2e_suites: smoke,common
       e2e_image: ghcr.io/projectbluefin/bluefin:testing
     secrets: inherit
-
-  close-failure-issue:
-    needs: [promote]
-    if: needs.promote.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      issues: write
-    steps:
-      - name: Close open failure issue if present
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const title = 'ci: testing→main promotion conflict';
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'area/ci,kind/bug',
-              state: 'open',
-            });
-            const open = existing.data.find(i => i.title === title);
-            if (open) {
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: open.number,
-                state: 'closed',
-                state_reason: 'completed',
-              });
-              core.info(`Closed stale failure issue #${open.number}`);
-            }
-
-  report-failure:
-    needs: [promote]
-    if: always() && failure()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      issues: write
-    steps:
-      - name: Open or update failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const mergeStateStatus = '${{ needs.promote.outputs.merge_state_status }}' || 'unknown';
-            const mergeable = '${{ needs.promote.outputs.mergeable }}' || 'unknown';
-            const testingSha = '${{ needs.promote.outputs.testing_sha }}' || 'unknown';
-            const prUrl = '${{ needs.promote.outputs.pr_url }}';
-            const title = 'ci: testing→main promotion conflict';
-            const body = `## Testing → Main Promotion Conflict\n\n**Run:** ${runUrl}\n**Merge state status:** ${mergeStateStatus}\n**Mergeable:** ${mergeable}\n**Testing SHA:** \`${testingSha}\`${prUrl ? `\n**PR:** ${prUrl}` : ''}\n\n_Automatically opened by promote-testing-to-main.yml_`;
-
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'area/ci,kind/bug',
-              state: 'open',
-            });
-            const dup = existing.data.find(i => i.title === title);
-            if (dup) {
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: dup.number,
-                body,
-              });
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels: ['area/ci', 'kind/bug', 'priority/p1'],
-              });
-            }

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-reminder.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-reminder.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
     with:
       days_warn: 7
       days_escalate: 14


### PR DESCRIPTION
## Summary

Factory convergence: eliminate all `@main` floating refs and adopt the thin-caller promote pattern already used by `bluefin-lts`.

### SHA pins — closes projectbluefin/common#600, #601

Pin 4 `@main` floating refs to current v1 SHA (`5f3cabacecd1a7b95b7f64b03aa4c298ff73f918`):

| File | Workflow | Before |
|------|----------|--------|
| `execute-release.yml` | `reusable-execute-release.yml` | `@main` |
| `execute-release.yml` | `reusable-release.yml` | `@main` |
| `pr-release-gate.yml` | `reusable-release-gate.yml` | `@main` |
| `release-reminder.yml` | `reusable-release-reminder.yml` | `@main` |

### Thin-caller promote — closes projectbluefin/common#599

Replace the 343-line fat `promote-testing-to-main.yml` with a thin caller delegating to `projectbluefin/actions/reusable-promote-squash.yml`, matching what `bluefin-lts` already adopted. Removes ~310 LoC of inline logic.

**Preserves**: variants `[bluefin, bluefin-nvidia]`, `run_e2e: true`, `e2e_suites: smoke,common`, cosign identity regexp.

## Verification

- [ ] CI passes on this PR
- `promote-testing-to-main.yml` triggers: push→testing, schedule, workflow_dispatch (unchanged)
- No change to release logic — all moved to reusable workflow