### PR TITLE
ci: trigger testing build post push-image authfile fix

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,4 @@
+# ci: trigger build after push-image authfile fix
 repo_organization := "projectbluefin"
 base_image_org := "quay.io/fedora-ostree-desktops"
 base_image_name := "silverblue"


### PR DESCRIPTION
Triggers a `push` build on `testing` so `post-testing-e2e` fires after the push-image authfile fix (projectbluefin/actions#256) landed.

The `workflow_dispatch` to `main` validated the fix but doesn't trigger the e2e gate. A merged PR to `testing` does.

_ci-only, no functional change_