### PR TITLE
fix(ci): pass explicit credentials to reusable-pkg-cadence

### DIFF
--- a/.github/workflows/pkg-cadence.yml
+++ b/.github/workflows/pkg-cadence.yml
@@ -26,4 +26,6 @@ jobs:
       image: ghcr.io/projectbluefin/bluefin:stable
       repo: projectbluefin/bluefin
       force_reclassify: ${{ inputs.force_reclassify || false }}
-    secrets: inherit
+    secrets:
+      app_id: ${{ secrets.BLUEFINBOT_APP_ID }}
+      private_key: ${{ secrets.BLUEFINBOT_PRIVATE_KEY }}


### PR DESCRIPTION
The reusable-pkg-cadence workflow now accepts parameterized credentials instead of relying on `secrets: inherit` with a hardcoded variable name.

Pass `BLUEFINBOT_APP_ID` and `BLUEFINBOT_PRIVATE_KEY` explicitly. The old approach failed because the reusable hardcoded `vars.MERGERAPTOR_APP_ID` which is not defined in this repo.

This fixes the recurring failure: `The client-id input must be set to a non-empty string.`

Depends on: projectbluefin/actions#302