### PR TITLE
fix(ci): fix execute-release trigger and remove unknown reusable inputs

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -1,19 +1,34 @@
 name: Execute Release
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - main
+  workflow_dispatch:
 
-permissions: {}
+permissions:
+  id-token: write
 
 jobs:
+  check-trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      is-promotion: ${{ steps.check.outputs.is-promotion }}
+    steps:
+      - id: check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || echo "$COMMIT_MSG" | grep -qE "^ci\(promote\): bluefin testing"; then
+            echo "is-promotion=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-promotion=false" >> "$GITHUB_OUTPUT"
+          fi
+
   execute:
-    if: >
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
+    needs: [check-trigger]
+    if: needs.check-trigger.outputs.is-promotion == 'true'
     permissions:
       actions: read
       contents: write
@@ -28,7 +43,8 @@ jobs:
           {"image":"bluefin","source_tag":"testing","target_tag":"stable"},
           {"image":"bluefin-nvidia","source_tag":"testing","target_tag":"stable"}
         ]
-      cosign_identity_regexp: ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
+      cosign_identity_regexp: >-
+        ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
     secrets: inherit
 
   release-notes:
@@ -42,8 +58,6 @@ jobs:
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin
-      generate_sbom_inline: true
-      checkout_ref: main
       project_name: Bluefin
       badge_label: Stable
       accent_color: "#0ea5e9"


### PR DESCRIPTION
## Bugs fixed

`execute-release.yml` has been `startup_failure` since 2026-06-13. Two causes:

### 1. Unknown inputs passed to `reusable-release.yml`

`generate_sbom_inline` and `checkout_ref` are not declared inputs of `reusable-release.yml`. GitHub rejects the entire workflow at load time when a caller passes undeclared inputs to a reusable workflow — before any job runs.

**Fix:** remove both fields from the `release-notes` `with:` block.

### 2. `pull_request: closed` trigger unreliable for reusable callers

The trigger has no `workflow_dispatch` fallback, making it impossible to manually test or recover from a stuck release. The event context can also fail to resolve correctly at startup for certain merge scenarios.

**Fix:** mirror the lts pattern — `push: branches: [main]` + `workflow_dispatch` with a `check-trigger` job that gates on the promotion commit message (`ci(promote): bluefin testing`). The squash commit from `auto/promote-testing-to-main` always starts with this prefix.

## Also

- Adds `id-token: write` at workflow level (required for OIDC in `release-notes`)
- Uses `>-` scalar for `cosign_identity_regexp` (consistent style, avoids parser edge cases)

---

_Assisted-by: Claude Sonnet 4.5 via pi_