### PR TITLE
ci: trigger build — v1 tag fixed at 549249ef

### DIFF
--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,3 +1,4 @@
+# renovate: managed
 images:
   - name: common
     image: ghcr.io/projectbluefin/common


### PR DESCRIPTION
Trivial file touch to trigger Testing Images on the testing branch after the `v1` tag in `projectbluefin/actions` was force-updated to `549249ef` (scan-image `severity_rank` fix). The empty-commit retrigger was skipped due to the `workflow_dispatch` guard.\n\nAssisted-by: Claude Sonnet 4 via pi