### PR TITLE
feat(nvidia): install nvidia-container-toolkit-base and configure CDI

### DIFF
--- a/build_files/base/04-install-kernel-akmods.sh
+++ b/build_files/base/04-install-kernel-akmods.sh
@@ -147,15 +147,13 @@ kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-dr
 EOF
 
     # Install NVIDIA Container Toolkit for CDI-based GPU passthrough in Podman.
-    # Uses -base variant only: ships nvidia-ctk + nvidia-cdi-hook without the legacy
-    # OCI hook or libnvidia-container. CDI is the correct path for bootc/rootless.
-    # This is NVIDIA's official C toolkit, not Fedora's golang-github-nvidia-container-toolkit.
+    # -base variant only: ships nvidia-ctk + nvidia-cdi-hook, no libnvidia-container,
+    # no legacy OCI hook. CDI is the correct path for bootc/rootless containers.
+    # Mirrors dakota elements/bluefin-nvidia/nvidia-container-toolkit.bst.
+    # NVIDIA's official C toolkit — distinct from Fedora's golang-github-nvidia-container-toolkit.
     curl -fsSL https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
         | tee /etc/yum.repos.d/nvidia-container-toolkit.repo
-    dnf5 -y install \
-        nvidia-container-toolkit-base \
-        libnvidia-container1 \
-        libnvidia-container-tools
+    dnf5 -y install nvidia-container-toolkit-base
     # Configure for rootless Podman: no cgroup device delegation needed with CDI
     nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place
     # Remove the repo file from the final image

--- a/build_files/base/04-install-kernel-akmods.sh
+++ b/build_files/base/04-install-kernel-akmods.sh
@@ -145,6 +145,21 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
     tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<EOF
 kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1", "initcall_blacklist=simpledrm_platform_driver_init"]
 EOF
+
+    # Install NVIDIA Container Toolkit for CDI-based GPU passthrough in Podman.
+    # Uses -base variant only: ships nvidia-ctk + nvidia-cdi-hook without the legacy
+    # OCI hook or libnvidia-container. CDI is the correct path for bootc/rootless.
+    # This is NVIDIA's official C toolkit, not Fedora's golang-github-nvidia-container-toolkit.
+    curl -fsSL https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
+        | tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+    dnf5 -y install \
+        nvidia-container-toolkit-base \
+        libnvidia-container1 \
+        libnvidia-container-tools
+    # Configure for rootless Podman: no cgroup device delegation needed with CDI
+    nvidia-ctk config --set nvidia-container-cli.no-cgroups --in-place
+    # Remove the repo file from the final image
+    rm -f /etc/yum.repos.d/nvidia-container-toolkit.repo
 fi
 
 # ZFS for stable


### PR DESCRIPTION
Adds NVIDIA Container Toolkit (`-base` variant, CDI-only — no OCI hook) to the nvidia image build.

After `nvidia-install.sh` installs the driver, this adds:
- `nvidia-container-toolkit-base` + `libnvidia-container` from NVIDIA's official RPM repo
- `nvidia-ctk config --set nvidia-container-cli.no-cgroups` for rootless Podman support

The companion PR in projectbluefin/common adds the systemd preset that enables `nvidia-cdi-refresh.{path,service}` at first boot, completing the CDI pipeline.

Result: `podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable nvcr.io/nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi` works out of the box.

Brings bluefin-nvidia to parity with projectbluefin/dakota `elements/bluefin-nvidia/nvidia-container-toolkit.bst` (dakota's reference implementation).

Note: explicitly installs from NVIDIA's official C toolkit repo, distinct from `golang-github-nvidia-container-toolkit` (Fedora's Go rewrite) which remains excluded.