### PR TITLE
chore(ci): bump actions SHA pin to 549249e (scan-image severity_rank fix)

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -41,7 +41,7 @@ jobs:
       should_build: ${{ steps.detect.outputs.should_build }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: projectbluefin/actions/bootc-build/detect-changes@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
+      - uses: projectbluefin/actions/bootc-build/detect-changes@549249efa621a2d1d175a8869cf05a102487edd2 # v1
         id: detect
 
   build-image-testing:
@@ -54,7 +54,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
       (github.event_name != 'pull_request' ||
        needs.detect-changes.outputs.should_build == 'true')
-    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@549249efa621a2d1d175a8869cf05a102487edd2 # v1
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Advance the `projectbluefin/actions` SHA pin from `6c2278ad` to `549249ef`.

`549249ef` fixes `NameError: name 'severity_rank' is not defined` in `bootc-build/scan-image` (merged in projectbluefin/actions#204), which was crashing every Testing Images build after the CVE summarizer step.

Assisted-by: Claude Sonnet 4 via pi