### PR TITLE
docs: final audit — fix remaining stale references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Bluefin bugs are data donations.
 Non-compliance = rejection.
 
 - Read [`docs/SKILL.md`](docs/SKILL.md) before modifying anything.
-- **After cloning, run `bash .github/scripts/install-hooks.sh` once** to install the pre-push hook that blocks accidental pushes to `origin` (ublue-os/bluefin).
+- **After cloning, run `bash .github/scripts/install-hooks.sh` once** to install the pre-push hook that blocks accidental pushes to `origin` (projectbluefin/bluefin).
 - Run `just check && pre-commit run --all-files` before every commit.
 - Never use `git add -A` or `git add .`. After any script execution, build step, or cross-repo checkout:
   `git status`                        # check for unexpected tracked paths

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ Bluefin is [`projectbluefin/bluefin`](https://github.com/projectbluefin/bluefin)
 
 **Read [`docs/SKILL.md`](docs/SKILL.md) before doing any work.** Load only the docs that match the task.
 
+> **Before using any tool or library: look up its docs via Context7 first. Always.**
+> bootc, cosign, skopeo, buildah, GitHub Actions, rpm-ostree — every tool has live, authoritative docs.
+> Pattern: `resolve-library-id` → `get-library-docs` → implement → cite the section.
+> Guessing, flag-hunting, and trial-and-error are banned. The docs exist. Read them.
+
 ## Docs router
 
 - [`docs/SKILL.md`](docs/SKILL.md) — task router

--- a/docs/build.md
+++ b/docs/build.md
@@ -90,7 +90,7 @@ just clean
 |---|---|---|
 | `bluefin` | `testing`, `stable` | `main`, `nvidia` |
 
-`:testing` is built daily from `main`. `:stable` is promoted weekly from `:testing` via `weekly-testing-promotion.yml` after e2e passes.
+`:testing` is built daily from `main`. `:stable` is promoted daily via the automated factory (`promote-testing-to-main.yml` → merge queue → `execute-release.yml`).
 
 ## Package locations
 

--- a/docs/skills/variants.md
+++ b/docs/skills/variants.md
@@ -61,7 +61,7 @@ ghcr.io/projectbluefin/bluefin:stable-nvidia
 
 ## Non-obvious patterns
 
-- This repo builds two streams: `testing` (daily from `main`) and `stable` (weekly gated promotion)
+- This repo builds two streams: `testing` (daily from `main`) and `stable` (daily automated promotion via factory)
 - LTS is a separate repo and workflow model
 - For development, do **not** rely on the VS Code Flatpak; use the Homebrew package instead
 


### PR DESCRIPTION
Three remaining stale lines from docs audit:

- AGENTS.md: origin remote note said ublue-os/bluefin; it points to projectbluefin/bluefin
- docs/build.md: stable stream described as weekly gated via weekly-testing-promotion.yml (doesn't exist)
- docs/skills/variants.md: same weekly gated description

All other ublue-os/ references in skill files are filesystem paths (/usr/share/ublue-os/) or COPR repo names that are correct as-is.