### PR TITLE
fix(ci): add variants table and mesa to release notes

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -58,6 +58,8 @@ jobs:
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin
+      generate_sbom_inline: true
+      checkout_ref: main
       project_name: Bluefin
       badge_label: Stable
       accent_color: "#0ea5e9"
@@ -65,10 +67,53 @@ jobs:
         ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
       notable_packages: >-
         [
-          {"sbom_name": "kernel", "label": "Kernel"},
-          {"sbom_name": "gnome-shell", "label": "GNOME Shell"},
-          {"sbom_name": "flatpak", "label": "Flatpak"},
-          {"sbom_name": "systemd", "label": "systemd"}
+          {"sbom_name": "kernel",            "label": "Kernel"},
+          {"sbom_name": "gnome-shell",        "label": "GNOME Shell"},
+          {"sbom_name": "mesa-filesystem",    "label": "Mesa"},
+          {"sbom_name": "flatpak",            "label": "Flatpak"},
+          {"sbom_name": "systemd",            "label": "systemd"}
         ]
       docs_url: https://docs.projectbluefin.io/changelogs
     secrets: inherit
+
+  post-release-variants:
+    needs: [execute, release-notes]
+    if: always() && needs.release-notes.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve promoted digests
+        id: digests
+        run: |
+          set -euo pipefail
+          for image in bluefin bluefin-nvidia; do
+            digest=$(skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/${image}:stable" \
+              | jq -r '.Digest' | cut -c1-19)
+            echo "${image}=${digest}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Prepend variants table to release
+        env:
+          BLUEFIN_DIGEST: ${{ steps.digests.outputs.bluefin }}
+          NVIDIA_DIGEST: ${{ steps.digests.outputs.bluefin-nvidia }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName')
+          CURRENT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body --jq '.body')
+
+          VARIANTS_SECTION=$(printf '%s\n' \
+            '## Variants promoted' \
+            '' \
+            '| Variant | Tag | Digest |' \
+            '|---|---|---|' \
+            "| \`bluefin\` | \`:stable\` | \`${BLUEFIN_DIGEST}\` |" \
+            "| \`bluefin-nvidia\` | \`:stable\` | \`${NVIDIA_DIGEST}\` |" \
+            '' \
+            '---' \
+            '')
+          printf '%s\n%s' "$VARIANTS_SECTION" "$CURRENT" > /tmp/updated-body.md
+          gh release edit "$TAG" --repo "${{ github.repository }}" --notes-file /tmp/updated-body.md


### PR DESCRIPTION
Consumer validation PR for projectbluefin/actions#269.

Changes:
- Add post-release-variants job (matches bluefin-lts pattern) — prepends a variants table with bluefin + bluefin-nvidia digests to every release
- Add mesa-filesystem to notable_packages so Mesa shows in the release card

Consumer PR: https://github.com/projectbluefin/bluefin/pull/new
Consumer CI run: pending
Out-of-org consumer impact: N/A