### PR TITLE
fix(release): pass fast_forward_sha to reusable promotion

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -44,6 +44,7 @@ jobs:
           {"image":"bluefin-nvidia","source_tag":"testing","target_tag":"stable"}
         ]
       cosign_identity_regexp: ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
+      fast_forward_sha: ${{ github.event.workflow_run.head_sha || github.sha }}
     secrets: inherit
 
   release-notes:


### PR DESCRIPTION
## Summary

projectbluefin/actions `reusable-execute-release.yml` adds an optional `fast_forward_sha` input that callers should pass to avoid the unsafe `github.sha` fallback and a deprecation warning. Future v2 will make it required.

This PR plumbs `${{ github.event.workflow_run.head_sha || github.sha }}` — `workflow_run.head_sha` is the verified source SHA; `github.sha` is the correct fallback for the `push: main` trigger path bluefin uses.

## Coordination

Depends on projectbluefin/actions PR (backward-compat, safe to merge here first if needed).

Assisted-by: Claude Opus 4.7 via GitHub Copilot