### PR TITLE
fix(ci): enable merge queue enqueue for promote PR

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -39,4 +39,8 @@ jobs:
       run_e2e: true
       e2e_suites: smoke,common
       e2e_image: ghcr.io/projectbluefin/bluefin:testing
+      # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked.
+      # use_merge_queue: true calls enqueuePullRequest GraphQL instead, which
+      # places the PR in the queue and lets it merge once approvals + checks pass.
+      use_merge_queue: true
     secrets: inherit


### PR DESCRIPTION
Companion PR to projectbluefin/actions#248.

`bluefin/main` uses merge queue ruleset 17070404. `gh pr merge --auto` (the previous approach in `reusable-promote-squash.yml`) calls `enablePullRequestAutoMerge` which the ruleset blocks. The promotion PR was silently not enqueued, requiring manual maintainer action every cycle.

## Change

Set `use_merge_queue: true` on the `reusable-promote-squash.yml` call. After actions#248 lands, this will switch from `--auto` to `enqueuePullRequest` GraphQL, placing the promotion PR in the merge queue automatically.

```diff
+      use_merge_queue: true
```

Depends on: projectbluefin/actions#248 (must land first).

Assisted-by: Claude Sonnet 4.5 via pi
