### PR TITLE
ci: remove post-testing E2E and issue spam; simplify gate

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -1,8 +1,8 @@
-name: Post-Testing E2E
+name: Post-Testing Gate
 
-# Runs e2e smoke tests after every successful push build on testing.
-# This gates testing continuously so the promotion workflow
-# (promote-testing-to-main.yml) promotes only e2e-verified commits.
+# Promotes :testing immediately after a successful build on the testing branch.
+# PR validation (pr-smoke.yml) already gates every change before merge.
+# :testing is NOT published by the build itself; this workflow does the promotion.
 on:
   workflow_run:
     workflows: ["Testing Images"]
@@ -12,68 +12,15 @@ on:
 permissions: read-all
 
 concurrency:
-  group: post-testing-e2e-${{ github.event.workflow_run.head_sha }}
+  group: post-testing-gate-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
-  e2e:
-    # Only run for push events (not merge_group or workflow_dispatch)
-    # and only when the build succeeded.
+  promote-to-testing:
+    name: Promote verified digests to :testing
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      image: ${{ steps.get-digest.outputs.image }}
-    steps:
-      - name: Download build digest
-        id: get-digest
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh run download "${{ github.event.workflow_run.id }}" \
-            --repo "${{ github.repository }}" \
-            --name "image-digest-testing-bluefin-main-x86_64" \
-            --dir /tmp/digest
-          DIGEST=$(grep "=" /tmp/digest/main-bluefin-x86_64.txt | head -1 | cut -d= -f2-)
-          echo "image=ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "Testing image: ghcr.io/${{ github.repository_owner }}/bluefin@${DIGEST}"
-
-  run-e2e:
-    needs: [e2e]
-    permissions:
-      packages: write
-      contents: read
-    uses: ./.github/workflows/run-testsuite.yml
-    with:
-      image: ${{ needs.e2e.outputs.image }}
-      suites: smoke,common
-
-  # run-upgrade-test: DISABLED — TODO(#400)
-  # lifecycle suite fails under GNOME 50 AT-SPI changes, marking
-  # post-testing-e2e as 'failure' and blocking weekly-testing-promotion.
-  # Disabled until testsuite lifecycle scenarios are stable on GNOME 50.
-  # To restore: uncomment the job below.
-  #
-  # run-upgrade-test:
-  #   needs: [e2e]
-  #   permissions:
-  #     packages: write
-  #     contents: read
-  #   uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@v1
-  #   with:
-  #     image: ${{ needs.e2e.outputs.image }}
-  #     suites: lifecycle
-
-  promote-to-testing:
-    # Promote all tested flavors to :testing only after e2e passes.
-    # This ensures :testing always points to a digest that has passed gate e2e.
-    # run-upgrade-test removed from needs — lifecycle suite is non-blocking (see TODO above).
-    needs: [e2e, run-e2e]
-    if: >-
-      needs.run-e2e.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -102,7 +49,6 @@ jobs:
           PROMOTED=0
 
           while IFS= read -r -d '' f; do
-            # Each file contains: IMAGE_NAME=sha256:... (= format, one digest per image per arch)
             while IFS='=' read -r image_name digest; do
               [[ -z "${image_name}" || -z "${digest}" || "${image_name}" == *"|"* ]] && continue
               SRC="docker://${REGISTRY}/${image_name}@${digest}"
@@ -115,45 +61,3 @@ jobs:
           done < <(find /tmp/all-digests -name "*.txt" -print0)
 
           echo "✅ Promoted ${PROMOTED} flavor(s) to :testing"
-
-  report-failure:
-    needs: [e2e, run-e2e, promote-to-testing]
-    if: failure() && needs.e2e.outputs.image != ''
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      issues: write
-    steps:
-      - name: Open or update failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const image = '${{ needs.e2e.outputs.image }}';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const sha = '${{ github.event.workflow_run.head_sha }}'.slice(0, 8);
-            const title = `ci: e2e smoke test failure — ${sha}`;
-
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'area/testing,kind/bug',
-              state: 'open',
-            });
-            const dup = existing.data.find(i => i.title === title);
-            if (dup) {
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: dup.number,
-                body: `## E2E Smoke Test Failure\n\n**Image:** \`${image}\`\n**Commit:** ${sha}\n**Run:** ${runUrl}\n**Suites:** smoke,common\n\n_Automatically opened by post-testing-e2e.yml_`,
-              });
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body: `## E2E Smoke Test Failure\n\n**Image:** \`${image}\`\n**Commit:** ${sha}\n**Run:** ${runUrl}\n**Suites:** smoke,common\n\n_Automatically opened by post-testing-e2e.yml_`,
-                labels: ['area/testing', 'kind/bug', 'priority/p1'],
-              });
-            }
-

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -36,9 +36,7 @@ jobs:
         [{"image":"bluefin"},{"image":"bluefin-nvidia"}]
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
-      run_e2e: true
-      e2e_suites: smoke,common
-      e2e_image: ghcr.io/projectbluefin/bluefin:testing
+      run_e2e: false
       # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked.
       # use_merge_queue: true calls enqueuePullRequest GraphQL instead, which
       # places the PR in the queue and lets it merge once approvals + checks pass.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: no-floating-action-tags
         name: Block floating GitHub Action tags (@main, @v*)
         language: pygrep
-        entry: 'uses:(?!.*projectbluefin/(actions|bonedigger)/).*@(main|master|latest|v[0-9])'
+        entry: 'uses:(?!.*projectbluefin/(actions|bonedigger|testsuite)/).*@(main|master|latest|v[0-9])'
         types: [yaml]
         files: '\.github/workflows/'
       - id: no-sha-pins-for-internal-actions


### PR DESCRIPTION
Mirrors the same change made in bluefin-lts (#342).

PR validation via pr-smoke.yml already gates every change before merge, making the post-merge E2E redundant. This removes the duplicate 40+ minute E2E run.

Changes:
- post-testing-e2e.yml: removed e2e, run-e2e, report-failure jobs; renamed to Post-Testing Gate; promotes :testing directly on successful build
- promote-testing-to-main.yml: run_e2e: false (gate now only checks cosign)
- .pre-commit-config.yaml: exempt projectbluefin/testsuite from no-floating-action-tags hook (run-testsuite.yml uses @v1 managed tag)