### PR TITLE
feat(diet): drop dead-weight packages and switch to CJK variable fonts

### DIFF
--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -61,7 +61,6 @@ FEDORA_PACKAGES=(
     alsa-firmware
     alsa-tools-firmware
     autofs
-    bash-color-prompt
     bcache-tools
     bootc
     borgbackup
@@ -82,11 +81,7 @@ FEDORA_PACKAGES=(
     git-credential-libsecret
     glow
     gnome-tweaks
-    google-noto-sans-balinese-fonts
-    google-noto-sans-cjk-fonts
-    google-noto-sans-javanese-fonts
-    google-noto-sans-sundanese-fonts
-    grub2-tools-extra
+    google-noto-sans-cjk-vf-fonts
     gum
     gvfs-nfs
     htop
@@ -105,8 +100,6 @@ FEDORA_PACKAGES=(
     libayatana-appindicator-gtk3
     libcamera-gstreamer
     libcamera-tools
-    libgda
-    libgda-sqlite
     libimobiledevice
     libimobiledevice-utils
     libratbag-ratbagd
@@ -118,9 +111,7 @@ FEDORA_PACKAGES=(
     make
     mesa-libGLU
     mozc
-    mtools
     nautilus-gsconnect
-    net-tools
     nvtop
     oddjob-mkhomedir
     opendyslexic-fonts
@@ -133,9 +124,7 @@ FEDORA_PACKAGES=(
     powerstat
     powertop
     printer-driver-brlaser
-    pulseaudio-utils
     python3-pip
-    python3-pygit2
     rclone
     restic
     samba
@@ -143,7 +132,6 @@ FEDORA_PACKAGES=(
     samba-ldb-ldap-modules
     samba-winbind-clients
     samba-winbind-modules
-    setools-console
     smartmontools
     solaar-udev
     squashfs-tools
@@ -151,18 +139,14 @@ FEDORA_PACKAGES=(
     sssd-krb5
     sssd-nfs-idmap
     switcheroo-control
-    symlinks
     tcpdump
     tmux
     traceroute
-    usbip
     usbmuxd
-    vim
     waypipe
     wireguard-tools
     wl-clipboard
     xdg-terminal-exec
-    xprop
     yubikey-manager
     zenity
     zsh
@@ -173,7 +157,6 @@ case "$FEDORA_MAJOR_VERSION" in
     42)
         FEDORA_PACKAGES+=(
             evolution-ews-core
-            uld
         )
         ;;
     43)
@@ -224,7 +207,7 @@ EXCLUDED_PACKAGES=(
     gnome-software
     gnome-software-rpm-ostree
     gnome-terminal-nautilus
-    google-noto-sans-cjk-vf-fonts
+    google-noto-sans-cjk-fonts
     podman-docker
     totem-video-thumbnailer
     yelp


### PR DESCRIPTION
~200 MB uncompressed savings. All removals confirmed with size data from F42 repodata in the common#546 investigation comment.

## Packages dropped entirely

| Package | Size | Reason |
|---|---|---|
| `vim` | 41.8 MB | `vim-minimal` already in Fedora base; `vi`/`ex` remain available |
| `google-noto-sans-cjk-fonts` | 124.6 MB → 31.2 MB | **Replaced by variable font** (see below) |
| `libgda` + `libgda-sqlite` | 7.5 MB | GNOME DB abstraction, no longer needed |
| `grub2-tools-extra` | 5.0 MB | BIOS/legacy boot tools, irrelevant on UEFI Secure Boot |
| `python3-pygit2` | 1.1 MB | niche libgit2 bindings, no user-facing need |
| `net-tools` | 0.8 MB | deprecated since 2011; `ip`/`ss` from iproute2 replaces ifconfig/netstat |
| `pulseaudio-utils` | 0.3 MB | PipeWire has superseded PulseAudio |
| `mtools` | 0.3 MB | MS-DOS filesystem tools, niche |
| `usbip` | 0.2 MB | USB over IP, requires kernel module anyway |
| `xprop` | 0.1 MB | no user-facing need |
| `setools-console` | 0.1 MB | SELinux policy analysis, niche |
| `google-noto-sans-sundanese-fonts` | 0.1 MB | niche script |
| `google-noto-sans-javanese-fonts` | 0.2 MB | niche script |
| `google-noto-sans-balinese-fonts` | 0.4 MB | niche script |
| `bash-color-prompt` | 26 KB | redundant, starship replaces it |
| `symlinks` | 22 KB | niche sysadmin utility |
| `uld` (F42 only) | — | niche Samsung printer driver; per-device opt-in |

## CJK fonts: static → variable (93.4 MB savings alone)

`google-noto-sans-cjk-fonts` (124.6 MB) → `google-noto-sans-cjk-vf-fonts` (31.2 MB)

Identical Unicode/CJK coverage. Variable font format. The static package moves to `EXCLUDED_PACKAGES` to prevent it from being pulled back in as a dependency.

The CJK font switch alone is larger than all other brew-move candidates combined except rclone.

## Cumulative savings (common#546)

| Scope | Uncompressed | Est. OCI delta |
|---|---|---|
| Epic as written (brew + drop, already in PR#554) | ~150 MB | ~70–100 MB |
| + this PR | ~200 MB | ~90–125 MB |

Closes part of common#546