### PR TITLE
fix(gnome): copy extension schemas system-wide for overrides

### DIFF
--- a/build_files/shared/build-gnome-extensions.sh
+++ b/build_files/shared/build-gnome-extensions.sh
@@ -45,6 +45,9 @@ glib-compile-schemas --strict /usr/share/gnome-shell/extensions/custom-command-l
 # Search Light
 glib-compile-schemas --strict /usr/share/gnome-shell/extensions/search-light@icedman.github.com/schemas
 
+# Copy all extension schemas to the system-wide schemas directory so they can be overridden system-wide
+find /usr/share/gnome-shell/extensions/ -name "*.gschema.xml" -exec cp -t /usr/share/glib-2.0/schemas/ {} +
+
 rm -rf /usr/share/gnome-shell/extensions/tmp
 
 echo "::endgroup::"


### PR DESCRIPTION
The GSettings overrides in `zz0-bluefin-modifications.gschema.override` (such as `blur=false` for `blur-my-shell`) were silently ignored because `glib-compile-schemas` compiles the main system directory `/usr/share/glib-2.0/schemas/`, but extension schema XML files are only kept inside their local folders.

Without the extension’s `.gschema.xml` file in `/usr/share/glib-2.0/schemas/`, GLib ignores any overrides for that schema.

This PR copies all unzipped GNOME extension `.gschema.xml` files to `/usr/share/glib-2.0/schemas/` during build so system-wide GSettings overrides compile successfully.

Assisted-by: Gemini 3.5 Flash via GitHub Copilot CLI