### PR TITLE
fix(release): pass fast_forward_sha to reusable promotion

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -44,6 +44,7 @@ jobs:
           {"image":"bluefin-nvidia","source_tag":"testing","target_tag":"stable"}
         ]
       cosign_identity_regexp: ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
+      fast_forward_sha: ${{ github.event.workflow_run.head_sha || github.sha }}
     secrets: inherit
 
   release-notes:


### PR DESCRIPTION
## Summary

projectbluefin/actions reusable-execute-release adds optional `fast_forward_sha` input. This PR plumbs `${{ github.event.workflow_run.head_sha || github.sha }}` to avoid the unsafe `github.sha` fallback and a deprecation warning.

Replaces #712 (wrong base branch).

Assisted-by: Claude Opus 4.7 via GitHub Copilot