### PR TITLE
ci: verify testsuite v1 E2E fixes

### DIFF
--- a/build_files/shared/build-gnome-extensions.sh
+++ b/build_files/shared/build-gnome-extensions.sh
@@ -5,6 +5,8 @@ set -eoux pipefail
 echo "::group:: ===$(basename "$0")==="
 
 # Build Extensions
+# Default enablement is supplied by common's GNOME schema override; CI must
+# preserve it when adding its unsafe-mode test extension.
 
 # AppIndicator Support
 glib-compile-schemas --strict /usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/schemas


### PR DESCRIPTION
Documents that CI must preserve the image extension defaults while enabling unsafe-mode. This source-path change also triggers the normal testing build so post-testing E2E resolves the repaired `projectbluefin/testsuite@v1`.

Validation: `just check && pre-commit run --all-files`.