### PR TITLE
fix(ci): disable e2e gate in promote workflow, fix post-testing-e2e branches filter

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -7,7 +7,10 @@ on:
   workflow_run:
     workflows: ["Testing Images"]
     types: [completed]
-    branches: [testing]
+    # Include main so the workflow file update reaches the default-branch evaluator.
+    # The promote-to-testing job is guarded to main-only to prevent double-promoting.
+    # See common docs/skills/e2e-ci.md — Requirement 1.
+    branches: [main, testing]
 
 permissions: read-all
 
@@ -73,7 +76,8 @@ jobs:
     # run-upgrade-test removed from needs — lifecycle suite is non-blocking (see TODO above).
     needs: [e2e, run-e2e]
     if: >-
-      needs.run-e2e.result == 'success'
+      needs.run-e2e.result == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -13,6 +13,12 @@ on:
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:
+  # Re-evaluate the release gate immediately after post-testing-e2e completes
+  # instead of waiting for the next push or midnight cron (e2e-ci.md Requirement 2).
+  workflow_run:
+    workflows: ["Post-Testing E2E"]
+    types: [completed]
+    branches: [testing]
 
 concurrency:
   group: promote-testing-to-main
@@ -36,9 +42,14 @@ jobs:
         [{"image":"bluefin"},{"image":"bluefin-nvidia"}]
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
-      run_e2e: true
-      e2e_suites: smoke,common
-      e2e_image: ghcr.io/projectbluefin/bluefin:testing
+      run_e2e: false
+      # run_e2e is intentionally false for bluefin. The post-testing-e2e workflow
+      # gates :testing continuously but the gate SHA lookup is broken until the
+      # branches:[main,testing] fix (post-testing-e2e.yml) reaches main via
+      # promotion. Model matches dakota: cosign verification only at the PR gate
+      # level; E2E evidence is gathered separately by post-testing-e2e.yml.
+      # Re-enable once post-testing-e2e reliably files evidence under the testing
+      # branch HEAD SHA. See docs/skills/ci.md and common e2e-ci.md for details.
       # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked.
       # use_merge_queue: true calls enqueuePullRequest GraphQL instead, which
       # places the PR in the queue and lets it merge once approvals + checks pass.


### PR DESCRIPTION
## Problem

The promotion PR (#595) is permanently stuck at `release/blocked` because the E2E gate has a structural SHA mismatch:

- The gate queries GitHub's runs API by the **testing branch HEAD SHA**
- But `workflow_run`-triggered workflows (like `post-testing-e2e.yml`) are stored in the API under the **default branch (main) SHA**
- These never match → gate reports "No completed post-testing-e2e run found" on every cycle

Additionally, the `common` E2E suite is genuinely failing on GNOME 50 (`Boot VM with QEMU + KVM` step).

## Changes

### `promote-testing-to-main.yml`
- `run_e2e: false` — matches the dakota model; cosign verification only at the PR gate level
- Adds `workflow_run` feedback trigger on `Post-Testing E2E` so the gate re-evaluates immediately after E2E completes instead of waiting for next push or midnight cron (**e2e-ci.md Requirement 2**)

### `post-testing-e2e.yml`  
- `branches: [main, testing]` — allows the default-branch workflow evaluator to see this fix once it reaches main (**e2e-ci.md Requirement 1**)
- `promote-to-testing` job guarded to `head_branch == 'main'` to prevent double-promoting on testing-branch-triggered runs

## Factory doc alignment

These changes align with the documented never-stall gate design in `projectbluefin/common` [`docs/skills/e2e-ci.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/e2e-ci.md) (Requirements 1 and 2) and match the dakota promotion model.

A follow-up PR to `projectbluefin/common` will update `release-promotion.md` to reflect the current `run_e2e: false` state for both bluefin and dakota.

## Re-enabling E2E

Once this PR reaches `main` via promotion:
- The `branches: [main, testing]` fix activates on the default-branch evaluator
- The `workflow_run` feedback trigger fires after each E2E run
- `run_e2e: true` can be restored once `post-testing-e2e` reliably files evidence under the testing branch HEAD SHA

See [common e2e-ci.md — Promotion gate bootstrap for bluefin](https://github.com/projectbluefin/common/blob/main/docs/skills/e2e-ci.md#gate-bootstrap-for-bluefin-circular-dependency) for the bootstrap procedure.

Assisted-by: Claude Sonnet 4.5 via pi