### PR TITLE
revert: remove invalid workflows permission scope

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -27,9 +27,6 @@ permissions:
   issues: write         # open / close failure-tracking issues
   packages: read        # read image digests in release-gate checks
   actions: read         # inspect workflow-run statuses in release-gate
-  # workflows: write is required when the testing2192main delta includes .github/workflows/ changes.
-  # actionlint 1.7.x flags this as unknown (stale built-in list) 2014 it is a valid GITHUB_TOKEN scope.
-  workflows: write      # push squash branch when delta includes workflow file changes
 
 jobs:
   promote:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,6 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
-        args:
-          - -ignore
-          - 'unknown permission scope "workflows"'
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:


### PR DESCRIPTION
URGENT ROLLBACK. Companion to projectbluefin/actions revert. Removes `workflows: write` that caused startup_failure on promote-testing-to-main.