### PR TITLE
ci(lab): publish PR results through MergeRaptor

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -1,0 +1,119 @@
+name: Lab check
+
+on:
+  repository_dispatch:
+    types: [lab-check]
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    name: Update MergeRaptor check
+    if: >-
+      github.event.client_payload.repository == github.repository &&
+      github.event.client_payload.sha != ''
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get MergeRaptor token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          permission-checks: write
+          permission-contents: read
+
+      - name: Create or update lab check
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.event.client_payload.sha }}
+          CHECK_JSON: ${{ toJSON(github.event.client_payload.check) }}
+        run: |
+          set -euo pipefail
+
+          PRODUCT="${GITHUB_REPOSITORY#*/}"
+          CHECK_NAME="testing-lab / ${PRODUCT}"
+          APP_SLUG="mergeraptor"
+
+          if [[ ! "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid commit SHA: ${SHA}" >&2
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}" >/dev/null
+
+          STATE=$(jq -r '.state // empty' <<<"${CHECK_JSON}")
+          case "${STATE}" in
+            queued|in_progress|completed) ;;
+            *)
+              echo "Invalid check state: ${STATE}" >&2
+              exit 1
+              ;;
+          esac
+
+          CONCLUSION=$(jq -r '.conclusion // empty' <<<"${CHECK_JSON}")
+          if [[ "${STATE}" == "completed" ]]; then
+            case "${CONCLUSION}" in
+              success|failure|neutral|cancelled|timed_out|action_required|skipped|stale) ;;
+              *)
+                echo "Invalid completed conclusion: ${CONCLUSION}" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          DETAILS_URL=$(jq -r '.details_url // empty' <<<"${CHECK_JSON}")
+          EXTERNAL_ID=$(jq -r '.external_id // empty' <<<"${CHECK_JSON}")
+          TITLE=$(jq -r '(.title // "Lab validation")[0:255]' <<<"${CHECK_JSON}")
+          SUMMARY=$(jq -r '(.summary // "No lab summary was provided.")[0:60000]' <<<"${CHECK_JSON}")
+          TEXT=$(jq -r '(.text // "")[0:60000]' <<<"${CHECK_JSON}")
+          STARTED_AT=$(jq -r '.started_at // empty' <<<"${CHECK_JSON}")
+          COMPLETED_AT=$(jq -r '.completed_at // empty' <<<"${CHECK_JSON}")
+
+          CHECK_ID=$(
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
+              -f per_page=100 \
+              --jq '.check_runs
+                | map(select(.name == "'"${CHECK_NAME}"'" and .app.slug == "'"${APP_SLUG}"'"))
+                | sort_by(.id)
+                | last
+                | .id // empty'
+          )
+
+          BODY=$(
+            jq -n \
+              --arg name "${CHECK_NAME}" \
+              --arg head_sha "${SHA}" \
+              --arg details_url "${DETAILS_URL}" \
+              --arg external_id "${EXTERNAL_ID}" \
+              --arg status "${STATE}" \
+              --arg conclusion "${CONCLUSION}" \
+              --arg started_at "${STARTED_AT}" \
+              --arg completed_at "${COMPLETED_AT}" \
+              --arg title "${TITLE}" \
+              --arg summary "${SUMMARY}" \
+              --arg text "${TEXT}" \
+              '{
+                name: $name,
+                head_sha: $head_sha,
+                status: $status,
+                output: {title: $title, summary: $summary, text: $text}
+              }
+              + if $details_url != "" then {details_url: $details_url} else {} end
+              + if $external_id != "" then {external_id: $external_id} else {} end
+              + if $started_at != "" then {started_at: $started_at} else {} end
+              + if $status == "completed" then {conclusion: $conclusion} else {} end
+              + if $status == "completed" and $completed_at != "" then {completed_at: $completed_at} else {} end'
+          )
+
+          if [[ -n "${CHECK_ID}" ]]; then
+            jq 'del(.head_sha)' <<<"${BODY}" |
+              gh api --method PATCH \
+                "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_ID}" \
+                --input - >/dev/null
+          else
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/check-runs" \
+              --input - <<<"${BODY}" >/dev/null
+          fi

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -6,6 +6,8 @@ metadata:
     - .github/workflows/
     - .github/workflows/pr-validation.yml
     - .github/workflows/build-image-testing.yml
+  context7-sources:
+    - /websites/github_en_actions
 ---
 
 # CI

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -32,6 +32,14 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 Read the actual workflow before describing or changing its behavior. Shared
 logic belongs in the reusable workflow that owns it; callers should stay thin.
 
+Every open Bluefin PR is discovered by the lab's five-minute PR poller. The lab
+runs smoke QA against `bluefin:testing` and sends bounded
+`repository_dispatch` lifecycle events to `.github/workflows/lab-check.yml`.
+That workflow must exist on the default branch and uses a short-lived
+MergeRaptor installation token to update one `testing-lab / bluefin` Check Run
+for the exact PR head SHA. Do not duplicate the result in a PR comment or commit
+status.
+
 ## Hard rules
 
 - Verify the pull request base branch before debugging missing checks.
@@ -78,3 +86,4 @@ Read the affected YAML, identify the owning reusable workflow, validate locally.
 ## Red Flags
 
 - Changing a caller when the behavior belongs in shared workflow logic.
+- Posting a lab result as a PR comment instead of updating the MergeRaptor Check Run.


### PR DESCRIPTION
## Summary

- add the default-branch `repository_dispatch` bridge for lab lifecycle events
- mint a least-privilege MergeRaptor token with `checks: write` and `contents: read`
- create or update one `testing-lab / bluefin` Check Run for the exact PR head SHA
- document the no-comment native Checks feedback path

The lab polls every open Bluefin PR every five minutes and runs smoke QA against the current `bluefin:testing` image. Detailed workflow timings, node placement, restart counts, and failure diagnostics appear in the Check Run without duplicating PR comments.

## Deployment order

Merge this default-branch workflow before projectbluefin/lab#397 is deployed. GitHub only triggers `repository_dispatch` workflows that exist on the default branch.

MergeRaptor `checks: write` approval is tracked in projectbluefin/common#865.

## Validation

- `just check`
- `pre-commit run --all-files`
- `actionlint .github/workflows/lab-check.yml`
