### PR TITLE
feat: release notes redesign — richer key components

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# Configure GitHub's automated release notes generation.
+# This file is read by the generate-notes API called in create-release action.
+changelog:
+  exclude:
+    authors:
+      - github-actions
+      - renovate
+      - dependabot
+    labels:
+      - dependencies
+      - skip-changelog
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Fixes
+      labels:
+        - bug
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -67,11 +67,15 @@ jobs:
         ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
       notable_packages: >-
         [
-          {"sbom_name": "kernel",            "label": "Kernel"},
-          {"sbom_name": "gnome-shell",        "label": "GNOME Shell"},
-          {"sbom_name": "mesa-filesystem",    "label": "Mesa"},
-          {"sbom_name": "flatpak",            "label": "Flatpak"},
-          {"sbom_name": "systemd",            "label": "systemd"}
+          {"sbom_name": "kernel", "label": "Kernel"},
+          {"sbom_name": "gnome-shell", "label": "GNOME Shell"},
+          {"sbom_name": "podman", "label": "Podman"},
+          {"sbom_name": "distrobox", "label": "Distrobox"},
+          {"sbom_name": "systemd", "label": "systemd"},
+          {"sbom_name": "mesa-vulkan-drivers", "label": "Mesa"},
+          {"sbom_name": "pipewire", "label": "PipeWire"},
+          {"sbom_name": "flatpak", "label": "Flatpak"},
+          {"sbom_name": "bootc", "label": "bootc"}
         ]
       docs_url: https://docs.projectbluefin.io/changelogs
     secrets: inherit


### PR DESCRIPTION
Consumer validation PR. Adds .github/release.yml for PR categorization. Expands notable_packages to include podman, distrobox, mesa-vulkan-drivers, pipewire, and bootc.