### PR TITLE
fix(sbom): add --parallelism 1 to gen-sbom Syft invocation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -712,7 +712,7 @@ gen-sbom $image="bluefin" $tag="testing" $flavor="main" $syft_cmd="syft":
     # Syft reads layer tarballs sequentially so memory usage stays low.
     ${PODMAN} save --format oci-dir -o "${OCI_DIR}" "${image_name}:${tag}"
 
-    ${syft_cmd} --source-name "${image_name}:${tag}" "oci-dir:${OCI_DIR}" -o syft-json="${SBOM}"
+    ${syft_cmd} --source-name "${image_name}:${tag}" "oci-dir:${OCI_DIR}" --parallelism 1 -o syft-json="${SBOM}"
     du -sh "${SBOM}"
 
     rm -rf "${OCI_DIR}"


### PR DESCRIPTION
Prevents concurrent cataloger memory spikes when Syft scans the OCI dir.

Complements projectbluefin/actions#300 which adds `timeout-minutes: 8` and `GOMEMLIMIT=3GiB` to the Generate SBOM step in `reusable-build.yml`.