### PR TITLE
docs: replace skills/README.md with redirect to SKILL.md

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,23 +1,8 @@
-# docs/skills — In-Repo Skill References
+# docs/skills
 
-Condensed guidance for contributors and agents working in Bluefin.
-Read the matching file before making changes in that area.
+See [`../SKILL.md`](../SKILL.md) for the full routing table — which skill to load for any task.
 
-## Routing Table
-
-| Task | Load |
-|---|---|
-| I need to build, validate, or open a PR | [build.md](build.md) |
-| I need to add, remove, or update packages | [packages.md](packages.md) |
-| I need to debug GitHub Actions or promotions | [ci.md](ci.md) |
-| I need the current image × tag × flavor matrix | [variants.md](variants.md) |
-| I need release or stream promotion workflow details | [release.md](release.md) |
-| I need to handle a Renovate PR or config change | [renovate.md](renovate.md) |
-| I need security rules for COPR, cosign, or secureboot | [security.md](security.md) |
-| I need Bluefin LTS guidance | See `projectbluefin/bluefin-lts` repo |
-| I need ISO build or promotion guidance | [iso.md](iso.md) |
-
-## How to extend these files
+## Extending skill files
 
 1. Update the closest matching skill file.
 2. Keep it short, command-heavy, and repo-specific.


### PR DESCRIPTION
docs/skills/README.md had a routing table that duplicated docs/SKILL.md but was missing 4 entries and would continue to drift. Replaced with a redirect — single source of truth for routing.