### PR TITLE
fix(ci): expand promote-testing-to-main permissions for reusable workflow

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -18,8 +18,16 @@ concurrency:
   group: promote-testing-to-main
   cancel-in-progress: false
 
+# The called reusable workflow needs write access to push the squash branch,
+# open/update PRs, and write issues. Caller-level permissions set the maximum
+# grants available to the called workflow's jobs — too-narrow a grant here
+# causes startup_failure before any job runs.
 permissions:
-  contents: read
+  contents: write       # push squash promotion branch
+  pull-requests: write  # create / update / auto-merge the promotion PR
+  issues: write         # open / close failure-tracking issues
+  packages: read        # read image digests in release-gate checks
+  actions: read         # inspect workflow-run statuses in release-gate
 
 jobs:
   promote:


### PR DESCRIPTION
## Problem

Promotion workflow has been producing `startup_failure` on every push to `testing` since PR #486 replaced the 343-line workflow with the thin caller.

Root cause: caller-level permissions cap what a cross-repo reusable workflow can receive. The thin caller only had `permissions: contents: read`. Before any job starts, GitHub evaluates whether the caller grants sufficient permissions — too-narrow a grant causes `startup_failure`.

The three failed runs:
- https://github.com/projectbluefin/bluefin/actions/runs/27358266529
- https://github.com/projectbluefin/bluefin/actions/runs/27352960689
- https://github.com/projectbluefin/bluefin/actions/runs/27352900071

## Fix

Expand caller permissions to match what `reusable-promote-squash.yml` and `reusable-release-gate.yml` require. Mirrors the already-correct `projectbluefin/bluefin-lts` version.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI