### PR TITLE
fix(ci): correct execute-release commit message trigger pattern

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -20,7 +20,7 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
           EVENT: ${{ github.event_name }}
         run: |
-          if [ "$EVENT" = "workflow_dispatch" ] || echo "$COMMIT_MSG" | grep -qE "^ci\(promote\): bluefin testing"; then
+          if [ "$EVENT" = "workflow_dispatch" ] || echo "$COMMIT_MSG" | grep -qE "^chore: promote testing to main"; then
             echo "is-promotion=true" >> "$GITHUB_OUTPUT"
           else
             echo "is-promotion=false" >> "$GITHUB_OUTPUT"

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -29,7 +29,7 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 | `consumer-validate-generate-release-notes.yml` | PRs to `testing` touching this file or `docs/skills/ci.md`, dispatch | Contract-tests the shared `generate-release-notes@v1` action from `projectbluefin/actions` |
 | `copr-health-monitor.yml` | Daily 07:00 UTC | COPR staleness check → opens issue on failure |
 | `e2e-dispatch.yml` | `/e2e` comment (write+ only) | Manual E2E trigger on a PR |
-| `execute-release.yml` | Push to `main`, dispatch | Detects promotion by commit message pattern `^ci\(promote\): bluefin testing`; delegates to `reusable-execute-release.yml@v1` → copies `:testing`→`:stable` |
+| `execute-release.yml` | Push to `main`, dispatch | Detects promotion by commit message pattern `^chore: promote testing to main`; delegates to `reusable-execute-release.yml@v1` → copies `:testing`→`:stable` |
 | `moderator.yml` | Issues/comments | AI spam detection |
 | `nightly.yml` | 02:00 UTC daily, dispatch | Runs `smoke,common,vanilla-gnome` suites against `:testing`. Diagnostic: smoke=fail+vanilla-gnome=pass → Bluefin-specific regression; both fail → upstream GNOME issue |
 | `pkg-cadence.yml` | After `Execute Release` completes, dispatch | Measures per-package update frequency after each release via `reusable-pkg-cadence.yml@v1` |
@@ -88,7 +88,7 @@ PR merges to testing
 
 **Key facts:**
 - `:testing` tag is applied by `post-testing-e2e.yml → promote-to-testing` job, and **only** when `head_branch == 'main'` (after a build on `main`, not `testing`)
-- `execute-release.yml` triggers by commit message pattern `^ci\(promote\): bluefin testing`, not a schedule
+- `execute-release.yml` triggers by commit message pattern `^chore: promote testing to main`, not a schedule
 - There is no `weekly-testing-promotion.yml` — that workflow does not exist
 
 ### Testing→main squash history gap
@@ -109,12 +109,13 @@ PR merges to testing
 | `track-common.yml` not firing | `repository_dispatch: common-updated` not sent by `common` | Manual: `gh workflow run track-common.yml --repo projectbluefin/bluefin` |
 | Renovate PR not automerging | `PR Validation — testsuite` did not complete successfully | Check `pr-validation.yml`; ensure `validate` job passed |
 | `skill-drift.yml` warning | Workflow/build change without matching `docs/skills/` update | Update the relevant skill file in the same PR |
-| `execute-release.yml` skips | Commit message does not match `^ci\(promote\): bluefin testing` | Message is set by `reusable-promote-squash.yml`; squash-merge the promotion PR correctly |
+| `execute-release.yml` skips | Commit message does not match `^chore: promote testing to main` | `reusable-promote-squash.yml` sets the promotion branch commit title, and the squash merge reuses that title on `main` |
 | Checkout fails with `No url found for submodule path '.workflow-scripts' in .gitmodules` | A gitlink was committed without a matching `.gitmodules` entry | Remove the stray gitlink (`git rm -f .workflow-scripts`), then verify every remaining mode `160000` path is declared in `.gitmodules` |
 
 ## Non-obvious patterns
 
 - **`:testing` tag assignment:** `build-image-testing.yml` sets `publish_stream_tag: false`. The `:testing` tag is only applied by `post-testing-e2e.yml → promote-to-testing`, and only when `head_branch == 'main'`.
+- **Promotion trigger source:** `execute-release.yml` must match the squash-merged promotion commit title on `main` (`chore: promote testing to main`), not the PR title. `reusable-promote-squash.yml` creates that branch commit title before the PR is opened.
 - **Merge queue, not auto-merge:** `promote-testing-to-main.yml` uses `use_merge_queue: true` → GraphQL `enqueuePullRequest`. `gh pr merge --auto --squash` is blocked by ruleset 17070404.
 - **`promote-testing-to-main.yml` has 5 triggers:** push to `testing`, daily 23:00 UTC, `workflow_dispatch`, `workflow_run: ["Post-Testing E2E"]` (re-evaluates immediately after e2e), and `pull_request_review: [submitted]` (auto-enqueues after 2nd approval).
 - **`pr-validation.yml` also fires on PRs to `main`** — only to run `check-base-branch` which blocks the PR with an error. Do not bypass.

--- a/docs/skills/release.md
+++ b/docs/skills/release.md
@@ -40,7 +40,7 @@ PR merges to testing
 
 `execute-release.yml` has three jobs:
 
-1. **check-trigger** — passes only for promotion commits (`ci(promote): bluefin testing`) or `workflow_dispatch`
+1. **check-trigger** — passes only for promotion commits (`chore: promote testing to main`) or `workflow_dispatch`
 2. **execute** — calls `reusable-execute-release.yml@v1`; cosign-verifies and re-tags images `:testing → :stable`
 3. **release-notes** — calls `reusable-release.yml@v1`; generates SBOM inline, renders release card, creates GitHub Release
 
@@ -87,7 +87,7 @@ gh workflow run execute-release.yml --repo projectbluefin/bluefin --ref main
 
 ## Non-obvious patterns
 
-- `execute-release.yml` trigger: `workflow_dispatch` always passes; push to `main` only passes if commit message matches `^ci\(promote\): bluefin testing`
+- `execute-release.yml` trigger: `workflow_dispatch` always passes; push to `main` only passes if commit message matches `^chore: promote testing to main`
 - `reusable-release.yml` computes tag as `stable-$(date -u +%Y%m%d)`. If a release with that tag already exists (e.g. manually created), `create-release` skips creation silently.
 - The centralized `create-release@v1` renders the full release body: release card, key components table, full SPDX package inventory, supply chain verification. A `post-release-variants` job can prepend the variants table (present in bluefin-lts; removed from bluefin).
 - bluefin-lts uses `image: ghcr.io/projectbluefin/bluefin-lts-hwe` for release notes so the HWE kernel version appears in the key components table.


### PR DESCRIPTION
The check-trigger job grep was matching the PR title format (ci(promote):) rather than the actual squash commit message (chore: promote testing to main) that lands on main.

reusable-promote-squash.yml creates a branch commit titled 'chore: promote ${SOURCE_BRANCH} to ${TARGET_BRANCH}', and squash merge uses that title on the target branch — not the PR title.

This means execute-release was silently skipping legitimate promotions triggered by push events. workflow_dispatch was unaffected.

Verified against recent main branch history: chore: promote testing to main (#630) correctly fired execute-release; manual dispatches were the only working path after that.

Sensitive path: .github/workflows/ — maintainer review required.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
