### PR TITLE
fix(ci): switch bonedigger caller to @main — eliminate SHA drift

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,9 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    # TODO: restore pull_request: opened trigger once bonedigger lifecycle handles PRs
-    # (tracked in projectbluefin/bluefin#TBD)
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@af62628cb964b7529fbd869ff7eac60bcf35713a
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@main
     with:
       brand_name: "Bluefin"
       brand_emoji: "🦖"


### PR DESCRIPTION
## Problem

`bonedigger.yml` was pinned to `af62628c` (June 5, 10 days stale). SHA pins on internal `projectbluefin/` workflow refs silently break when they drift — GitHub returns "workflow file issue" startup_failure with no actionable error.

## Fix

Switch `@af62628c...` → `@main`. Internal org refs don't need SHA pinning — any breakage in the called workflow fails CI immediately and is caught. Renovate SHA-pinning for `projectbluefin/` is already disabled (bluefin#215). Also removes the stale TODO comment.

Part of factory-wide cleanup: bonedigger#27.