### PR TITLE
docs(ci): remove pr-release-gate.yml from pipeline diagram

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -55,8 +55,8 @@ jobs:
       suites: smoke,common
 
   # run-upgrade-test: DISABLED — TODO(#400)
-  # lifecycle suite fails under GNOME 50 AT-SPI changes, marking
-  # post-testing-e2e as 'failure' and blocking weekly-testing-promotion.
+  # lifecycle suite fails under GNOME 50 AT-SPI changes, causing post-testing-e2e
+  # to mark as 'failure' and blocking promotion.
   # Disabled until testsuite lifecycle scenarios are stable on GNOME 50.
   # To restore: uncomment the job below.
   #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ No human approvals required. See [docs/skills/ci.md](docs/skills/ci.md) for the 
 
 | | `:testing` | `:stable` |
 |---|---|---|
-| Built from | `testing` branch | Promoted from `:testing` daily |
-| Published | On every merge to `testing` | Daily automated promotion |
+| Built from | `testing` + `main` branches | Promoted from `:testing` daily |
+| Published | After daily promotion cycle (push to `main` triggers the tag) | Daily automated promotion |
 | Who should use it | Testers, developers | Regular users |
 
 ## Branching for a new Fedora version

--- a/docs/pr-checklist.md
+++ b/docs/pr-checklist.md
@@ -47,7 +47,7 @@
 
 ## CI / workflow changes
 
-- [ ] Trigger branches are intentional (`testing` for PR validation; `main`/`stable`/`latest` where the current image workflows expect them)
+- [ ] Trigger branches are intentional (`testing` for PR validation; `main` for release and promotion workflows)
 - [ ] Action pins stay intact or are updated deliberately
 - [ ] Artifact names, workflow names, and branch filters stay consistent across dependent workflows
 - [ ] E2E (`testsuite` job) is gated to `merge_group` only — never add E2E to per-push PR jobs

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -78,7 +78,7 @@ PR merges to testing
             └─ smoke + common E2E suites run
                  └─ promote-testing-to-main.yml fires (push to testing)
                       └─ reusable-promote-squash.yml opens/updates auto/promote-testing-to-main PR
-                           └─ pr-release-gate.yml: cosign verify gate
+                           └─ cosign verify + smoke,common E2E gate (runs inside reusable-promote-squash.yml)
                                 └─ merge queue: pr-validation.yml runs validate on merge-group → squash-merge to main
                                      └─ execute-release.yml: :testing → :stable
                                      └─ sync-main-to-testing.yml: merges main→testing; deletes promotion branch


### PR DESCRIPTION
docs/skills/ci.md pipeline diagram still referenced pr-release-gate.yml which was deleted in #717. Updated to reflect that the gate runs inside reusable-promote-squash.yml.