### PR TITLE
fix(ci): remove stale che/nerd-fonts COPR check

### DIFF
--- a/.github/workflows/copr-health-monitor.yml
+++ b/.github/workflows/copr-health-monitor.yml
@@ -70,7 +70,6 @@ jobs:
           }
 
           # COPRs used by build_files/base/03-packages.sh
-          check_copr_package "che"      "nerd-fonts" "nerd-fonts"
           check_copr_package "ublue-os" "packages"   "uupd"
 
           if [[ ${#FAILURES[@]} -gt 0 ]]; then
@@ -111,6 +110,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `ci: COPR health check failed — ${new Date().toISOString().slice(0,10)}`,
-              body: `## COPR Health Check Failure\n\nThe daily COPR health monitor detected problems:\n\n\`\`\`\n${failures}\n\`\`\`\n\n## Impact\n\nBuild failures are likely if the affected COPR repo is unavailable or packages are stale.\n\n## COPRs checked\n- \`che/nerd-fonts\` — nerd-fonts\n- \`ublue-os/packages\` — uupd\n\n_Automated detection by copr-health-monitor.yml_`,
+              body: `## COPR Health Check Failure\n\nThe daily COPR health monitor detected problems:\n\n\`\`\`\n${failures}\n\`\`\`\n\n## Impact\n\nBuild failures are likely if the affected COPR repo is unavailable or packages are stale.\n\n## COPRs checked\n- \`ublue-os/packages\` — uupd\n\n_Automated detection by copr-health-monitor.yml_`,
               labels: ['area/copr', 'kind/bug', 'priority/p1'],
             });


### PR DESCRIPTION
## Summary

Removes the stale `che/nerd-fonts` check from the daily COPR health monitor.

nerd-fonts was removed from the OCI image build in e5eb90b4
(`feat(fonts): remove font RPMs and nerd-fonts COPR from OCI image`).
The monitor was still checking `che/nerd-fonts`, firing a false-positive
staleness alert every day.

## Changes

- Delete `check_copr_package "che" "nerd-fonts" "nerd-fonts"` call
- Update the issue body template to only mention `ublue-os/packages`
- Only `ublue-os/packages` (uupd) remains — the only COPR we still use

## Validation

`actionlint .github/workflows/copr-health-monitor.yml` → clean

Closes #478
Assisted-by: Claude Sonnet 4.5 via pi