### PR TITLE
fix(ci): bump actions SHA pin to v1 (6c2278ad) — drop broken 355f162b

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -41,7 +41,7 @@ jobs:
       should_build: ${{ steps.detect.outputs.should_build }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: projectbluefin/actions/bootc-build/detect-changes@355f162bb79f73f72b645cbce9c3dbbf71fcacf0 # v1
+      - uses: projectbluefin/actions/bootc-build/detect-changes@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
         id: detect
 
   build-image-testing:
@@ -54,7 +54,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@355f162bb79f73f72b645cbce9c3dbbf71fcacf0 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

Every Testing Images build fails with:

```
Unable to resolve action `projectbluefin/actions/bootc-build/setup-runner@94a11ae0b0997bfded884f7ae32fca6afcb46c77`
```

`build-image-testing.yml` was pinned to `355f162bb79f73f72b645cbce9c3dbbf71fcacf0` (`fix/scan-image` branch). That SHA's `reusable-build.yml` internally calls `setup-runner@94a11ae0` — a SHA that does not exist in `projectbluefin/actions`.

## Fix

Bump both `detect-changes` and `reusable-build.yml` pins to the current `v1` HEAD (`6c2278adfcde0818079173b40f6c0f07a68c7198`). The v1 HEAD uses `@v1` tags for its internal action refs instead of hardcoded SHAs, so this class of breakage can't recur.

## Verification

- `actionlint` passes clean
- v1 HEAD (`6c2278ad`) is the same SHA as `main` of `projectbluefin/actions` — stable and tested

Assisted-by: Claude Sonnet 4 via pi