### PR TITLE
fix(akmods): add --tmpdir /boot to dracut call to fix EXDEV on nvidia builds

### DIFF
--- a/build_files/base/04-install-kernel-akmods.sh
+++ b/build_files/base/04-install-kernel-akmods.sh
@@ -193,7 +193,7 @@ dnf5 copr disable -y ublue-os/akmods
 # 19-initramfs.sh that dracut already ran for this kernel.
 echo "Generating initramfs for ${KERNEL}"
 export DRACUT_NO_XATTR=1
-/usr/bin/dracut --no-hostonly --kver "${KERNEL}" --reproducible \
+/usr/bin/dracut --no-hostonly --kver "${KERNEL}" --reproducible --tmpdir /boot \
     -v --add ostree -f "/lib/modules/${KERNEL}/initramfs.img"
 chmod 0600 "/lib/modules/${KERNEL}/initramfs.img"
 touch "/lib/modules/${KERNEL}/.bluefin-initramfs-done"


### PR DESCRIPTION
## Problem

nvidia testing image builds are failing with:

```
dracut[E]: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.dNlN6cc/initramfs -f /root
```

`/var/tmp` and `/boot` are separate tmpfs mounts inside a container build `RUN` layer. dracut stages its initramfs in `/var/tmp` by default, then tries to `rename(2)` the result to `/boot` — this crosses device boundaries and fails with EXDEV (os error 18).

The nvidia variant is the first to surface this because `nvidia-install.sh` writes `/usr/lib/dracut/dracut.conf.d/99-nvidia.conf` before the dracut call, adding more modules to the initramfs. The non-nvidia builds happen to avoid it.

## Fix

Add `--tmpdir /boot` to the explicit `dracut` invocation in `04-install-kernel-akmods.sh`. One flag. dracut stages and finalises on the same device.

## Impact

- Unblocks `Testing Images [testing]` builds
- Unblocks `post-testing-e2e` (which triggers on successful testing builds)
- Unblocks the `testing → main` promotion gate (PR #568)