### PR TITLE
docs(ci): record testing branch recovery learnings

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,6 +43,16 @@ uses: projectbluefin/actions/bootc-build/detect-changes@v1
 
 Renovate tracks SHA pins automatically (`config:best-practices` includes `github-actions` manager).
 
+**Never pin to a SHA from a non-merged feature branch.** Feature branch SHAs may reference internal action SHAs that don't exist on `main`, causing `startup_failure` with `Unable to resolve action`. Verify reachability: `gh api repos/projectbluefin/actions/commits/<SHA> --jq '.sha'` — a 422 means the commit is not on `main`.
+
+**Advancing the `v1` tag must use the GitHub API**, not `git push --force` (which can silently no-op):
+```bash
+gh api repos/projectbluefin/actions/git/refs/tags/v1 -X PATCH \
+  --field "sha=<NEW_SHA>" --field "force=true"
+# Verify:
+gh api repos/projectbluefin/actions/git/refs/tags/v1 --jq '.object.sha'
+```
+
 ### Available shared components
 
 | Name | Path | Purpose |
@@ -357,6 +367,9 @@ GitHub provides 10 GB per repo. With 4 flavor+image combinations each ~2-3 GB, t
 | Cosign sign/verify fails | Sigstore Fulcio/Rekor outage or key rotation | Check `check-cosign-key-rotation.yml` issues; retry after Sigstore recovers |
 | Promotion PR shows CONFLICTING | Commit landed directly on `main` without going through `testing`, severing git merge base | Run `git merge projectbluefin/main --allow-unrelated-histories -X ours` on `testing` and push — see "Squash-merge history gap" above |
 | Trivy scan crashes: "No SARIF file found" | Image reference passed to scan no longer exists — `tag-images` untags the default tag | Verify `tag-images` Justfile recipe re-applies the default tag after alias-tag loop; scan must use `oci-archive:/tmp/scan-image.tar` |
+| Testing Images `startup_failure` — `Unable to resolve action ... setup-runner@<SHA>` | SHA pin in `build-image-testing.yml` points to a non-merged `actions` feature branch; that SHA's `reusable-build.yml` internally references action SHAs that don't exist on `main` | Bump the pin to current `v1` HEAD: `gh api repos/projectbluefin/actions/commits/v1 --jq '.sha'`. Only pin SHAs reachable from `projectbluefin/actions` `main`. |
+| Testing Images build job **skipped** after `workflow_dispatch` on `testing` branch | `build-image-testing.yml` guards `workflow_dispatch` to `main` or non-empty `pr_number` only | Push a real file change to `testing`. An empty commit also skips — path filters treat no-file-change as all-excluded. Touch `image-versions.yml` or any `build_files/**` file. |
+| `v1` tag update silently no-ops (`git push ... --force` says "Everything up-to-date") | Local git remote tracking is stale or mismatched | Use the API: `gh api repos/projectbluefin/actions/git/refs/tags/v1 -X PATCH --field "sha=<SHA>" --field "force=true"`. Verify with `gh api repos/projectbluefin/actions/git/refs/tags/v1 --jq '.object.sha'`. |
 | `weekly-testing-promotion.yml` dispatch returns HTTP 422 "secret name 'github_token' can not be used" | GitHub enforces (2026-06-07+) that `github_token` is a reserved name in `workflow_call` secrets | In the callee, remove `secrets: { github_token: ... }` block; replace all `secrets.github_token` usages with `github.token` |
 | `weekly-testing-promotion.yml` dispatches succeed but `startup_failure` with 0 jobs | `environment: production` in any job + `branch_policy: protected_branches: true` when `main` only has a **ruleset** (not classic branch protection) | Switch environment to custom branch policy: `gh api repos/projectbluefin/bluefin/environments/production -X PUT --field "deployment_branch_policy[custom_branch_policies]=true" --field "deployment_branch_policy[protected_branches]=false"` then add `main`: `gh api .../environments/production/deployment-branch-policies -X POST --field "name=main"` |
 | `generate-release.yml` is called as external reusable workflow and causes `startup_failure` | `generate-release.yml` was moved to `projectbluefin/actions` — external cross-repo `workflow_call` causes startup_failure in this workflow chain | **`generate-release.yml` must be a LOCAL workflow.** Restore from git history (`git show <known-good-sha>:.github/workflows/generate-release.yml`) and keep it in-repo. Do not centralize to `projectbluefin/actions`. |

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -111,7 +111,9 @@ This is a known gap tracked in [#368](https://github.com/projectbluefin/bluefin/
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `startup_failure` with zero jobs | unsupported permissions scope in that environment | compare `permissions:` with a known-good upstream run |
+| Testing Images `startup_failure` — `Unable to resolve action ... setup-runner@<SHA>` | `build-image-testing.yml` is pinned to an `actions` SHA from a **non-merged feature branch**; that SHA's `reusable-build.yml` references internal action SHAs that don't exist on `main` | Bump the SHA pin to the current `v1` HEAD: `gh api repos/projectbluefin/actions/commits/v1 --jq '.sha'`. Only pin to SHAs reachable from `projectbluefin/actions` `main`. |
+| Testing Images build job **skipped** after `workflow_dispatch` | `build-image-testing.yml` has a guard: `workflow_dispatch` only runs when `github.ref_name == 'main'` or `inputs.pr_number != ''`. Dispatching manually on `testing` without a PR number silently skips the job. | Push a real file change to `testing` (any path not in `paths-ignore`). An **empty commit also does not work** — path filters treat it as all-files-excluded. Touch `image-versions.yml` or `build_files/**` instead. |
+| `v1` tag update silently no-ops with `git push origin refs/tags/v1 --force` | Local git remote may not match the real upstream, or the local tag object is stale. Git reports "Everything up-to-date" even when the remote tag is wrong. | Always update `v1` via the GitHub API: `gh api repos/projectbluefin/actions/git/refs/tags/v1 -X PATCH --field "sha=<NEW_SHA>" --field "force=true"`. Verify: `gh api repos/projectbluefin/actions/git/refs/tags/v1 --jq '.object.sha'`. |
 | `startup_failure` — `promote-to-stable` waits but workflow never starts | `environment: production` with `branch_policy: protected_branches: true` — rulesets are **not** recognized as classic branch protection by environment deployment policies | Switch the `production` environment to `custom_branch_policies: true` and explicitly add `main`: `gh api repos/projectbluefin/bluefin/environments/production -X PUT --field "deployment_branch_policy[custom_branch_policies]=true" --field "deployment_branch_policy[protected_branches]=false"` then `gh api repos/projectbluefin/bluefin/environments/production/deployment-branch-policies -X POST --field "name=main"` |
 | `startup_failure` — workflow that calls `generate-release.yml` | `generate-release.yml` moved to `projectbluefin/actions` as an external reusable workflow | **`generate-release.yml` must remain a LOCAL workflow in this repo.** External cross-repo `workflow_call` reusable workflows cause `startup_failure` in `weekly-testing-promotion.yml` even when actionlint passes and the SHA is reachable. This may be a GitHub bug — do not attempt to centralize it again without testing first. |
 | `startup_failure` — caller passes unknown `with:` inputs to `generate-release.yml` | Extra undeclared inputs in `with:` block for a `workflow_call` job cause startup validation failure | Match the `with:` inputs exactly to the callee's declared `inputs:` block; remove any keys not declared in the callee |
@@ -184,6 +186,10 @@ Workflow consumers in this repo pin `projectbluefin/actions` references to a ful
 
 Floating `@v1` tags are blocked by the repo's `no-floating-action-tags` pre-commit hook. The `# v1` comment is the stable contract; the SHA is the actual pin that Renovate updates.
 
+**Never pin to a SHA from a non-merged feature branch.** Feature branch SHAs in `projectbluefin/actions` may reference internal action SHAs that don't exist on `main`. Always verify: `gh api repos/projectbluefin/actions/commits/<SHA> --jq '.sha'` — if it returns a 422 the commit doesn't exist on `main`.
+
+**After advancing `v1` in `projectbluefin/actions`, bump the SHA pin here too** — even though `reusable-build.yml` resolves `@v1` at runtime, the caller pin in `build-image-testing.yml` is a fixed SHA and must be updated to pick up the new `v1` HEAD. Then push a real file change to trigger a build.
+
 ### Migration pattern
 
 Replace inline workflow steps with action calls:
@@ -231,6 +237,7 @@ Never duplicate an existing shared action inline — doing so creates a second R
 
 ## Hard rules for agents
 
+- **Always wait for and verify build completion before claiming success.** Use `gh run watch <id> --exit-status` to block until done, then confirm with `gh run view <id> --json conclusion --jq .conclusion`. Never assume a merge unblocked builds — read the actual failure logs.
 - **PRs always target `testing`.** Never `main`. If you open a PR targeting `main`, close it and re-open.
 - **Never add shared CI logic to `.github/` or `common`.** New reusable actions go in `projectbluefin/actions` only. See "CI fix workflow for agents" above for the correct sequence.
 - **Never inline a third-party action that is already wrapped in `projectbluefin/actions`.** Use the shared action instead; duplicating the pin creates Renovate drift.


### PR DESCRIPTION
Documents four failure patterns discovered while recovering Testing Images from a multi-day outage:\n\n1. **SHA pinned to non-merged feature branch** → `startup_failure: Unable to resolve action` — internal SHAs in that branch don't exist on `main`. Adds verification command.\n2. **`workflow_dispatch` on `testing` silently skips build** — guard requires `ref_name == 'main'` or `pr_number`. Empty commits also skip (path filters treat no-file-change as all-excluded).\n3. **`git push --force` for `v1` tag silently no-ops** — always use the GitHub API to advance the tag. Adds the exact command.\n4. **Always verify build completion** — `gh run watch --exit-status` before claiming success. Hard rule added.\n\nUpdates `docs/ci.md` and `docs/skills/ci.md`.\n\nAssisted-by: Claude Sonnet 4 via pi