### PR TITLE
ci(execute-release): enable release e2e gate for stable promotion

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -45,6 +45,8 @@ jobs:
         ]
       cosign_identity_regexp: ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
       fast_forward_sha: ${{ github.event.workflow_run.head_sha || github.sha }}
+      run_release_gate: true
+      gate_suites: smoke,common
     secrets: inherit
 
   release-notes:

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -80,7 +80,7 @@ PR merges to testing
                       └─ reusable-promote-squash.yml opens/updates auto/promote-testing-to-main PR
                            └─ cosign verify + smoke,common E2E gate (runs inside reusable-promote-squash.yml)
                                 └─ merge queue: pr-validation.yml runs validate on merge-group → squash-merge to main
-                                     └─ execute-release.yml: :testing → :stable
+                                     └─ execute-release.yml: resolve digest → testsuite e2e smoke,common against exact digest → :testing → :stable
                                      └─ sync-main-to-testing.yml: merges main→testing; deletes promotion branch
                                           └─ build-image-testing.yml fires on main push
                                                └─ post-testing-e2e.yml (head_branch == 'main'): tags :testing
@@ -89,6 +89,7 @@ PR merges to testing
 **Key facts:**
 - `:testing` tag is applied by `post-testing-e2e.yml → promote-to-testing` job, and **only** when `head_branch == 'main'` (after a build on `main`, not `testing`)
 - `execute-release.yml` triggers by commit message pattern `^chore: promote testing to main`, not a schedule
+- `execute-release.yml` now runs a final testsuite e2e gate (`smoke,common`) against the exact `:testing` digest before retagging it to `:stable`. The gate lives in `projectbluefin/actions/.github/workflows/reusable-execute-release.yml` and can be disabled per-call with `run_release_gate: false`
 - There is no `weekly-testing-promotion.yml` — that workflow does not exist
 
 ### Testing→main squash history gap


### PR DESCRIPTION
## Summary
Pass `run_release_gate=true` and `gate_suites=smoke,common` to `reusable-execute-release.yml@v1` so the exact `:testing` digest is tested before it is retagged to `:stable`.

Depends on projectbluefin/actions#319.

## Security review requested
- **New/changed permissions:** caller already grants `packages: write`; no new permissions added in this repo.
- **New cross-repo workflow calls:** none added directly — still calls `projectbluefin/actions/.github/workflows/reusable-execute-release.yml@v1`. That reusable now calls `projectbluefin/testsuite/.github/workflows/e2e.yml@e59bc86ecb444b84854b17ae063aa874f0c80d90` (# v1, matches this repo's `run-testsuite.yml` pin).
- **Secrets usage:** unchanged; `secrets: inherit` already used.
- **Behavior change:** stable releases now block on a passing testsuite e2e gate by default.

## Verification
- actionlint: passed
- pre-commit: passed
- `just check`: passed
- Standalone digest-resolve + testsuite e2e run (digest gate): https://github.com/projectbluefin/actions/actions/runs/29705682267
  - Result: cancelled after common shards failed with `error: Installing to disk: bootupd is required for ostree-based installs`.
- Standalone tag-only comparison run: https://github.com/projectbluefin/actions/actions/runs/29707345715
  - Result: cancelled after the same `bootupd is required` failure.
- Digest-ref assessment: digest-pinned and tag-only invocations fail identically, so the digest reference itself is not the cause. The current `bluefin:testing` candidate is red in testsuite e2e because of a pre-existing bootc/bootupd environment issue, which the gate correctly catches.

## Out-of-org consumer impact
This change is scoped to projectbluefin/bluefin. Aurora/bazzite use ublue-os workflows and are unaffected.
