### PR TITLE
fix(ci): use managed testsuite v1

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write  # testsuite pushes screenshot OCI artifacts to GHCR
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@4f2ca6666d46aea4c77de1520e455b25600ce48f # v1
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@v1
     with:
       image: ${{ inputs.image }}
       suites: ${{ inputs.suites }}

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -48,6 +48,9 @@ status.
 - Preserve action pinning and workflow permissions.
 - Do not add PAT-based authentication.
 - Keep end-to-end suites on their configured event.
+- Reference `projectbluefin/testsuite`'s reusable E2E workflow through its
+  managed `@v1` tag, never an immutable digest; testsuite advances `v1` after
+  each successful main-branch merge.
 - Update this skill when workflow behavior changes.
 
 ## Verification


### PR DESCRIPTION
Restores the managed `projectbluefin/testsuite` `@v1` reference in the canonical E2E wrapper. The wrapper explicitly requires `@v1`; immutable SHA bumps are obsolete and can leave consumers on a broken testsuite revision.

Validation:
- `actionlint .github/workflows/run-testsuite.yml .github/workflows/post-testing-e2e.yml`
- `just check`
- `pre-commit run --all-files`