### PR TITLE
fix(ci): enable shellcheck coverage for system_files scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v0.9.0.6
     hooks:
       - id: shellcheck
-        files: (build_files|system_files)/.*\.sh$
+        files: ^(build_files|system_files)/.*\.sh$
   - repo: local
     hooks:
       - id: no-floating-action-tags

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6
+    hooks:
+      - id: shellcheck
+        files: (build_files|system_files)/.*\.sh$
   - repo: local
     hooks:
       - id: no-floating-action-tags

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: actionlint
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.6
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         files: ^(build_files|system_files)/.*\.sh$

--- a/system_files/shared/etc/profile.d/91-bluefin-aliases.sh
+++ b/system_files/shared/etc/profile.d/91-bluefin-aliases.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Bluefin convenience aliases
 # ramalama shorthand - https://github.com/containers/ramalama
 if command -v ramalama &>/dev/null; then

--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/10-tailscale.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/10-tailscale.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script tailscale privileged 1 || exit 0

--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/99-flatpaks.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/99-flatpaks.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script flatpaks privileged 1 || exit 0

--- a/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
+++ b/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script framework system 2 || exit 0

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script theming user 1 || exit 0

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-framework.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-framework.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
 version-script framework tool 1 || exit 0


### PR DESCRIPTION
## Summary

Shell scripts in `system_files/shared/` had zero shellcheck coverage: no pre-commit hook and no CI check covered them. This PR adds full shellcheck integration at shellcheck 0.11.0.

## Changes

**`.pre-commit-config.yaml`**
- Add shellcheck-py `v0.11.0.1` hook covering `^(build_files|system_files)/.*\.sh$` (anchored regex)

**6 `system_files/shared/` scripts — shellcheck annotations**
- `system_files/shared/etc/profile.d/91-bluefin-aliases.sh`: add `# shellcheck shell=bash` (no shebang — profile.d convention)
- 5 hook scripts (`10-tailscale.sh`, `99-flatpaks.sh`, `10-framework.sh`, `10-theming.sh`, `20-framework.sh`): add `# shellcheck source=/dev/null` before `source /usr/lib/ublue/setup-services/libsetup.sh` calls (runtime path not present at lint time)

## Testing
- `shellcheck system_files/shared/**/*.sh` exits 0 under shellcheck 0.11.0
- `pre-commit run --all-files` passes (11 hooks)
- No real shellcheck bugs found in the scripts — all errors were SC1091 (unresolvable source) and SC2148 (missing shebang/directive)

## Renovate
After merge, Renovate will auto-track `shellcheck-py` via the pre-commit manager (`config:best-practices` enables it). No additional config needed.