### PR TITLE
docs: link copr-security.md from SKILL.md router

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -14,7 +14,7 @@ Agent entry point. Load only the skill that matches the task in front of you.
 | Fix a stuck, conflicted, or wrong-base PR | [`workflow.md` → Fixing stuck PRs](workflow.md#fixing-stuck-prs) |
 | Handle Renovate PRs or auto-merge behavior | `docs/skills/renovate.md` |
 | Review COPR usage, cosign, or other security-sensitive changes | `docs/skills/security.md` |
-| Review or change COPR isolation logic or the enable/disable/install sequence | [`docs/skills/copr-security.md`](docs/skills/copr-security.md) |
+| Review or change COPR isolation logic or the enable/disable/install sequence | `docs/skills/copr-security.md` |
 | Work on the LTS image or LTS-specific policy | `docs/skills/lts.md` |
 | Build or promote installation ISOs | `docs/skills/iso.md` |
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -14,6 +14,7 @@ Agent entry point. Load only the skill that matches the task in front of you.
 | Fix a stuck, conflicted, or wrong-base PR | [`workflow.md` → Fixing stuck PRs](workflow.md#fixing-stuck-prs) |
 | Handle Renovate PRs or auto-merge behavior | `docs/skills/renovate.md` |
 | Review COPR usage, cosign, or other security-sensitive changes | `docs/skills/security.md` |
+| Review or change COPR isolation logic or the enable/disable/install sequence | [`docs/skills/copr-security.md`](docs/skills/copr-security.md) |
 | Work on the LTS image or LTS-specific policy | `docs/skills/lts.md` |
 | Build or promote installation ISOs | `docs/skills/iso.md` |
 

--- a/docs/skills/security.md
+++ b/docs/skills/security.md
@@ -43,6 +43,10 @@ bash -n build_files/base/03-packages.sh
 shellcheck build_files/**/*.sh
 ```
 
+> **Invariant detail:** the enable → disable → install three-step sequence is a
+> security boundary, not cleanup. See [`copr-security.md`](copr-security.md) for
+> the full reasoning and safe/unsafe patterns.
+
 ## Cosign verification
 
 Bluefin verifies upstream containers before building.


### PR DESCRIPTION
## Summary

`copr-security.md` documents the COPR isolation invariant but was orphaned — not reachable from the skill router or any cross-reference.

## Changes
- `docs/SKILL.md`: add routing row for COPR isolation work
- `docs/skills/security.md`: add callout cross-linking to `copr-security.md`

## Testing
- `just check && pre-commit run --all-files` passes