### PR TITLE
feat: Apple Silicon (Asahi) flavor — bluefin-asahi (aarch64)

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -72,3 +72,28 @@ jobs:
       stream_name: testing
       publish_stream_tag: "false"
       pr_number: ${{ inputs.pr_number }}
+
+  build-image-testing-asahi:
+    name: Build Testing Images (Asahi)
+    needs: [detect-changes]
+    # Apple Silicon flavor: aarch64 only (the build script hard-guards),
+    # separate call so the main x86_64 matrix never sees the asahi flavor.
+    if: |
+      always() &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main' || inputs.pr_number != '') &&
+      (github.event_name != 'pull_request' ||
+       needs.detect-changes.outputs.should_build == 'true')
+    uses: projectbluefin/actions/.github/workflows/reusable-build.yml@v1
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+      issues: write
+    with:
+      image_flavors: '["asahi"]'
+      architecture: '["aarch64"]'
+      stream_name: testing
+      publish_stream_tag: "false"
+      pr_number: ${{ inputs.pr_number }}

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@ images := '(
 flavors := '(
     [main]=main
     [nvidia]=nvidia
+    [asahi]=asahi
 )'
 tags := '(
     [testing]=testing

--- a/build_files/base/04-install-kernel-akmods.sh
+++ b/build_files/base/04-install-kernel-akmods.sh
@@ -14,6 +14,57 @@ for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-
     rpm --erase $pkg --nodeps
 done
 
+# ── Apple Silicon (Asahi) flavor ─────────────────────────────────────────────
+# The asahi flavor swaps the ublue/CoreOS kernel machinery for the Fedora
+# Asahi Remix stack: 16K-page asahi kernel + platform userspace from the
+# @asahi COPRs (same package set as fedora-asahi-remix-atomic-desktops).
+# aarch64 only; akmods (nvidia/zfs) do not apply on Apple Silicon.
+if [[ "${IMAGE_NAME}" =~ asahi ]]; then
+    if [[ "$(uname -m)" != "aarch64" ]]; then
+        echo "ERROR: the asahi flavor only builds on aarch64" >&2
+        exit 1
+    fi
+    # Branding COPR carries the GPG keys; asahi-repos lays down the full set.
+    dnf5 -y copr enable @asahi/fedora-remix-branding
+    dnf5 -y install asahi-repos
+    dnf5 -y install kernel-16k kernel-16k-modules-extra \
+        asahi-platform-metapackage \
+        alsa-ucm-asahi tiny-dfr \
+        grub2-efi-aa64-modules uboot-images-armv8 \
+        asahi-fwupdate dracut-asahi update-m1n1
+    dnf5 versionlock add kernel-16k kernel-16k-modules-extra || true
+
+    KVER=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1 | xargs basename)
+    case "$KVER" in
+    *asahi* | *16k*) ;;
+    *)
+        echo "ERROR: newest kernel '${KVER}' is not an asahi/16k build" >&2
+        exit 1
+        ;;
+    esac
+    ls "/usr/lib/modules/${KVER}/dtb/apple/" >/dev/null 2>&1 || {
+        echo "ERROR: no Apple DTBs in /usr/lib/modules/${KVER}/dtb" >&2
+        exit 1
+    }
+
+    # boot.bin lifecycle on bootc: package scriptlets never run on deploys,
+    # so update-m1n1 must be re-driven by this Apple-DT-gated oneshot
+    # (no-op off Apple hardware). Pinned from tuna-os/bootc-installer-asahi.
+    BOOTBIN_SYNC_REF=b263b74083d8000736aef7fbb2bf20e610ebbca0
+    BOOTBIN_URL="https://raw.githubusercontent.com/tuna-os/bootc-installer-asahi/${BOOTBIN_SYNC_REF}/components/asahi-bootbin-sync"
+    install -d /usr/libexec /usr/lib/systemd/system /usr/lib/systemd/system-preset
+    ghcurl "${BOOTBIN_URL}/asahi-bootbin-sync.sh" --retry 3 -Lo /usr/libexec/asahi-bootbin-sync
+    chmod 0755 /usr/libexec/asahi-bootbin-sync
+    ghcurl "${BOOTBIN_URL}/asahi-bootbin-sync.service" --retry 3 -Lo /usr/lib/systemd/system/asahi-bootbin-sync.service
+    grep -q "ExecStart=/usr/libexec/asahi-bootbin-sync" /usr/lib/systemd/system/asahi-bootbin-sync.service
+    printf 'enable asahi-bootbin-sync.service\n' >/usr/lib/systemd/system-preset/90-asahi-bootbin-sync.preset
+    install -d /usr/lib/systemd/system/multi-user.target.wants
+    ln -sf ../asahi-bootbin-sync.service /usr/lib/systemd/system/multi-user.target.wants/asahi-bootbin-sync.service
+
+    echo "::endgroup::"
+    exit 0
+fi
+
 # Fetch Common AKMODS & Kernel RPMS
 # Pull large OCI artifacts in parallel before any RPM installs.
 declare -A PULL_PIDS


### PR DESCRIPTION
Makes Bluefin bootable on M1/M2 Macs via the Fedora Asahi Remix stack (@asahi COPRs) — the companion to projectbluefin/bluefin-lts#448, both ported from the tuna-os overlay that produced the first promoted TunaOS asahi image earlier today (35/35 on the Asahi verify harness; installer payload boots U-Boot EFI → GNOME userspace in QEMU).

**Kernel path:** the asahi flavor branches out of `04-install-kernel-akmods.sh` before any akmods machinery: `@asahi/fedora-remix-branding` COPR → `asahi-repos` → `kernel-16k` + `asahi-platform-metapackage` + `alsa-ucm-asahi`/`tiny-dfr` + `uboot-images-armv8` (apple_m1 U-Boot payload) + `asahi-fwupdate`/`dracut-asahi`/`update-m1n1` — the same set Fedora Asahi Remix atomic desktops use. Hard asserts on the 16K asahi kernel and Apple DTBs in the modules tree. The existing `19-initramfs.sh` dracut rebuild picks up dracut-asahi's ESP vendor-firmware modules.

**boot.bin lifecycle:** ships `asahi-bootbin-sync` (pinned from tuna-os/bootc-installer-asahi) — bootc deploys never run package scriptlets, so update-m1n1 otherwise never re-runs after `bootc upgrade`. Apple-DT-gated; no-op off Apple hardware.

**Wiring:** `asahi` in the Justfile flavor map; a **separate reusable-build call** in build-image-testing.yml with `architecture: ["aarch64"]` so the x86_64 matrix never sees the flavor (the script hard-guards non-aarch64 anyway). `ghcr.io/ublue-os/akmods` is already multiarch, so shared plumbing is unaffected; nvidia/zfs akmods simply don't apply on Apple Silicon.

**Open questions for review:**
- Flavor naming: this follows the repo's flavor→image-name convention (`bluefin-asahi`, like `bluefin-nvidia`). The TunaOS-side rule is 'asahi is a tag suffix' — happy to rework if you want tag-suffix semantics here instead.
- First aarch64 leg for this repo: the asahi call is scoped so nothing else changes, but the reusable workflow's aarch64 runner path gets its first bluefin exercise.
- No ISO/installer path — Apple Silicon cannot external-boot; installs go through the asahi-installer flow (tuna-os/bootc-installer-asahi).

Part of the Apple Silicon effort tracked at tuna-os/tunaOS#781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ