### PR TITLE
fix(ci): add guard against undeclared gitlinks in PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -42,6 +42,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Check for undeclared gitlinks
+        shell: bash
+        env:
+          TARGET_TREEISH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t gitlinks < <(git ls-tree -r --full-tree "$TARGET_TREEISH" | awk '$1 == "160000" {print $4}')
+          if [[ ${#gitlinks[@]} -eq 0 ]]; then
+            exit 0
+          fi
+
+          declared_paths=()
+          if git cat-file -e "$TARGET_TREEISH:.gitmodules" 2>/dev/null; then
+            mapfile -t declared_paths < <(git config --blob "$TARGET_TREEISH:.gitmodules" --get-regexp '^submodule\..*\.path$' | awk '{print $2}')
+          fi
+
+          dangling=()
+          for path in "${gitlinks[@]}"; do
+            if ! printf '%s\n' "${declared_paths[@]}" | grep -Fxq -- "$path"; then
+              dangling+=("$path")
+            fi
+          done
+
+          if [[ ${#dangling[@]} -gt 0 ]]; then
+            echo "ERROR: gitlink(s) missing .gitmodules entries:"
+            printf ' - %s\n' "${dangling[@]}"
+            exit 1
+          fi
+
       - name: Validate
         uses: projectbluefin/actions/bootc-build/validate-pr@v1
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -110,6 +110,7 @@ PR merges to testing
 | Renovate PR not automerging | `PR Validation — testsuite` did not complete successfully | Check `pr-validation.yml`; ensure `validate` job passed |
 | `skill-drift.yml` warning | Workflow/build change without matching `docs/skills/` update | Update the relevant skill file in the same PR |
 | `execute-release.yml` skips | Commit message does not match `^ci\(promote\): bluefin testing` | Message is set by `reusable-promote-squash.yml`; squash-merge the promotion PR correctly |
+| Checkout fails with `No url found for submodule path '.workflow-scripts' in .gitmodules` | A gitlink was committed without a matching `.gitmodules` entry | Remove the stray gitlink (`git rm -f .workflow-scripts`), then verify every remaining mode `160000` path is declared in `.gitmodules` |
 
 ## Non-obvious patterns
 
@@ -117,6 +118,8 @@ PR merges to testing
 - **Merge queue, not auto-merge:** `promote-testing-to-main.yml` uses `use_merge_queue: true` → GraphQL `enqueuePullRequest`. `gh pr merge --auto --squash` is blocked by ruleset 17070404.
 - **`promote-testing-to-main.yml` has 5 triggers:** push to `testing`, daily 23:00 UTC, `workflow_dispatch`, `workflow_run: ["Post-Testing E2E"]` (re-evaluates immediately after e2e), and `pull_request_review: [submitted]` (auto-enqueues after 2nd approval).
 - **`pr-validation.yml` also fires on PRs to `main`** — only to run `check-base-branch` which blocks the PR with an error. Do not bypass.
+- **Gitlinks must be declared:** Bluefin has legitimate submodules under `system_files/shared/...`, so the CI guard in `pr-validation.yml` does **not** ban mode `160000` entries outright. It fails only when a gitlink path is missing from `.gitmodules` (for example a stray `.workflow-scripts` entry).
+- **Guard inspects the PR head tree:** the undeclared-gitlink check reads `github.event.pull_request.head.sha` on PRs instead of the synthetic merge ref, so a testing→main promotion PR can pass once the `testing` head no longer carries the stray gitlink even if `main` still does.
 - **E2E (`testsuite` job) only runs on `merge_group`** — per-push PR CI is fast: `validate` + `unit-tests` only (~2 min).
 - **Unit tests run the whole directory:** `bats --formatter tap tests/unit/` — not a specific file.
 - **`consumer-validate-generate-release-notes.yml` intentionally uses `@v1`** (not SHA-pinned) so action fixes propagate without a Renovate bump. Explicit exception to the SHA-pinning rule.


### PR DESCRIPTION
Multiple workflows (Scorecard, Cache Maintenance) are failing on main with:

fatal: No url found for submodule path '.workflow-scripts' in .gitmodules

The testing branch already lacks .workflow-scripts. Main will be cleaned when the next testing->main squash promotion lands.

This PR adds a guard to pr-validation.yml that rejects PRs introducing undeclared gitlinks (mode 160000 tree entries with no corresponding .gitmodules entry), preventing recurrence.

The guard checks the PR HEAD tree directly, not the merge result, so the promotion PR itself passes cleanly.

Sensitive path: .github/workflows/ — maintainer review required.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>