### PR TITLE
fix: use generate_sbom_inline for release notes to avoid testing build SBOM OOM

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -59,9 +59,7 @@ jobs:
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/bluefin
-      build_workflow: build-image-testing.yml
-      build_branch: testing
-      sbom_artifact: sbom-bluefin
+      generate_sbom_inline: true
       checkout_ref: main
       project_name: Bluefin
       badge_label: Stable


### PR DESCRIPTION
Switch execute-release.yml to generate SBOM inline at release time from the :stable image rather than downloading from testing build artifacts.

Root cause: Syft OOM-kills the testing build runner (~7 min scan of the full OCI image). Even with GOMEMLIMIT=3GiB, the runner VM is killed because Syft mmaps the entire OCI layer set, bypassing Go heap limits.

Changes:
- Remove build_workflow, build_branch, sbom_artifact inputs (artifact download path)
- Add generate_sbom_inline: true (reusable-release.yml generates SBOM from :stable at release time)
- Produces correct SPDX JSON format instead of Syft JSON (artifact path bug)

bluefin-lts already uses generate_sbom_inline: true. This brings bluefin in line.

Part of factory runner crash repair sprint.