### PR TITLE
fix(test): run all BATS unit tests in just test-unit

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,1 +1,1 @@
-pre-commit==4.2.0
+pre-commit==4.6.0

--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,7 @@ test-unit:
         exit 1
     fi
     echo "Running unit tests..."
-    bats tests/unit/package-lib_test.bats
+    bats tests/unit/
 
 # Fix Just Syntax
 [group('Just')]


### PR DESCRIPTION
## Summary

`just test-unit` was hardcoded to run only `package-lib_test.bats`, silently skipping the other 8 test files (~82 tests total).

## Changes
- `Justfile`: `bats tests/unit/package-lib_test.bats` → `bats tests/unit/`
- `.github/requirements-ci.txt`: `pre-commit==4.2.0` → `pre-commit==4.6.0` (matches what validate-pr actually installs)

## Testing
- `just test-unit` now runs all 9 test files
- `just check && pre-commit run --all-files` passes