### PR TITLE
fix(hardware): mitigate Framework Core Ultra ucsi_acpi s2idle resume failures

### DIFF
--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/11-framework-ucsi-workaround.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/11-framework-ucsi-workaround.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+
+# shellcheck source=/dev/null
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script framework-ucsi-workaround privileged 1 || exit 0
+
+set -euo pipefail
+
+VENDOR_PATH="/sys/devices/virtual/dmi/id/chassis_vendor"
+PRODUCT_PATH="/sys/devices/virtual/dmi/id/product_name"
+WORKAROUND_KARG="usbcore.autosuspend=-1"
+
+if [[ ! -r "${VENDOR_PATH}" || ! -r "${PRODUCT_PATH}" ]]; then
+    echo "Framework UCSI workaround skipped: DMI information not available."
+    exit 0
+fi
+
+vendor="$(<"${VENDOR_PATH}")"
+product_name="$(<"${PRODUCT_PATH}")"
+
+if [[ "${vendor}" != "Framework" ]]; then
+    exit 0
+fi
+
+if [[ ! "${product_name}" =~ Intel\ Core\ Ultra ]]; then
+    exit 0
+fi
+
+if ! command -v rpm-ostree >/dev/null 2>&1; then
+    echo "Warning: rpm-ostree not found; unable to apply Framework UCSI workaround."
+    exit 0
+fi
+
+if rpm-ostree kargs | grep -Fq "${WORKAROUND_KARG}"; then
+    echo "Framework UCSI workaround already configured: ${WORKAROUND_KARG}"
+    exit 0
+fi
+
+rpm-ostree kargs --append-if-missing="${WORKAROUND_KARG}"
+echo "Applied Framework UCSI workaround (${WORKAROUND_KARG}). Reboot to activate."

--- a/tests/unit/11-framework-ucsi-workaround_test.bats
+++ b/tests/unit/11-framework-ucsi-workaround_test.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Unit tests for system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/11-framework-ucsi-workaround.sh
+# Run with: bats tests/unit/11-framework-ucsi-workaround_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+HOOK_SCRIPT="${SCRIPT_DIR}/../../system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/11-framework-ucsi-workaround.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/11-framework-ucsi-workaround.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    mkdir -p "${STUB_BIN}"
+    export PATH="${STUB_BIN}:${PATH}"
+
+    cat > "${STUB_BIN}/rpm-ostree" <<EOF
+#!/usr/bin/bash
+echo "rpm-ostree \$*" >> "${STUB_BIN}/rpm-ostree.log"
+if [[ "\$1" == "kargs" && "\$#" -eq 1 ]]; then
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm-ostree"
+
+    PATCHED_SCRIPT="${TEST_ROOT}/11-framework-ucsi-workaround-patched.sh"
+    sed \
+        -e "s|source /usr/lib/ublue/setup-services/libsetup.sh|version-script() { return 0; }|g" \
+        -e "s|/sys/devices/virtual/dmi/id/chassis_vendor|${TEST_ROOT}/chassis_vendor|g" \
+        -e "s|/sys/devices/virtual/dmi/id/product_name|${TEST_ROOT}/product_name|g" \
+        "${HOOK_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+    export PATCHED_SCRIPT TEST_ROOT STUB_BIN
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+@test "11-framework-ucsi-workaround: non-Framework systems are skipped" {
+    echo "ACME Corp" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (Intel Core Ultra Series 1)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "${STUB_BIN}/rpm-ostree.log" ]
+}
+
+@test "11-framework-ucsi-workaround: Framework Core Ultra systems append autosuspend karg" {
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (Intel Core Ultra Series 1)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    grep -q "kargs --append-if-missing=usbcore.autosuspend=-1" "${STUB_BIN}/rpm-ostree.log"
+    [[ "$output" == *"Applied Framework UCSI workaround"* ]]
+}
+
+@test "11-framework-ucsi-workaround: existing autosuspend karg is not appended again" {
+    cat > "${STUB_BIN}/rpm-ostree" <<EOF
+#!/usr/bin/bash
+echo "rpm-ostree \$*" >> "${STUB_BIN}/rpm-ostree.log"
+if [[ "\$1" == "kargs" && "\$#" -eq 1 ]]; then
+    echo "quiet usbcore.autosuspend=-1"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm-ostree"
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (Intel Core Ultra Series 1)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already configured"* ]]
+    ! grep -q -- "--append-if-missing" "${STUB_BIN}/rpm-ostree.log"
+}
+
+@test "11-framework-ucsi-workaround: missing rpm-ostree exits with warning" {
+    rm -f "${STUB_BIN}/rpm-ostree"
+    export PATH="${STUB_BIN}:/usr/bin:/bin"
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (Intel Core Ultra Series 1)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning: rpm-ostree not found"* ]]
+}


### PR DESCRIPTION
## Summary
- Add a privileged setup hook that applies usbcore.autosuspend=-1 on Framework Intel Core Ultra systems.
- Keep the workaround hardware-scoped and idempotent.
- Add unit tests for skip/apply/idempotent/missing-rpm-ostree behavior.

## Why
This mitigates issue #231 (ucsi_acpi resume escalation on Framework 13 Intel Core Ultra) while upstream kernel fixes are tracked.

Fixes projectbluefin/bluefin#231

## Validation
- bash -n system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/11-framework-ucsi-workaround.sh
- bats tests/unit/11-framework-ucsi-workaround_test.bats (blocked locally: bats not installed)
- just check (blocked locally: just not installed)
- pre-commit run --all-files (blocked locally: toolchain unavailable)