### PR TITLE
ci: verify E2E health fixes

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -13,6 +13,7 @@ systemctl enable dconf-update.service
 systemctl enable flatpak-nuke-fedora.service
 systemctl enable input-remapper.service
 systemctl enable rpm-ostree-countme.service
+# Smoke E2E verifies that the delivered image starts the Tailscale daemon.
 systemctl enable tailscaled.service
 systemctl enable ublue-system-setup.service
 


### PR DESCRIPTION
Documents the delivered-image Tailscale smoke contract and triggers the normal testing-first build so E2E resolves the latest `projectbluefin/testsuite@v1`.

Validation: `just check && pre-commit run --all-files`.