### PR TITLE
feat(ci): add BATS coverage reporting artifacts

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -153,14 +153,20 @@ jobs:
           export PATH="${GITHUB_WORKSPACE}/tests/coverage/bin:${PATH}"
           mkdir -p "${KCOV_RAW_DIR}"
 
+          # The instrumented rerun exists to collect coverage; the "Run unit
+          # tests" step above owns pass/fail, so a failing test must not mask
+          # the coverage report.
+          coverage_status=0
           kcov \
             --bash-method=DEBUG \
             --bash-parse-files-in-dir="${INCLUDE_PATHS}" \
             --include-path="${INCLUDE_PATHS}" \
             --exclude-path="${EXCLUDE_PATHS}" \
             "${KCOV_RAW_DIR}/top" \
-            bash -c 'exec bats --formatter tap tests/unit/ > coverage/bats-coverage-run.tap 2>&1'
-          tail -n 20 coverage/bats-coverage-run.tap
+            bash -c 'exec bats --formatter tap tests/unit/ > coverage/bats-coverage-run.tap 2>&1' \
+            || coverage_status=$?
+          echo "instrumented bats exit status: ${coverage_status}"
+          grep -c '^ok' coverage/bats-coverage-run.tap
           python3 tests/coverage/merge_kcov.py \
             --raw-dir "${KCOV_RAW_DIR}" \
             --output-dir coverage/kcov \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -79,18 +79,31 @@ jobs:
     needs: [check-base-branch]
     if: always() && (needs.check-base-branch.result == 'success' || needs.check-base-branch.result == 'skipped')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Install bats
-        run: sudo apt-get install -y bats
+      - name: Install unit test tools
+        run: sudo apt-get install -y bats kcov
 
       - name: Run unit tests
         run: bats --formatter tap tests/unit/ | tee results.tap
+
+      - name: Generate BATS coverage report
+        env:
+          INCLUDE_PATHS: ${{ github.workspace }}/build_files,${{ github.workspace }}/system_files
+          EXCLUDE_PATHS: ${{ github.workspace }}/tests,${{ github.workspace }}/.github
+        run: |
+          mkdir -p coverage/kcov
+          kcov \
+            --bash-method=DEBUG \
+            --include-path="${INCLUDE_PATHS}" \
+            --exclude-path="${EXCLUDE_PATHS}" \
+            coverage/kcov \
+            bats tests/unit/
 
       - name: Upload TAP results
         if: always()
@@ -98,6 +111,16 @@ jobs:
         with:
           name: bats-tap-results
           path: results.tap
+
+      - name: Upload BATS coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bats-kcov-report
+          path: coverage/kcov
+
+      - name: Run Python unit tests
+        run: python3 -m unittest discover -s tests -p 'test_*.py'
 
   testsuite:
     name: E2E smoke

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -87,7 +87,42 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install unit test tools
-        run: sudo apt-get install -y bats kcov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            bats \
+            binutils-dev \
+            build-essential \
+            cmake \
+            libcurl4-openssl-dev \
+            libdw-dev \
+            libelf-dev \
+            libiberty-dev \
+            libssl-dev \
+            zlib1g-dev
+
+      - name: Install kcov
+        env:
+          KCOV_SOURCE_SHA: a39874f938ce13f7a65f253120d1ec946b349ffe # v43
+          KCOV_ARCHIVE_SHA256: dac01569171979477b500924be264d2a1bc649dae6010536228cbb319344d516
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/kcov.tar.gz"
+          source_dir="${RUNNER_TEMP}/kcov-source"
+          build_dir="${RUNNER_TEMP}/kcov-build"
+
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            "https://github.com/SimonKagstrom/kcov/archive/${KCOV_SOURCE_SHA}.tar.gz" \
+            --output "${archive}"
+          echo "${KCOV_ARCHIVE_SHA256}  ${archive}" | sha256sum --check
+
+          mkdir -p "${source_dir}"
+          tar --extract --gzip --file "${archive}" \
+            --directory "${source_dir}" --strip-components=1
+          cmake -S "${source_dir}" -B "${build_dir}" -DCMAKE_BUILD_TYPE=Release
+          cmake --build "${build_dir}" --parallel 2
+          sudo cmake --install "${build_dir}"
+          kcov --version
 
       - name: Run unit tests
         run: bats --formatter tap tests/unit/ | tee results.tap
@@ -97,13 +132,25 @@ jobs:
           INCLUDE_PATHS: ${{ github.workspace }}/build_files,${{ github.workspace }}/system_files
           EXCLUDE_PATHS: ${{ github.workspace }}/tests,${{ github.workspace }}/.github
         run: |
-          mkdir -p coverage/kcov
+          set -euo pipefail
+          export KCOV_REPO_ROOT="${GITHUB_WORKSPACE}"
+          export KCOV_RAW_DIR="${GITHUB_WORKSPACE}/coverage/kcov-raw"
+          export PATH="${GITHUB_WORKSPACE}/tests/coverage/bin:${PATH}"
+          mkdir -p "${KCOV_RAW_DIR}"
+
           kcov \
             --bash-method=DEBUG \
+            --bash-parse-files-in-dirs="${INCLUDE_PATHS}" \
             --include-path="${INCLUDE_PATHS}" \
             --exclude-path="${EXCLUDE_PATHS}" \
-            coverage/kcov \
+            "${KCOV_RAW_DIR}/top" \
             bats tests/unit/
+          python3 tests/coverage/merge_kcov.py \
+            --raw-dir "${KCOV_RAW_DIR}" \
+            --output-dir coverage/kcov \
+            --repo-root "${GITHUB_WORKSPACE}"
+          cat coverage/kcov/summary.md >> "${GITHUB_STEP_SUMMARY}"
+          rm -rf "${KCOV_RAW_DIR}"
 
       - name: Upload TAP results
         if: always()

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -79,7 +79,7 @@ jobs:
     needs: [check-base-branch]
     if: always() && (needs.check-base-branch.result == 'success' || needs.check-base-branch.result == 'skipped')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:
@@ -101,12 +101,26 @@ jobs:
             libssl-dev \
             zlib1g-dev
 
+      - name: Cache kcov build
+        id: kcov-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/bluefin-kcov
+          key: kcov-v43-a39874f-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install kcov
         env:
           KCOV_SOURCE_SHA: a39874f938ce13f7a65f253120d1ec946b349ffe # v43
           KCOV_ARCHIVE_SHA256: dac01569171979477b500924be264d2a1bc649dae6010536228cbb319344d516
         run: |
           set -euo pipefail
+          cache_dir="${HOME}/.cache/bluefin-kcov"
+          if [[ -x "${cache_dir}/usr/local/bin/kcov" ]]; then
+            sudo cp -a "${cache_dir}/usr/local/." /usr/local/
+            kcov --version
+            exit 0
+          fi
+
           archive="${RUNNER_TEMP}/kcov.tar.gz"
           source_dir="${RUNNER_TEMP}/kcov-source"
           build_dir="${RUNNER_TEMP}/kcov-build"
@@ -120,8 +134,9 @@ jobs:
           tar --extract --gzip --file "${archive}" \
             --directory "${source_dir}" --strip-components=1
           cmake -S "${source_dir}" -B "${build_dir}" -DCMAKE_BUILD_TYPE=Release
-          cmake --build "${build_dir}" --parallel 2
-          sudo cmake --install "${build_dir}"
+          cmake --build "${build_dir}" --parallel "$(nproc)"
+          DESTDIR="${cache_dir}" cmake --install "${build_dir}"
+          sudo cp -a "${cache_dir}/usr/local/." /usr/local/
           kcov --version
 
       - name: Run unit tests
@@ -140,11 +155,12 @@ jobs:
 
           kcov \
             --bash-method=DEBUG \
-            --bash-parse-files-in-dirs="${INCLUDE_PATHS}" \
+            --bash-parse-files-in-dir="${INCLUDE_PATHS}" \
             --include-path="${INCLUDE_PATHS}" \
             --exclude-path="${EXCLUDE_PATHS}" \
             "${KCOV_RAW_DIR}/top" \
-            bats tests/unit/
+            bash -c 'exec bats --formatter tap tests/unit/ > coverage/bats-coverage-run.tap 2>&1'
+          tail -n 20 coverage/bats-coverage-run.tap
           python3 tests/coverage/merge_kcov.py \
             --raw-dir "${KCOV_RAW_DIR}" \
             --output-dir coverage/kcov \

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -60,6 +60,8 @@ kcov is not packaged for Ubuntu 24.04, so the job builds v43 from a pinned,
 SHA-256-verified source archive and caches the result. The coverage run must
 redirect BATS output to a file: kcov captures child stdout through a pipe it
 stops draining, so streaming the full TAP log through it deadlocks the job.
+The instrumented rerun does not gate the job — `Run unit tests` owns pass/fail
+— but `merge_kcov.py` fails when no source lines were executed.
 Tests that `source` a library into the BATS process itself are not traced.
 
 Containerfile stages that consume source through bind mounts inherit the mounted

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -51,6 +51,11 @@ Read the actual workflow before describing or changing its behavior. Shared
 logic belongs in the reusable workflow that owns it; callers should stay thin.
 The `unit-tests` job in `pr-validation.yml` runs BATS with kcov and publishes
 `bats-tap-results` plus `bats-kcov-report` artifacts for shell-test visibility.
+Coverage runs route child `bash <script>` calls through
+`tests/coverage/bin/bash`, because wrapping only the top-level BATS process
+does not trace those child shells. The wrapper records each sandbox copy's
+original source path, and `merge_kcov.py` combines those hits with kcov's
+pre-parsed source inventory. A zero-line report is an instrumentation failure.
 
 Containerfile stages that consume source through bind mounts inherit the mounted
 stage's image ID as part of their cache key. Give the package stage its own

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -56,6 +56,11 @@ Coverage runs route child `bash <script>` calls through
 does not trace those child shells. The wrapper records each sandbox copy's
 original source path, and `merge_kcov.py` combines those hits with kcov's
 pre-parsed source inventory. A zero-line report is an instrumentation failure.
+kcov is not packaged for Ubuntu 24.04, so the job builds v43 from a pinned,
+SHA-256-verified source archive and caches the result. The coverage run must
+redirect BATS output to a file: kcov captures child stdout through a pipe it
+stops draining, so streaming the full TAP log through it deadlocks the job.
+Tests that `source` a library into the BATS process itself are not traced.
 
 Containerfile stages that consume source through bind mounts inherit the mounted
 stage's image ID as part of their cache key. Give the package stage its own

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -49,6 +49,8 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 
 Read the actual workflow before describing or changing its behavior. Shared
 logic belongs in the reusable workflow that owns it; callers should stay thin.
+The `unit-tests` job in `pr-validation.yml` runs BATS with kcov and publishes
+`bats-tap-results` plus `bats-kcov-report` artifacts for shell-test visibility.
 
 Containerfile stages that consume source through bind mounts inherit the mounted
 stage's image ID as part of their cache key. Give the package stage its own

--- a/tests/coverage/bin/bash
+++ b/tests/coverage/bin/bash
@@ -3,8 +3,11 @@ set -euo pipefail
 
 real_bash="/usr/bin/bash"
 
+kcov_bin="$(command -v kcov || true)"
+
 if [[ "${KCOV_ACTIVE:-}" == "1" || -z "${KCOV_RAW_DIR:-}" ||
-    -z "${KCOV_REPO_ROOT:-}" || $# -eq 0 || "$1" == -* || ! -f "$1" ]]; then
+    -z "${KCOV_REPO_ROOT:-}" || -z "${kcov_bin}" || ! -d "${KCOV_RAW_DIR}" ||
+    $# -eq 0 || "$1" == -* || ! -f "$1" ]]; then
     exec "${real_bash}" "$@"
 fi
 
@@ -35,7 +38,7 @@ fi
 run_dir="$(mktemp -d "${KCOV_RAW_DIR}/run.XXXXXX")"
 printf '%s\n' "${source_path}" > "${run_dir}/source-path"
 shift
-exec env KCOV_ACTIVE=1 kcov \
+exec env KCOV_ACTIVE=1 "${kcov_bin}" \
     --bash-method=DEBUG \
     --include-path="$(dirname "${script}"),${KCOV_REPO_ROOT}/build_files,${KCOV_REPO_ROOT}/system_files" \
     --exclude-path="${KCOV_REPO_ROOT}/.github" \

--- a/tests/coverage/bin/bash
+++ b/tests/coverage/bin/bash
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+real_bash="/usr/bin/bash"
+
+if [[ "${KCOV_ACTIVE:-}" == "1" || -z "${KCOV_RAW_DIR:-}" ||
+    -z "${KCOV_REPO_ROOT:-}" || $# -eq 0 || "$1" == -* || ! -f "$1" ]]; then
+    exec "${real_bash}" "$@"
+fi
+
+script="$(realpath "$1")"
+source_path=""
+
+case "${script}" in
+    "${KCOV_REPO_ROOT}"/build_files/* | "${KCOV_REPO_ROOT}"/system_files/*)
+        source_path="${script}"
+        ;;
+    "${KCOV_REPO_ROOT}"/tests/unit/.bats-sandbox/*)
+        source_name="$(basename "${script}")"
+        source_name="${source_name/-patched/}"
+        mapfile -t source_matches < <(
+            find "${KCOV_REPO_ROOT}/build_files" "${KCOV_REPO_ROOT}/system_files" \
+                -type f -name "${source_name}" -print
+        )
+        if [[ ${#source_matches[@]} -eq 1 ]]; then
+            source_path="$(realpath "${source_matches[0]}")"
+        fi
+        ;;
+esac
+
+if [[ -z "${source_path}" ]]; then
+    exec "${real_bash}" "$@"
+fi
+
+run_dir="$(mktemp -d "${KCOV_RAW_DIR}/run.XXXXXX")"
+printf '%s\n' "${source_path}" > "${run_dir}/source-path"
+shift
+exec env KCOV_ACTIVE=1 kcov \
+    --bash-method=DEBUG \
+    --include-path="$(dirname "${script}"),${KCOV_REPO_ROOT}/build_files,${KCOV_REPO_ROOT}/system_files" \
+    --exclude-path="${KCOV_REPO_ROOT}/.github" \
+    "${run_dir}" \
+    "${script}" "$@"

--- a/tests/coverage/merge_kcov.py
+++ b/tests/coverage/merge_kcov.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Merge kcov reports from BATS child shells into source-mapped reports."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import time
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+
+def _is_shell_source(path: Path) -> bool:
+    try:
+        with path.open(encoding="utf-8") as source_file:
+            first_line = source_file.readline().lstrip()
+    except (OSError, UnicodeDecodeError):
+        return False
+    return path.suffix == ".sh" or (
+        first_line.startswith("#!") and "bash" in first_line
+    )
+
+
+def _source_path(
+    filename: str, report: Path, repo_root: Path, allowed_roots: tuple[Path, ...]
+) -> Path | None:
+    mapping_file = report.parent.parent / "source-path"
+    if mapping_file.is_file():
+        candidate = Path(mapping_file.read_text(encoding="utf-8").strip())
+    else:
+        candidate = Path(filename)
+        if not candidate.is_absolute():
+            candidate = repo_root / candidate
+
+    candidate = candidate.resolve()
+    if not candidate.is_file() or not _is_shell_source(candidate):
+        return None
+    if not any(candidate.is_relative_to(root) for root in allowed_roots):
+        return None
+    return candidate
+
+
+def _collect_coverage(raw_dir: Path, repo_root: Path) -> dict[Path, dict[int, int]]:
+    allowed_roots = (
+        (repo_root / "build_files").resolve(),
+        (repo_root / "system_files").resolve(),
+    )
+    coverage: dict[Path, dict[int, int]] = defaultdict(lambda: defaultdict(int))
+    seen_reports: set[Path] = set()
+    reports = []
+
+    for report in sorted(raw_dir.rglob("cobertura.xml")):
+        resolved_report = report.resolve()
+        if resolved_report in seen_reports:
+            continue
+        seen_reports.add(resolved_report)
+        reports.append(report)
+
+    reports.sort(
+        key=lambda report: (
+            (report.parent.parent / "source-path").is_file(),
+            str(report),
+        )
+    )
+    for report in reports:
+        is_child_report = (report.parent.parent / "source-path").is_file()
+        root = ET.parse(report).getroot()
+        for class_element in root.findall("./packages/package/classes/class"):
+            source = _source_path(
+                class_element.get("filename", ""),
+                report,
+                repo_root,
+                allowed_roots,
+            )
+            if source is None:
+                continue
+            relative_source = source.relative_to(repo_root)
+            for line in class_element.findall("./lines/line"):
+                number = int(line.get("number", "0"))
+                hits = int(float(line.get("hits", "0")))
+                if is_child_report and (
+                    relative_source not in coverage
+                    or number not in coverage[relative_source]
+                ):
+                    continue
+                coverage[relative_source][number] += hits
+
+    return coverage
+
+
+def _write_cobertura(
+    coverage: dict[Path, dict[int, int]], output_dir: Path, repo_root: Path
+) -> tuple[int, int]:
+    total_lines = sum(len(lines) for lines in coverage.values())
+    covered_lines = sum(
+        1 for lines in coverage.values() for hits in lines.values() if hits > 0
+    )
+    line_rate = covered_lines / total_lines if total_lines else 0
+
+    root = ET.Element(
+        "coverage",
+        {
+            "line-rate": f"{line_rate:.6f}",
+            "lines-covered": str(covered_lines),
+            "lines-valid": str(total_lines),
+            "branch-rate": "0",
+            "branches-covered": "0",
+            "branches-valid": "0",
+            "complexity": "0",
+            "version": "bluefin-kcov",
+            "timestamp": str(int(time.time())),
+        },
+    )
+    sources = ET.SubElement(root, "sources")
+    ET.SubElement(sources, "source").text = str(repo_root)
+    packages = ET.SubElement(root, "packages")
+    package = ET.SubElement(
+        packages,
+        "package",
+        {
+            "name": "bluefin-shell",
+            "line-rate": f"{line_rate:.6f}",
+            "branch-rate": "0",
+            "complexity": "0",
+        },
+    )
+    classes = ET.SubElement(package, "classes")
+
+    for source, lines in sorted(coverage.items(), key=lambda item: str(item[0])):
+        file_covered = sum(1 for hits in lines.values() if hits > 0)
+        file_rate = file_covered / len(lines) if lines else 0
+        class_element = ET.SubElement(
+            classes,
+            "class",
+            {
+                "name": str(source).replace("/", "."),
+                "filename": str(source),
+                "line-rate": f"{file_rate:.6f}",
+                "branch-rate": "0",
+                "complexity": "0",
+            },
+        )
+        class_lines = ET.SubElement(class_element, "lines")
+        for number, hits in sorted(lines.items()):
+            ET.SubElement(
+                class_lines,
+                "line",
+                {"number": str(number), "hits": str(hits), "branch": "false"},
+            )
+
+    tree = ET.ElementTree(root)
+    ET.indent(tree, space="  ")
+    tree.write(output_dir / "cobertura.xml", encoding="utf-8", xml_declaration=True)
+    return covered_lines, total_lines
+
+
+def _write_html(
+    coverage: dict[Path, dict[int, int]],
+    output_dir: Path,
+    repo_root: Path,
+    covered_lines: int,
+    total_lines: int,
+) -> None:
+    total_rate = 100 * covered_lines / total_lines if total_lines else 0
+    rows = []
+    details = []
+
+    for index, (source, hits_by_line) in enumerate(
+        sorted(coverage.items(), key=lambda item: str(item[0]))
+    ):
+        file_covered = sum(1 for hits in hits_by_line.values() if hits > 0)
+        file_total = len(hits_by_line)
+        file_rate = 100 * file_covered / file_total if file_total else 0
+        anchor = f"source-{index}"
+        rows.append(
+            "<tr>"
+            f'<td><a href="#{anchor}">{html.escape(str(source))}</a></td>'
+            f"<td>{file_covered}</td><td>{file_total}</td>"
+            f"<td>{file_rate:.1f}%</td></tr>"
+        )
+
+        source_lines = (repo_root / source).read_text(encoding="utf-8").splitlines()
+        rendered_lines = []
+        for number, text in enumerate(source_lines, start=1):
+            hits = hits_by_line.get(number)
+            css_class = "neutral"
+            marker = " "
+            if hits is not None:
+                css_class = "covered" if hits > 0 else "missed"
+                marker = str(hits)
+            rendered_lines.append(
+                f'<span class="{css_class}">'
+                f"{number:4} {marker:>4} {html.escape(text)}</span>"
+            )
+        details.append(
+            f'<section id="{anchor}"><h2>{html.escape(str(source))}</h2>'
+            f"<p>{file_covered} / {file_total} lines ({file_rate:.1f}%)</p>"
+            f"<pre>{chr(10).join(rendered_lines)}</pre></section>"
+        )
+
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Bluefin BATS coverage</title>
+<style>
+body {{ color: #1f2328; font-family: sans-serif; margin: 2rem; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ border: 1px solid #d0d7de; padding: .4rem .6rem; text-align: left; }}
+th {{ background: #f6f8fa; }}
+pre {{ background: #f6f8fa; overflow-x: auto; padding: 1rem; }}
+pre span {{ display: block; }}
+.covered {{ background: #dafbe1; }}
+.missed {{ background: #ffebe9; }}
+.neutral {{ color: #656d76; }}
+</style>
+</head>
+<body>
+<h1>Bluefin BATS coverage</h1>
+<p><strong>{covered_lines} / {total_lines} lines ({total_rate:.1f}%)</strong></p>
+<table>
+<thead><tr><th>File</th><th>Covered</th><th>Valid</th><th>Coverage</th></tr></thead>
+<tbody>{''.join(rows)}</tbody>
+</table>
+{''.join(details)}
+</body>
+</html>
+"""
+    (output_dir / "index.html").write_text(document, encoding="utf-8")
+
+    summary_lines = [
+        "## BATS shell coverage",
+        "",
+        f"**{covered_lines} / {total_lines} lines ({total_rate:.1f}%)**",
+        "",
+        "| File | Covered | Valid | Coverage |",
+        "|---|---:|---:|---:|",
+    ]
+    for source, lines in sorted(coverage.items(), key=lambda item: str(item[0])):
+        file_covered = sum(1 for hits in lines.values() if hits > 0)
+        file_rate = 100 * file_covered / len(lines) if lines else 0
+        summary_lines.append(
+            f"| `{source}` | {file_covered} | {len(lines)} | {file_rate:.1f}% |"
+        )
+    (output_dir / "summary.md").write_text(
+        "\n".join(summary_lines) + "\n", encoding="utf-8"
+    )
+
+
+def generate_report(raw_dir: Path, output_dir: Path, repo_root: Path) -> tuple[int, int]:
+    repo_root = repo_root.resolve()
+    coverage = _collect_coverage(raw_dir.resolve(), repo_root)
+    if not coverage:
+        raise RuntimeError("No shell source files were found in kcov reports")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    covered_lines, total_lines = _write_cobertura(
+        coverage, output_dir, repo_root
+    )
+    if covered_lines == 0:
+        raise RuntimeError("kcov collected no executed shell source lines")
+    _write_html(coverage, output_dir, repo_root, covered_lines, total_lines)
+    return covered_lines, total_lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--raw-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    args = parser.parse_args()
+
+    covered, total = generate_report(args.raw_dir, args.output_dir, args.repo_root)
+    print(f"BATS shell coverage: {covered}/{total} lines")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_merge_kcov.py
+++ b/tests/test_merge_kcov.py
@@ -1,0 +1,97 @@
+"""Tests for the BATS kcov report merger."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parent / "coverage" / "merge_kcov.py"
+SPEC = importlib.util.spec_from_file_location("merge_kcov", MODULE_PATH)
+assert SPEC and SPEC.loader
+merge_kcov = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(merge_kcov)
+
+
+def write_report(path: Path, filename: str, lines: dict[int, int]) -> None:
+    root = ET.Element("coverage")
+    packages = ET.SubElement(root, "packages")
+    package = ET.SubElement(packages, "package")
+    classes = ET.SubElement(package, "classes")
+    class_element = ET.SubElement(classes, "class", {"filename": filename})
+    class_lines = ET.SubElement(class_element, "lines")
+    for number, hits in lines.items():
+        ET.SubElement(
+            class_lines,
+            "line",
+            {"number": str(number), "hits": str(hits)},
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+class MergeKcovTests(unittest.TestCase):
+    def test_merges_sandbox_hits_into_original_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            repo = root / "repo"
+            source = repo / "build_files" / "example.sh"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "#!/usr/bin/bash\nfirst=true\nsecond=false\n", encoding="utf-8"
+            )
+
+            raw = root / "raw"
+            write_report(
+                raw / "top" / "bats" / "cobertura.xml",
+                "build_files/example.sh",
+                {2: 0, 3: 0},
+            )
+            child = raw / "run.123"
+            (child / "source-path").parent.mkdir(parents=True, exist_ok=True)
+            (child / "source-path").write_text(str(source), encoding="utf-8")
+            write_report(
+                child / "bash" / "cobertura.xml",
+                "/repo/tests/unit/.bats-sandbox/example.sh",
+                {2: 3, 3: 0, 4: 99},
+            )
+
+            output = root / "output"
+            covered, total = merge_kcov.generate_report(raw, output, repo)
+
+            self.assertEqual((covered, total), (1, 2))
+            report = ET.parse(output / "cobertura.xml")
+            class_element = report.find("./packages/package/classes/class")
+            self.assertIsNotNone(class_element)
+            assert class_element is not None
+            self.assertEqual(class_element.get("filename"), "build_files/example.sh")
+            hits = {
+                int(line.get("number", "0")): int(line.get("hits", "0"))
+                for line in class_element.findall("./lines/line")
+            }
+            self.assertEqual(hits, {2: 3, 3: 0})
+            self.assertIn("50.0%", (output / "index.html").read_text(encoding="utf-8"))
+
+    def test_rejects_zero_coverage_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            repo = root / "repo"
+            source = repo / "system_files" / "example.sh"
+            source.parent.mkdir(parents=True)
+            source.write_text("#!/usr/bin/bash\nexit 0\n", encoding="utf-8")
+            raw = root / "raw"
+            write_report(
+                raw / "top" / "bats" / "cobertura.xml",
+                "system_files/example.sh",
+                {2: 0},
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "no executed"):
+                merge_kcov.generate_report(raw, root / "output", repo)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- install `kcov` in PR validation unit-test job
- run BATS tests with coverage instrumentation for `build_files/` and `system_files/`
- upload coverage output as a `bats-kcov-report` artifact
- keep existing TAP artifact upload and document this behavior in the CI skill

## Why
Issue #518 reports that Bluefin has BATS unit tests but no shell coverage reporting. This adds CI-visible coverage output without requiring external secrets or token setup.

Fixes projectbluefin/bluefin#518

## Validation
- `python3 -m compileall tests`
- `just check` *(blocked locally: `just` not installed in this environment)*
- `pre-commit run --all-files` *(blocked locally because `just`/toolchain prerequisites are unavailable)*