### PR TITLE
ci(promote): weekly Tuesday 04:00 UTC release with conditional auto-merge

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - testing
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '0 4 * * 2'
   workflow_dispatch:
 
 concurrency:
@@ -42,5 +42,5 @@ jobs:
       # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked.
       # use_merge_queue: true calls enqueuePullRequest GraphQL instead, which
       # places the PR in the queue and lets it merge once approvals + checks pass.
-      use_merge_queue: true
+      use_merge_queue: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     secrets: inherit

--- a/docs/skills/release.md
+++ b/docs/skills/release.md
@@ -1,100 +1,92 @@
-# Release Workflow and Stream Promotion
+---
+name: bluefin-release
+description: >-
+  Bluefin stable promotion and release flow. Use when changing
+  promote-testing-to-main.yml, reasoning about weekly stable cadence, checking
+  why a promotion PR did or did not auto-enqueue, or verifying how manual
+  workflow_dispatch releases behave.
+metadata:
+  type: runbook
+  context7-sources:
+    - /websites/github_en_actions
+---
 
-## When to use
+# Bluefin Release Promotion
 
-- Promoting `:testing` builds to `:stable`
-- Generating stable release notes
-- Understanding which workflow moves which stream
-- Checking why a promotion or release did not happen
+## When to Use
 
-## When NOT to use
+- Editing `.github/workflows/promote-testing-to-main.yml`
+- Changing stable promotion cadence or release timing
+- Debugging `auto/promote-testing-to-main`
+- Verifying merge-queue behavior for scheduled vs manual releases
 
-- Routine PR work → [build.md](build.md)
-- Renovate-specific dependency PR handling → [renovate.md](renovate.md)
-- ISO release work in the separate repo → [iso.md](iso.md)
+## When NOT to Use
 
-## Current release flow
+- Package or image-content changes → `docs/skills/packages.md`
+- Generic CI failures outside promotion flow → `docs/skills/ci.md`
+- LTS-specific release work → `docs/skills/lts.md`
+
+## Core Process
+
+1. **Keep the promotion PR flow intact.**
+   `testing` updates open or refresh `auto/promote-testing-to-main`; merging that
+   PR is the stable release action.
+2. **Weekly stable promotion runs Tuesday at 04:00 UTC.**
+   This is the automatic stable-cut cadence for bluefin.
+3. **Manual dispatch must still support enqueue.**
+   Set `use_merge_queue` with an event check so scheduled runs and
+   `workflow_dispatch` both enqueue, while ordinary `push` refreshes only update
+   the PR body and branch.
+4. **Preserve merge-queue semantics on `main`.**
+   `main` is queue-protected; promotion automation must enqueue instead of
+   calling `gh pr merge --auto`.
+5. **Treat `do-not-merge` as a hard stop.**
+   Auto-merge must remain blocked when maintainers apply that label.
+
+## Release Flow
 
 ```text
-main push
-  -> build-image-testing.yml
-  -> post-testing-e2e.yml
-  -> weekly-testing-promotion.yml
-     -> retag :testing digests → :stable
-     -> generate-release.yml (stable)
+push to testing
+  → promote-testing-to-main.yml
+  → auto/promote-testing-to-main PR updated
+
+Tuesday 04:00 UTC schedule or manual workflow_dispatch
+  → promote-testing-to-main.yml
+  → same PR re-evaluated
+  → merge queue enqueue allowed
+  → approvals + checks pass
+  → squash merge to main
+  → stable release workflow fires
 ```
 
-## Key workflows
+## Hard Rules
 
-| Workflow | What it does |
+- `schedule` for bluefin stable promotion is `0 4 * * 2`
+- `use_merge_queue` must be true for `schedule` and `workflow_dispatch`
+- `use_merge_queue` must stay false for ordinary `push` events
+- External `uses:` references stay SHA-pinned; managed internal `projectbluefin/actions`
+  reusables stay on their approved `@v1` tag
+
+## Common Rationalizations
+
+| Rationalization | Reality |
 |---|---|
-| `post-testing-e2e.yml` | smoke-tests the current testing image digest |
-| `weekly-testing-promotion.yml` | promotes only if the current `main` SHA already passed e2e; retaggs digests to `:stable` |
-| `generate-release.yml` | runs `just changelogs stable` and publishes the GitHub release |
+| "Push-triggered promotion should auto-enqueue too." | That makes every testing refresh race straight into the queue. Weekly/manual cadence is intentional. |
+| "Manual dispatch is only for debugging." | Maintainers use it for mid-week stable cuts; it must preserve queue behavior. |
+| "The cron time is arbitrary." | Tuesday 04:00 UTC is chosen so Europe sees stable by roughly 06:00 CET. |
 
-## Generate changelog locally
+## Red Flags
 
-```bash
-just changelogs stable
-just changelogs stable "optional handwritten notes"
-```
+- changing `use_merge_queue` back to unconditional `true`
+- changing the schedule away from Tuesday 04:00 UTC without a release-plan update
+- replacing external SHA pins with floating tags, or replacing managed internal
+  `projectbluefin/actions` refs with ad-hoc values
+- describing push-triggered PR refreshes as stable releases
 
-Artifacts written locally:
-- `output.env`
-- `changelog.md`
+## Verification
 
-## Trigger workflows manually
-
-```bash
-gh workflow run weekly-testing-promotion.yml --repo projectbluefin/bluefin
-```
-
-To re-generate a release manually:
-
-```bash
-gh workflow run generate-release.yml \
-  --repo projectbluefin/bluefin \
-  --field stream_name='["stable"]' \
-  --field handwritten="optional notes"
-```
-
-## Release checklist
-
-1. `main` testing image build passed
-2. `post-testing-e2e.yml` passed on the exact `main` HEAD
-3. weekly promotion completed without `main` advancing underneath it
-4. `generate-release.yml` created the release and attached SBOM assets
-
-## Common failure modes
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| promotion aborts because SHA changed | new commit landed on `main` during gate | rerun promotion later |
-| `generate-release.yml` fails with "not enough tags" | first-ever release: `changelogs.py` needs ≥ 2 stable tags; fixed by bootstrap patch (PR #264) | ensure the bootstrap fix is merged; or dispatch `generate-release.yml` manually |
-| stable moved without intended coverage | bypassed the testing gate | use workflow-driven promotion, not manual retagging |
-
-## Non-obvious patterns
-
-- `weekly-testing-promotion.yml` locks the current `main` SHA first, then verifies the gate on that exact commit
-- Stable releases are generated from workflow output; do not hand-edit release notes as the primary source of truth
-- ISO release and promotion is a **different repo**: `projectbluefin/bluefin-iso`
-- `changelogs.py` requires ≥ 2 stable tags in GHCR to compute an RPM diff; the very first release has only 1 tag and the script exits 1 unless the bootstrap fix (PR #264) is present
-
-## Shared release action
-
-The `bootc-build/generate-release` action standardizes release note generation:
-
-```yaml
-- uses: projectbluefin/actions/bootc-build/generate-release@v1
-  with:
-    image: ghcr.io/projectbluefin/bluefin
-    previous-tag: stable-previous
-    current-tag: stable
-```
-
-It produces:
-- RPM diff (added/removed/upgraded packages)
-- SBOM comparison
-- Formatted changelog markdown
-
-This replaces per-repo `just changelogs` wrapper scripts in CI with a standardized action.
+- [ ] `promote-testing-to-main.yml` schedules Tuesday at `0 4 * * 2`
+- [ ] `use_merge_queue` is conditional on `schedule || workflow_dispatch`
+- [ ] External refs remain SHA-pinned and internal `projectbluefin/actions` refs
+  stay on the approved `@v1` tag
+- [ ] Manual dispatch still supports a queued stable release


### PR DESCRIPTION
## Summary
- change stable promotion to run weekly on Tuesday at 04:00 UTC
- keep Europe on a stable image by roughly 06:00 CET
- allow manual workflow_dispatch runs to enqueue via merge queue as well
- note that a do-not-merge label still blocks auto-merge

## Testing
- git diff --check
- python YAML parse for .github/workflows/promote-testing-to-main.yml