### PR TITLE
fix(ci): replace artifact-metadata with issues:write in Testing Images

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -61,7 +61,7 @@ jobs:
       id-token: write
       attestations: write
       security-events: write
-      artifact-metadata: write
+      issues: write
     with:
       image_flavors: >-
         ${{


### PR DESCRIPTION
## Problem

`Testing Images` workflow on the `testing` branch has been failing with `startup_failure` and **"This run likely failed because of a workflow file issue"** since approximately 17:17Z 2026-06-11.

**Root cause:** The `build-image-testing` job grants `artifact-metadata: write` which is **not a valid GitHub Actions permission scope**. GitHub rejects the workflow during validation before any job starts, producing `startup_failure`.

Additionally, `reusable-build@v1` (`355f162b`) requires `issues: write` in the calling job to file CVE issues from Trivy scans. The caller must grant it explicitly or GitHub rejects the reusable workflow call.

## Fix

In the `build-image-testing` job permissions block:
- **Remove** `artifact-metadata: write` (invalid scope → startup_failure)
- **Add** `issues: write` (required by reusable-build@v1)

## Affected builds

- `Testing Images` on `testing` branch: all `startup_failure` since ~17:17Z today
- Last successful `Testing Images` on `testing` branch: 2026-06-10T21:26:46Z (~25h stale)

## Verification

Merging this to `testing` will trigger a new `Testing Images` run which should no longer startup_fail.
