### PR TITLE
docs: quality follow-up — fix missing entries and stale notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,4 @@ Tests live in `tests/unit/`. Run with `bats tests/unit/` (or a single file). The
   | `disable-repos_test.bats` | `build_files/shared/disable-repos.sh` |
   | `package-lib_test.bats` | `build_files/shared/package-lib.sh` |
   | `validate-repos_test.bats` | `build_files/shared/validate-repos.sh` |
+  | `00-image-info_test.bats` | `build_files/base/00-image-info.sh` |

--- a/docs/skills/copr-security.md
+++ b/docs/skills/copr-security.md
@@ -1,5 +1,7 @@
 # COPR isolation security invariant
 
+> See also: [`docs/skills/security.md`](security.md) for general COPR usage, cosign, and shellcheck coverage.
+
 ## Rule
 
 Keep the `copr_install_isolated` helper as a three-step sequence:

--- a/docs/skills/security.md
+++ b/docs/skills/security.md
@@ -41,11 +41,14 @@ Validation:
 ```bash
 bash -n build_files/base/03-packages.sh
 shellcheck build_files/**/*.sh
+shellcheck system_files/**/*.sh
 ```
 
 > **Invariant detail:** the enable → disable → install three-step sequence is a
 > security boundary, not cleanup. See [`copr-security.md`](copr-security.md) for
 > the full reasoning and safe/unsafe patterns.
+
+> This runs automatically on commit via the pre-commit shellcheck hook (covers `build_files/` and `system_files/`).
 
 ## Cosign verification
 


### PR DESCRIPTION
## Summary

Four small follow-up items from the quality improvements review:

- `AGENTS.md`: add `00-image-info_test.bats` to the tested scripts inventory table
- `docs/skills/copr-security.md`: add back-link to `security.md`
- `docs/skills/security.md`: note shellcheck runs automatically via pre-commit hook (covers both `build_files/` and `system_files/`)