### PR TITLE
feat(ci): enable E2E release gate for bluefin

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -52,14 +52,8 @@ jobs:
         [{"image":"bluefin"},{"image":"bluefin-nvidia"}]
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
-      run_e2e: false
-      # run_e2e is intentionally false for bluefin. The post-testing-e2e workflow
-      # gates :testing continuously but the gate SHA lookup is broken until the
-      # branches:[main,testing] fix (post-testing-e2e.yml) reaches main via
-      # promotion. Model matches dakota: cosign verification only at the PR gate
-      # level; E2E evidence is gathered separately by post-testing-e2e.yml.
-      # Re-enable once post-testing-e2e reliably files evidence under the testing
-      # branch HEAD SHA. See docs/skills/ci.md and common e2e-ci.md for details.
+      run_e2e: true
+      e2e_suites: smoke,common
       # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked.
       # use_merge_queue: true calls enqueuePullRequest GraphQL instead, which
       # places the PR in the queue and lets it merge once approvals + checks pass.


### PR DESCRIPTION
Enable run_e2e: true in the promote-testing-to-main workflow.

All prerequisites are now met:
- post-testing-e2e.yml on main with branches:[main,testing] trigger (already was correct)
- testsuite action.yml: -type d fix merged (PR projectbluefin/testsuite#518, v1 updated)
- actions reusable-build.yml: SBOM step is non-blocking (PR projectbluefin/actions#284, v1 updated)
- gate SHA lookup in reusable-promote-squash.yml is correct (was never broken)

How the gate will work after this merges:
1. Push to testing branch triggers Testing Images build
2. Testing Images succeeds (SBOM no longer blocks)
3. post-testing-e2e.yml fires, E2E runs smoke+common
4. If E2E passes: digests promoted to :testing, evidence filed at testing HEAD SHA
5. Next promote cycle: gate resolves testing HEAD SHA, finds E2E evidence, clears