### PR TITLE
test(hooks): add edge-case coverage for setup hook scripts

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -7,6 +7,7 @@ Agent entry point. Load only the skill that matches the task in front of you.
 | I need to... | Load |
 |---|---|
 | Build, validate, or test an image change | `docs/skills/build.md` |
+| Add or extend Bats coverage for setup hook scripts | `docs/skills/setup-hook-tests.md` |
 | Add, remove, or adjust RPMs, Flatpaks, or Brewfiles | `docs/skills/packages.md` |
 | Debug GitHub Actions or understand workflow behavior | `docs/skills/ci.md` |
 | Understand image variants, streams, or flavors | `docs/skills/variants.md` |

--- a/docs/skills/setup-hook-tests.md
+++ b/docs/skills/setup-hook-tests.md
@@ -1,0 +1,68 @@
+---
+name: setup-hook-tests
+description: Add or extend Bats coverage for setup hook scripts. Use when touching tests/unit/*hook*_test.bats, user-setup hooks, privileged-setup hooks, or patching hook scripts for unit tests.
+metadata:
+  context7-sources:
+    - /bats-core/bats-core
+---
+
+# Setup Hook Bats Tests
+
+## When to Use
+
+- Adding tests for `system_files/shared/usr/share/ublue-os/user-setup.hooks.d/*.sh`
+- Adding tests for `system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/*.sh`
+- Extending `tests/unit/*_test.bats` for hook edge cases
+
+## When NOT to Use
+
+- Testing `build_files/**` helpers without hook-specific path patching
+- Full image or workflow validation work
+- Refactoring hook scripts themselves without changing test coverage
+
+## Core Process
+
+1. Append to the existing hook test file in `tests/unit/`; do not create a second file for the same hook.
+2. In `setup()`, create the sandbox at `${SCRIPT_DIR}/.bats-sandbox/<name>.<test_num>.$$`, add `stub-bin/`, and prepend it to `PATH`.
+3. Patch hook scripts with `sed` before running them:
+   - replace `source /usr/lib/ublue/setup-services/libsetup.sh` with `version-script() { return 0; }`
+   - replace absolute system paths (`/usr/libexec/...`, `/var/lib/...`, `/sys/...`, `/usr/share/...`) with sandbox paths
+   - replace absolute command paths like `/usr/bin/cp` if the test needs a stubbed command
+4. Run imperative hooks with Bats `run`, then assert on `$status` and `$output`:
+   ```bash
+   run bash "${PATCHED_SCRIPT}"
+   [ "$status" -eq 0 ]
+   [[ "$output" == *"Warning:"* ]]
+   ```
+5. Assert the real side effect that would catch a regression: file mode, idempotent config line count, skipped branch, or non-zero exit propagation.
+
+## Common Rationalizations
+
+- "A happy-path install test is enough."
+  Edge branches in hooks are where regressions hide; add the branch that would actually crash, duplicate config, or ignore a failure.
+
+- "I can call the real system path."
+  Hook tests must stay sandboxed; patch absolute paths or the test stops being deterministic.
+
+- "I'll add a new test file for one edge case."
+  Keep one test file per hook so coverage stays discoverable and CI stays boring.
+
+## Red Flags
+
+- Tests write outside `${SCRIPT_DIR}/.bats-sandbox/...`
+- A hook test sources real `/usr/lib/...` helpers
+- Assertions only check "exit 0" without validating the branch effect
+- A patched hook still calls an unstubbed absolute binary path
+
+## Verification
+
+- [ ] Added coverage only in the existing hook test file
+- [ ] Sandbox path follows `${SCRIPT_DIR}/.bats-sandbox/<name>.<test_num>.$$`
+- [ ] Absolute paths were patched to sandbox or stubbed commands
+- [ ] Tests assert on `$status`, `$output`, or concrete file side effects
+- [ ] `bats tests/unit/` passes
+- [ ] `just check && pre-commit run --all-files` passes before commit
+
+## Sources
+
+- Context7: `/bats-core/bats-core` — `setup`/`teardown` hooks and `run` status/output assertions

--- a/tests/unit/12-gnupg_test.bats
+++ b/tests/unit/12-gnupg_test.bats
@@ -45,3 +45,25 @@ teardown() {
     [ "$status" -eq 0 ]
     [ ! -f "${HOME}/.gnupg/gpg-agent.conf" ]
 }
+
+@test "12-gnupg: creates .gnupg with mode 700" {
+    rm -rf "${HOME}/.gnupg"
+    touch "${TEST_ROOT}/usr/libexec/scdaemon"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [ -d "${HOME}/.gnupg" ]
+    [ "$(stat -c '%a' "${HOME}/.gnupg")" = "700" ]
+}
+
+@test "12-gnupg: running twice does not duplicate scdaemon-program line" {
+    touch "${TEST_ROOT}/usr/libexec/scdaemon"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c '^scdaemon-program ' "${HOME}/.gnupg/gpg-agent.conf")" -eq 1 ]
+}

--- a/tests/unit/20-framework_test.bats
+++ b/tests/unit/20-framework_test.bats
@@ -50,3 +50,42 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -q "install" "${STUB_BIN}/brew.log"
 }
+
+@test "20-framework: missing brew exits cleanly" {
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    rm -f "${STUB_BIN}/brew"
+    export PATH="${STUB_BIN}:/usr/bin:/bin"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning: brew not found"* ]]
+}
+
+@test "20-framework: non-writable brew prefix skips install with warning" {
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    chmod 555 "${TEST_ROOT}/linuxbrew"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"user lacks write permission"* ]]
+    [ ! -f "${STUB_BIN}/brew.log" ]
+}
+
+@test "20-framework: installed casks are skipped without install calls" {
+    cat > "${STUB_BIN}/brew" <<EOF
+#!/usr/bin/bash
+echo "brew \$*" >> "${STUB_BIN}/brew.log"
+[[ "\$1" == "list" ]] && exit 0
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/brew"
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed, skipping"* ]]
+    ! grep -q "install" "${STUB_BIN}/brew.log"
+}

--- a/tests/unit/99-flatpaks_test.bats
+++ b/tests/unit/99-flatpaks_test.bats
@@ -55,3 +55,16 @@ teardown() {
     # Bug: rm uses quoted glob, old file survives — test documents known regression
     [ -f "${PREF_DIR}/bluefin-stale.js" ]
 }
+
+@test "99-flatpaks: aarch64 skips firefox config setup" {
+    cat > "${STUB_BIN}/arch" <<'EOF'
+#!/usr/bin/bash
+echo "aarch64"
+EOF
+    chmod +x "${STUB_BIN}/arch"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_ROOT}/var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/aarch64" ]
+}

--- a/tests/unit/99-privileged_test.bats
+++ b/tests/unit/99-privileged_test.bats
@@ -30,3 +30,15 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -q "/usr/bin/ublue-privileged-setup" "${STUB_BIN}/pkexec.log"
 }
+
+@test "99-privileged: pkexec failure exits non-zero" {
+    cat > "${STUB_BIN}/pkexec" <<EOF
+#!/usr/bin/bash
+exit 23
+EOF
+    chmod +x "${STUB_BIN}/pkexec"
+
+    run bash "${HOOK_SCRIPT}"
+
+    [ "$status" -eq 23 ]
+}


### PR DESCRIPTION
Adds missing branch coverage for setup hooks. Closes #497.

- 20-framework.sh: brew absent, non-writable prefix, already-installed cask paths
- 99-flatpaks.sh: aarch64 arch skip path
- 12-gnupg.sh: .gnupg mode 700, idempotency
- 99-privileged.sh: pkexec failure propagation