### PR TITLE
test: add unit tests for 03-packages.sh and 05-override-install.sh

### DIFF
--- a/tests/unit/03-packages_test.bats
+++ b/tests/unit/03-packages_test.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/base/03-packages.sh.
+#
+# Tests Fedora-version-specific package conditionals, COPR install calls,
+# and excluded-package removal logic.
+#
+# Run with: bats tests/unit/03-packages_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+PACKAGES_SCRIPT="${SCRIPT_DIR}/../../build_files/base/03-packages.sh"
+COPR_HELPERS="${SCRIPT_DIR}/../../build_files/shared/copr-helpers.sh"
+PACKAGE_LIB="${SCRIPT_DIR}/../../build_files/shared/package-lib.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/03-packages.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    DNF5_LOG="${TEST_ROOT}/dnf5.log"
+
+    mkdir -p "${STUB_BIN}"
+    mkdir -p "${TEST_ROOT}/usr/share/vulkan/icd.d"
+
+    export PATH="${STUB_BIN}:${PATH}"
+    export DNF5_LOG
+    export FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-42}"
+
+    # ── dnf5 stub: log every invocation ──────────────────────────────────
+    cat > "${STUB_BIN}/dnf5" <<'EOF'
+#!/usr/bin/bash
+echo "dnf5 $*" >> "${DNF5_LOG}"
+# Simulate: dnf5 repolist prints nothing (triggers fedora-multimedia add path)
+if [[ "$1" == "repolist" ]]; then
+    exit 0
+fi
+# Simulate: rpm -qa for remove_excluded_packages (nothing installed)
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/dnf5"
+
+    # ── rpm stub: returns fedora version and handles -qa ─────────────────
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+if [[ "$1" == "-E" && "$2" == "%fedora" ]]; then
+    echo "${FEDORA_MAJOR_VERSION}"
+fi
+# rpm -qa: return empty (no packages installed from EXCLUDED list)
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    # ── Patch the script ──────────────────────────────────────────────────
+    PATCHED_SCRIPT="${TEST_ROOT}/03-packages-patched.sh"
+    sed \
+        -e "s|source /ctx/build_files/shared/copr-helpers.sh|source ${COPR_HELPERS}|g" \
+        -e "s|source /ctx/build_files/shared/package-lib.sh|source ${PACKAGE_LIB}|g" \
+        -e "s|/usr/share/vulkan|${TEST_ROOT}/usr/share/vulkan|g" \
+        "${PACKAGES_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+
+    export PATCHED_SCRIPT TEST_ROOT STUB_BIN DNF5_LOG
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fedora-version-specific package additions
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "f42: evolution-ews-core is included in package install" {
+    export FEDORA_MAJOR_VERSION=42
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "evolution-ews-core" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "f42: uld is included in package install" {
+    export FEDORA_MAJOR_VERSION=42
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "uld" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "f43: evolution-ews-core is included in package install" {
+    export FEDORA_MAJOR_VERSION=43
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "evolution-ews-core" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "f43: gnupg2-scdaemon is included in package install" {
+    export FEDORA_MAJOR_VERSION=43
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "gnupg2-scdaemon" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "f44: gnupg2-scdaemon is included in package install" {
+    export FEDORA_MAJOR_VERSION=44
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "gnupg2-scdaemon" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "f43: uld is NOT included (f42-only package)" {
+    export FEDORA_MAJOR_VERSION=43
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    # uld is an f42-only package; it must not appear for f43
+    run grep -q "^dnf5.*install.* uld " "${DNF5_LOG}"
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fedora 42 OpenCL swap (only on f42)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "f42: OpenCL-ICD-Loader swap is invoked" {
+    export FEDORA_MAJOR_VERSION=42
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "OpenCL-ICD-Loader" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "f43: OpenCL-ICD-Loader swap is NOT invoked" {
+    export FEDORA_MAJOR_VERSION=43
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "OpenCL-ICD-Loader" "${DNF5_LOG}"
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COPR install is invoked for ublue-os/packages
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "copr_install_isolated is called for ublue-os/packages" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    # copr_install_isolated calls dnf5 copr enable + dnf5 install
+    run grep -q "ublue-os/packages" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Base packages: spot-check a few that must always be installed
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "distrobox is in the package install list" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "distrobox" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "tailscale is in the package install list" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "tailscale" "${DNF5_LOG}"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/05-override-install_test.bats
+++ b/tests/unit/05-override-install_test.bats
@@ -1,0 +1,227 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/base/05-override-install.sh.
+#
+# Tests security-critical sha256 integrity verification, sudoers modification,
+# firewalld configuration changes, and version extraction from image-versions.yml.
+#
+# Run with: bats tests/unit/05-override-install_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+OVERRIDE_SCRIPT="${SCRIPT_DIR}/../../build_files/base/05-override-install.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/05-override-install.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+
+    mkdir -p "${STUB_BIN}"
+    mkdir -p "${TEST_ROOT}/etc/firewalld"
+    mkdir -p "${TEST_ROOT}/usr/bin"
+    mkdir -p "${TEST_ROOT}/usr/lib/firewalld/zones"
+    mkdir -p "${TEST_ROOT}/usr/lib/systemd/system-generators"
+    mkdir -p "${TEST_ROOT}/usr/share/doc"
+    mkdir -p "${TEST_ROOT}/usr/share/fonts"
+    mkdir -p "${TEST_ROOT}/usr/src"
+    mkdir -p "${TEST_ROOT}/tmp"
+    mkdir -p "${TEST_ROOT}/ctx"
+    mkdir -p "${TEST_ROOT}/fixtures/tmp-content"
+
+    export PATH="${STUB_BIN}:${PATH}"
+
+    # ── System stubs ──────────────────────────────────────────────────────
+    for cmd in setfattr gdk-pixbuf-query-loaders-64 rpm; do
+        printf '#!/usr/bin/bash\nexit 0\n' > "${STUB_BIN}/${cmd}"
+        chmod +x "${STUB_BIN}/${cmd}"
+    done
+
+    # ── Fixtures ──────────────────────────────────────────────────────────
+    # sudoers with a typical secure_path
+    cat > "${TEST_ROOT}/etc/sudoers" <<'EOF'
+Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+EOF
+
+    # firewalld.conf with values that will be overwritten
+    cat > "${TEST_ROOT}/etc/firewalld/firewalld.conf" <<'EOF'
+DefaultZone=public
+IPv6_rpfilter=yes
+EOF
+
+    # FedoraWorkstation.xml with the content the script verifies via grep
+    cat > "${TEST_ROOT}/usr/lib/firewalld/zones/FedoraWorkstation.xml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<zone>
+  <short>Fedora Workstation</short>
+  <port protocol="udp" port="1025-65535"/>
+  <port protocol="tcp" port="1025-65535"/>
+</zone>
+EOF
+
+    # image-versions.yml
+    cat > "${TEST_ROOT}/ctx/image-versions.yml" <<'EOF'
+packages:
+  # renovate: datasource=github-releases depName=starship/starship
+  starship: "1.22.0"
+EOF
+
+    # Starship archive: create a real archive so sha256 can be verified
+    printf 'starship-dummy-binary' > "${TEST_ROOT}/fixtures/tmp-content/starship"
+    (cd "${TEST_ROOT}/fixtures/tmp-content" && tar -czf "${TEST_ROOT}/fixtures/starship.tar.gz" starship)
+    VALID_SHA=$(sha256sum "${TEST_ROOT}/fixtures/starship.tar.gz" | awk '{print $1}')
+    echo "${VALID_SHA}" > "${TEST_ROOT}/fixtures/starship.tar.gz.sha256"
+
+    # ── ghcurl stub ───────────────────────────────────────────────────────
+    # Serves pre-created fixtures; supports a "corrupt" mode for sha256 tests.
+    cat > "${STUB_BIN}/ghcurl" <<GHCURL_STUB
+#!/usr/bin/bash
+URL="\$1"
+shift
+DEST=""
+while [[ \$# -gt 0 ]]; do
+    if [[ "\$1" == "-o" || "\$1" == "-Lo" ]]; then
+        DEST="\$2"
+        shift 2
+    elif [[ "\$1" == "--retry" ]]; then
+        shift 2
+    else
+        shift
+    fi
+done
+[[ -z "\${DEST:-}" ]] && exit 0
+case "\$URL" in
+    *.tar.gz.sha256)
+        MODE=\$(cat "${TEST_ROOT}/ghcurl-sha256-mode" 2>/dev/null || echo "valid")
+        if [[ "\$MODE" == "corrupt" ]]; then
+            echo "0000000000000000000000000000000000000000000000000000000000000000" > "\$DEST"
+        else
+            cp "${TEST_ROOT}/fixtures/starship.tar.gz.sha256" "\$DEST"
+        fi
+        ;;
+    *.tar.gz)
+        cp "${TEST_ROOT}/fixtures/starship.tar.gz" "\$DEST"
+        ;;
+    *FedoraWorkstation.xml)
+        cp "${TEST_ROOT}/usr/lib/firewalld/zones/FedoraWorkstation.xml" "\$DEST"
+        ;;
+    *coreos-sulogin-force-generator)
+        printf '#!/bin/bash\n' > "\$DEST"
+        ;;
+    *.pdf)
+        printf 'dummy-pdf\n' > "\$DEST"
+        ;;
+    *)
+        touch "\$DEST"
+        ;;
+esac
+exit 0
+GHCURL_STUB
+    chmod +x "${STUB_BIN}/ghcurl"
+
+    # ── Patch the script ──────────────────────────────────────────────────
+    PATCHED_SCRIPT="${TEST_ROOT}/05-override-install-patched.sh"
+    # Protect the coreos generator URL before path replacements mangle it.
+    # The URL contains /usr/lib/systemd/system-generators which would otherwise
+    # be replaced with the TEST_ROOT path, producing a malformed URL.
+    local COREOS_URL="https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator"
+    local COREOS_URL_PLACEHOLDER="COREOS_SULOGIN_GENERATOR_URL_PLACEHOLDER"
+    sed \
+        -e "s|${COREOS_URL}|${COREOS_URL_PLACEHOLDER}|g" \
+        -e "s|/usr/src|${TEST_ROOT}/usr/src|g" \
+        -e "s|/usr/src|${TEST_ROOT}/usr/src|g" \
+        -e "s|/usr/share/doc|${TEST_ROOT}/usr/share/doc|g" \
+        -e "s|/usr/share/fonts|${TEST_ROOT}/usr/share/fonts|g" \
+        -e "s|/usr/lib/systemd/system-generators|${TEST_ROOT}/usr/lib/systemd/system-generators|g" \
+        -e "s|/usr/lib/firewalld|${TEST_ROOT}/usr/lib/firewalld|g" \
+        -e "s|/usr/bin|${TEST_ROOT}/usr/bin|g" \
+        -e "s|/etc/firewalld|${TEST_ROOT}/etc/firewalld|g" \
+        -e "s|/etc/sudoers|${TEST_ROOT}/etc/sudoers|g" \
+        -e "s|/ctx/image-versions.yml|${TEST_ROOT}/ctx/image-versions.yml|g" \
+        -e "s|/tmp|${TEST_ROOT}/tmp|g" \
+        -e "s|${COREOS_URL_PLACEHOLDER}|${COREOS_URL}|g" \
+        "${OVERRIDE_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+
+    export PATCHED_SCRIPT TEST_ROOT STUB_BIN VALID_SHA
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# sha256 integrity verification (CWE-494)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "sha256 pattern: valid archive passes check" {
+    # Test the exact sha256sum pattern used in the script, in isolation.
+    echo "${VALID_SHA}" > "${TEST_ROOT}/tmp/starship.tar.gz.sha256"
+    cp "${TEST_ROOT}/fixtures/starship.tar.gz" "${TEST_ROOT}/tmp/starship.tar.gz"
+    run bash -c "cd '${TEST_ROOT}/tmp' && echo \"\$(tr -d '[:space:]' < starship.tar.gz.sha256)  starship.tar.gz\" | sha256sum -c"
+    [ "$status" -eq 0 ]
+}
+
+@test "sha256 pattern: corrupted archive fails check" {
+    # A wrong hash must cause a non-zero exit — supply chain attack is caught.
+    echo "0000000000000000000000000000000000000000000000000000000000000000" > "${TEST_ROOT}/tmp/starship.tar.gz.sha256"
+    cp "${TEST_ROOT}/fixtures/starship.tar.gz" "${TEST_ROOT}/tmp/starship.tar.gz"
+    run bash -c "cd '${TEST_ROOT}/tmp' && echo \"\$(tr -d '[:space:]' < starship.tar.gz.sha256)  starship.tar.gz\" | sha256sum -c"
+    [ "$status" -ne 0 ]
+}
+
+@test "script exits non-zero when starship sha256 is corrupt" {
+    echo "corrupt" > "${TEST_ROOT}/ghcurl-sha256-mode"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# sudoers modification
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "sudoers: linuxbrew path is appended to secure_path" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "linuxbrew" "${TEST_ROOT}/etc/sudoers"
+    [ "$status" -eq 0 ]
+}
+
+@test "sudoers: original secure_path entries are preserved" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep "secure_path" "${TEST_ROOT}/etc/sudoers"
+    [ "$status" -eq 0 ]
+    [[ "$output" == */sbin:* ]]
+    [[ "$output" == */usr/bin:* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# firewalld configuration
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "firewalld: DefaultZone is set to FedoraWorkstation" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "^DefaultZone=FedoraWorkstation$" "${TEST_ROOT}/etc/firewalld/firewalld.conf"
+    [ "$status" -eq 0 ]
+}
+
+@test "firewalld: IPv6_rpfilter is set to loose" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    run grep -q "^IPv6_rpfilter=loose$" "${TEST_ROOT}/etc/firewalld/firewalld.conf"
+    [ "$status" -eq 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Version extraction and archive installation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "starship is installed after successful sha256 verification" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_ROOT}/usr/bin/starship" ]
+}
+
+@test "coreos sulogin generator is installed" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_ROOT}/usr/lib/systemd/system-generators/coreos-sulogin-force-generator" ]
+}


### PR DESCRIPTION
## Summary

Adds 20 new BATS unit tests across two previously uncovered build scripts, bringing total coverage from 82 → 102 tests.

Closes #489, #506.

---

### `tests/unit/03-packages_test.bats` (11 tests)

**Covers `build_files/base/03-packages.sh`**

- Fedora-version-specific package conditionals (f42 adds `evolution-ews-core` + `uld`; f43 adds `evolution-ews-core` + `gnupg2-scdaemon`; f44 adds `gnupg2-scdaemon`)
- f42-only `OpenCL-ICD-Loader` swap is NOT invoked on f43+
- `copr_install_isolated` is called for `ublue-os/packages`
- Base packages spot-check (`distrobox`, `tailscale`)

### `tests/unit/05-override-install_test.bats` (9 tests)

**Covers `build_files/base/05-override-install.sh`**

- **Security-critical (CWE-494):** sha256 integrity verification pattern passes for a valid archive and fails for a corrupted one
- Full-script sha256 failure causes non-zero exit (supply chain attack is caught)
- `sudoers` `secure_path` is extended with linuxbrew path; original entries preserved
- `firewalld.conf` `DefaultZone` set to `FedoraWorkstation`
- `firewalld.conf` `IPv6_rpfilter` set to `loose`
- `starship` binary is installed after successful sha256 verification
- CoreOS sulogin generator is installed

---

### Test approach

Both test files follow the established BATS sandbox pattern:
- Per-test sandboxes under `.bats-sandbox/`
- `ghcurl`, `setfattr`, `rpm`, `dnf5` stubbed via `PATH`-prepended stub scripts
- Absolute paths patched via `sed` to redirect filesystem ops into the sandbox
- URL-embedded paths (coreos generator URL) protected before path replacement to prevent malformed URLs