### PR TITLE
fix(ci): trigger promote on PR review for zero-touch merge queue enqueue

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -19,6 +19,11 @@ on:
     workflows: ["Post-Testing E2E"]
     types: [completed]
     branches: [testing]
+  # Re-run enqueue after each approval so the PR enters the merge queue
+  # automatically once 2 maintainers approve — no manual button required.
+  # Filtered in the job to the promotion PR only.
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: promote-testing-to-main
@@ -36,6 +41,11 @@ permissions:
 
 jobs:
   promote:
+    # For pull_request_review events, only run on the promotion PR itself.
+    # Other PRs' reviews would otherwise trigger a full promote cycle.
+    if: >
+      github.event_name != 'pull_request_review' ||
+      github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
     uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@v1
     with:
       variants: >-


### PR DESCRIPTION
## Problem

After #611 landed, the promotion PR (#595) sits at `release/ready` but never enters the merge queue automatically. The reusable already calls `enqueuePullRequest` at the end of every promote run — but it silently skips with a warning when required approvals aren't met yet. Nothing re-triggers it after approvals land.

Result: maintainers approve, nothing happens, someone has to manually re-run the workflow or wait for the midnight cron.

## Fix

Add `pull_request_review: types: [submitted]` trigger. Each approval re-runs the promote workflow:

- Squash tree is unchanged → push is skipped → **existing approvals are preserved** (reusable tree-unchanged logic, line ~204)
- Gate re-checks cosign (fast, already passing)
- `enqueuePullRequest` is called → succeeds once 2 approvals are in → PR enters merge queue

Job-level `if:` guard ensures only reviews on `auto/promote-testing-to-main` trigger the full cycle — reviews on all other PRs are skipped immediately.

## Full automated flow after this reaches main

```
maintainer 1 approves → promote fires → enqueue: 1/2, skip
maintainer 2 approves → promote fires → enqueue: ✅
  → merge queue runs PR Validation — testsuite/validate
  → merges to main
  → execute-release.yml fires
  → :testing → :stable + GitHub Release with changelog
```

Zero buttons.

Assisted-by: Claude Sonnet 4.5 via pi