### PR TITLE
fix(image): include bootupd for bootc installs

### DIFF
--- a/build_files/packages/base.toml
+++ b/build_files/packages/base.toml
@@ -36,6 +36,7 @@ packages = [
     "alsa-tools-firmware",
     "anaconda-live",
     "bootc",
+    "bootupd",
     "containerd",
     "ddcutil",
     "distrobox",

--- a/docs/skills/packages/SKILL.md
+++ b/docs/skills/packages/SKILL.md
@@ -27,7 +27,9 @@ metadata:
 1. Search the repository and shared inputs before adding a new source.
 2. Put base package data in the package manifest, not an inline shell array.
 3. Keep Fedora and COPR package transactions separate.
-4. Run:
+4. For images installed with `bootc install`, include `bootupd` explicitly;
+   do not rely on the base image to provide it transitively.
+5. Run:
 
 ```bash
 just check


### PR DESCRIPTION
## Summary

Add `bootupd` explicitly to the base Fedora package manifest so `bootc install` can install the bootloader during release-gate VM validation.

## Validation

- `python3 build_files/shared/read-packages build_files/packages/base.toml fedora | grep -Fx bootupd`
- `just check`
- `pre-commit run --all-files`