### PR TITLE
test: cover GNOME extension build stages

### DIFF
--- a/tests/unit/build-gnome-extensions_test.bats
+++ b/tests/unit/build-gnome-extensions_test.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/build-gnome-extensions.sh.
+# Run with: bats tests/unit/build-gnome-extensions_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+SOURCE_SCRIPT="${SCRIPT_DIR}/../../build_files/shared/build-gnome-extensions.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/build-gnome-extensions.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    COMMAND_LOG="${TEST_ROOT}/commands.log"
+    mkdir -p "${STUB_BIN}"
+    export PATH="${STUB_BIN}:${PATH}"
+    export COMMAND_LOG
+
+    for command in glib-compile-schemas make unzip mv rm meson gradia-build; do
+        cat > "${STUB_BIN}/${command}" <<'EOF'
+#!/usr/bin/bash
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${COMMAND_LOG}"
+exit 0
+EOF
+        chmod +x "${STUB_BIN}/${command}"
+    done
+
+    PATCHED_SCRIPT="${TEST_ROOT}/build-gnome-extensions-patched.sh"
+    sed "s|bash /usr/share/gnome-shell/extensions/gradia-integration@alexandervanhee.github.io/build.sh|gradia-build|" \
+        "${SOURCE_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+    export PATCHED_SCRIPT
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+@test "build-gnome-extensions: compiles schemas and runs extension build tools" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q '^glib-compile-schemas ' "${COMMAND_LOG}"
+    grep -q '^make ' "${COMMAND_LOG}"
+    grep -q '^unzip ' "${COMMAND_LOG}"
+    grep -q '^meson setup ' "${COMMAND_LOG}"
+    grep -q '^meson install ' "${COMMAND_LOG}"
+    grep -q '^gradia-build ' "${COMMAND_LOG}"
+}
+
+@test "build-gnome-extensions: removes the temporary extension tree" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q '^rm -rf /usr/share/gnome-shell/extensions/tmp$' "${COMMAND_LOG}"
+}
+
+@test "build-gnome-extensions: fails when a build command fails" {
+    cat > "${STUB_BIN}/make" <<'EOF'
+#!/usr/bin/bash
+exit 1
+EOF
+    chmod +x "${STUB_BIN}/make"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}

--- a/tests/unit/finalize-gnome-extensions_test.bats
+++ b/tests/unit/finalize-gnome-extensions_test.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/finalize-gnome-extensions.sh.
+# Run with: bats tests/unit/finalize-gnome-extensions_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+SOURCE_SCRIPT="${SCRIPT_DIR}/../../build_files/shared/finalize-gnome-extensions.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/finalize-gnome-extensions.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    COMMAND_LOG="${TEST_ROOT}/commands.log"
+    mkdir -p "${STUB_BIN}"
+    export PATH="${STUB_BIN}:${PATH}"
+    export COMMAND_LOG
+
+    for command in rm glib-compile-schemas setfattr; do
+        cat > "${STUB_BIN}/${command}" <<'EOF'
+#!/usr/bin/bash
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${COMMAND_LOG}"
+exit 0
+EOF
+        chmod +x "${STUB_BIN}/${command}"
+    done
+
+    PATCHED_SCRIPT="${TEST_ROOT}/finalize-gnome-extensions-patched.sh"
+    sed \
+        -e "s|/usr/share/glib-2.0/schemas|${TEST_ROOT}/usr/share/glib-2.0/schemas|g" \
+        -e "s|/usr/share/gnome-shell/extensions|${TEST_ROOT}/usr/share/gnome-shell/extensions|g" \
+        "${SOURCE_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+    export PATCHED_SCRIPT
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+@test "finalize-gnome-extensions: recompiles shared schemas" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q "^rm -f ${TEST_ROOT}/usr/share/glib-2.0/schemas/gschemas.compiled$" "${COMMAND_LOG}"
+    grep -q "^glib-compile-schemas ${TEST_ROOT}/usr/share/glib-2.0/schemas$" "${COMMAND_LOG}"
+}
+
+@test "finalize-gnome-extensions: assigns the rechunker component" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+    grep -q "^setfattr -n user.component -v gnome-extensions ${TEST_ROOT}/usr/share/gnome-shell/extensions/$" "${COMMAND_LOG}"
+}
+
+@test "finalize-gnome-extensions: fails when schema compilation fails" {
+    cat > "${STUB_BIN}/glib-compile-schemas" <<'EOF'
+#!/usr/bin/bash
+exit 1
+EOF
+    chmod +x "${STUB_BIN}/glib-compile-schemas"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## What problem are you solving?

Add unit coverage for the two GNOME extension scripts that are actively invoked by the image build. The legacy `build_files/shared/build.sh` remains intentionally out of scope because the repository documents it as unused.

Closes the actionable portion of #680.

## Changes

- Add Bats coverage for `build-gnome-extensions.sh`:
  - schema compilation
  - build-tool invocation
  - temporary-tree cleanup
  - failure propagation
- Add Bats coverage for `finalize-gnome-extensions.sh`:
  - schema recompilation
  - rechunker component tagging
  - failure propagation

## Testing

- `bats tests/unit/build-gnome-extensions_test.bats tests/unit/finalize-gnome-extensions_test.bats`
- `bats tests/unit/` (existing unrelated `20-framework_test.bats` fails because its source hook is absent on `testing`)
- `pre-commit run --all-files`
- `just check`
