### PR TITLE
chore(ci): pin testsuite e2e.yml to @v1

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e299372ebe302d132c9c9a1ea4d1180793f7a7bb # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@v1
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Switches from a SHA pin to the v1 mutable tag. testsuite auto-updates v1 to main after every merge — no more Renovate SHA bumps needed.