### PR TITLE
chore(ci): consumer validation for projectbluefin/actions#209

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -746,3 +746,5 @@ retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
     for image in bluefin-nvidia; do
       $skopeo copy docker://ghcr.io/projectbluefin/${image}:{{ working_tag }} docker://ghcr.io/projectbluefin/${image}:{{ stream }}
     done
+
+# consumer-validation: perf/build-caching in projectbluefin/actions PR #209


### PR DESCRIPTION
## Consumer validation PR

Triggers CI to validate [projectbluefin/actions#209](https://github.com/projectbluefin/actions/pull/209) — `perf(build): add apt/trivy-db caching and Containerfile-aware dnf-cache key`.

All changes in the actions PR are **additive with backward-compatible defaults**. This PR exercises the current `@v1` to confirm baseline CI health before the actions PR merges and `@v1` is advanced.

**Do not merge** — close once actions#209 is merged and `@v1` is advanced.