### PR TITLE
fix(ci): exclude main-targeting PRs from remaining pull_request triggers

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -7,6 +7,8 @@ on:
     types: [created]
   pull_request:
     types: [opened]
+    branches-ignore:
+      - main
   schedule:
     - cron: '0 9 * * *'
 

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -3,6 +3,8 @@ name: Validate Renovate Config
 
 on:
   pull_request:
+    branches-ignore:
+      - main
     paths:
       - ".github/renovate.json5"
       - ".github/workflows/renovate.yml"


### PR DESCRIPTION
## Problem

Followup to #717. Code review identified two more workflows with unscoped `pull_request` triggers that can fire on the `auto/promote-testing-to-main` promotion PR (created by GITHUB_TOKEN), producing `action_required` check suites that block the HEADGREEN merge queue.

- `bonedigger.yml`: `pull_request: types: [opened]` with no branch filter — fires when the promotion PR is opened each cycle
- `validate-renovate.yml`: `pull_request: paths: [renovate files]` with no branch filter — fires if a promotion PR ever includes renovate config changes

## Fix

Add `branches-ignore: [main]` to the `pull_request` trigger in both workflows. All legitimate developer PRs target `testing` — no functionality is lost.