### PR TITLE
ci: restore run-upgrade-test as promotion gate

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -54,29 +54,23 @@ jobs:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common
 
-  # run-upgrade-test: DISABLED — TODO(#400)
-  # lifecycle suite fails under GNOME 50 AT-SPI changes, causing post-testing-e2e
-  # to mark as 'failure' and blocking promotion.
-  # Disabled until testsuite lifecycle scenarios are stable on GNOME 50.
-  # To restore: uncomment the job below.
-  #
-  # run-upgrade-test:
-  #   needs: [e2e]
-  #   permissions:
-  #     packages: write
-  #     contents: read
-  #   uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@v1
-  #   with:
-  #     image: ${{ needs.e2e.outputs.image }}
-  #     suites: lifecycle
+  run-upgrade-test:
+    needs: [e2e]
+    permissions:
+      packages: write
+      contents: read
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@v1
+    with:
+      image: ${{ needs.e2e.outputs.image }}
+      suites: lifecycle
 
   promote-to-testing:
-    # Promote all tested flavors to :testing only after e2e passes.
-    # This ensures :testing always points to a digest that has passed gate e2e.
-    # run-upgrade-test removed from needs — lifecycle suite is non-blocking (see TODO above).
-    needs: [e2e, run-e2e]
+    # Promote all tested flavors to :testing only after e2e and lifecycle pass.
+    # This ensures :testing always points to a digest that has passed all gate suites.
+    needs: [e2e, run-e2e, run-upgrade-test]
     if: >-
       needs.run-e2e.result == 'success' &&
+      needs.run-upgrade-test.result == 'success' &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## What does this change?

Restores `run-upgrade-test` as a promotion gate in `post-testing-e2e.yml`.

## Why?

Closes #400

**Root cause re-investigation:**

The issue attributed the lifecycle failure to GNOME 50 AT-SPI, but investigation of the actual run logs and testsuite source reveals:

- The lifecycle test suite is **pure SSH** — no GNOME session, no AT-SPI. The testsuite `e2e.yml` explicitly skips AT-SPI setup for lifecycle shards (`suite_dir != 'lifecycle'` conditionals). AT-SPI changes cannot affect lifecycle tests.
- The original failure (run [27075323936](https://github.com/projectbluefin/bluefin/actions/runs/27075323936)) showed a **VM boot/bootupd issue**, not an AT-SPI regression. The bootupd error was handled, but SSH timed out.
- The testsuite SHA has since been bumped to `f71d58d` (includes `ghcr.io/` prefix fix, PR #412) which fixes image-reference handling in upgrade tests.
- **`common` tests (also SSH-only) are currently passing** in every CI run, confirming SSH infrastructure and the bootc test environment are healthy. Lifecycle tests are structurally equivalent.

**Changes:**
- Uncomment the `run-upgrade-test` job
- Add it back to `promote-to-testing`'s `needs:` array
- Restore gate condition: `needs.run-upgrade-test.result == 'success'`
- Remove the TODO comment and disabled-state block comment

## Checklist

- [x] PR title follows Conventional Commits (`ci:`)
- [x] Workflow YAML is valid (no actionlint config changes needed; `@v1` tag is exempt per pre-commit rule)
- [x] No SHA pinning regression (uses `projectbluefin/actions/.github/workflows/upgrade-test.yml@v1` per repo convention)

## AI attribution

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>