### PR TITLE
fix(build): invalidate package layer for build file changes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,6 +32,7 @@ ARG IMAGE_VENDOR="projectbluefin"
 ARG KERNEL="6.10.10-200.fc40.x86_64"
 ARG UBLUE_IMAGE_TAG="stable"
 ARG IMAGE_FLAVOR=""
+ARG BUILD_FILES_SHA=""
 
 # Stage 1 — Package installs only (cache key: build_files/)
 # Runs the package-install layer (`03-packages.sh`, `04-install-kernel-akmods.sh`,
@@ -45,6 +46,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=secret,id=GITHUB_TOKEN \
     --mount=type=tmpfs,dst=/boot \
     bash -euo pipefail -c ' \
+        echo "build_files cache key: ${BUILD_FILES_SHA}" && \
         dnf5 config-manager setopt keepcache=1 && \
         dnf5 config-manager setopt install_weak_deps=0 && \
         dnf5 -y swap fedora-logos generic-logos && \

--- a/Containerfile
+++ b/Containerfile
@@ -12,10 +12,17 @@ ARG BREW_IMAGE_SHA=""
 FROM ${COMMON_IMAGE}@${COMMON_IMAGE_SHA} AS common
 FROM ${BREW_IMAGE}@${BREW_IMAGE_SHA} AS brew
 
+# Package-install context. Kept separate from `ctx` on purpose: buildah folds the
+# mounted stage's image ID into the RUN cache key, so a combined context would make
+# every system_files edit invalidate Stage 1. Only build_files/ and image-versions.yml
+# belong here.
+FROM scratch AS ctx-build
+COPY /build_files /build_files
+COPY /image-versions.yml /image-versions.yml
+
 FROM scratch AS ctx
 COPY /system_files /system_files
 COPY /build_files /build_files
-COPY /image-versions.yml /image-versions.yml
 COPY --from=common /system_files/shared /system_files/shared
 COPY --from=common /system_files/bluefin /system_files/shared
 COPY --from=brew /system_files /system_files/shared
@@ -37,12 +44,14 @@ ARG BUILD_FILES_SHA=""
 # Stage 1 — Package installs only (cache key: build_files/)
 # Runs the package-install layer (`03-packages.sh`, `04-install-kernel-akmods.sh`,
 # `05-override-install.sh`) before any system_files overlay work.
-# Narrow mount (build_files/ only) enables granular layer caching:
+# Mounting from `ctx-build` (not `ctx`) enables granular layer caching:
 # a system_files-only PR change gets a cache hit here, saving 20-80 min.
+# BUILD_FILES_SHA is a second, explicit cache key over build_files/ so the layer
+# still rebuilds if a builder ever stops keying on the mounted stage.
 RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=cache,dst=/var/cache/rpm-ostree \
-    --mount=type=bind,from=ctx,source=/build_files,target=/ctx/build_files \
-    --mount=type=bind,from=ctx,source=/image-versions.yml,target=/ctx/image-versions.yml \
+    --mount=type=bind,from=ctx-build,source=/build_files,target=/ctx/build_files \
+    --mount=type=bind,from=ctx-build,source=/image-versions.yml,target=/ctx/image-versions.yml \
     --mount=type=secret,id=GITHUB_TOKEN \
     --mount=type=tmpfs,dst=/boot \
     bash -euo pipefail -c ' \

--- a/Justfile
+++ b/Justfile
@@ -218,6 +218,8 @@ build $image="bluefin" $tag="testing" $flavor="main" rechunk="0" ghcr="0" pipeli
     BUILD_ARGS+=("--build-arg" "IMAGE_VENDOR={{ repo_organization }}")
     BUILD_ARGS+=("--build-arg" "KERNEL=${kernel_release}")
     BUILD_ARGS+=("--build-arg" "VERSION=${ver}")
+    BUILD_FILES_SHA="$(find build_files -type f -print0 | LC_ALL=C sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)"
+    BUILD_ARGS+=("--build-arg" "BUILD_FILES_SHA=${BUILD_FILES_SHA}")
     if [[ -z "$(git status -s)" ]]; then
         BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")
     fi

--- a/Justfile
+++ b/Justfile
@@ -218,7 +218,9 @@ build $image="bluefin" $tag="testing" $flavor="main" rechunk="0" ghcr="0" pipeli
     BUILD_ARGS+=("--build-arg" "IMAGE_VENDOR={{ repo_organization }}")
     BUILD_ARGS+=("--build-arg" "KERNEL=${kernel_release}")
     BUILD_ARGS+=("--build-arg" "VERSION=${ver}")
-    BUILD_FILES_SHA="$(find build_files -type f -print0 | LC_ALL=C sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)"
+    # Explicit content hash over build_files/ so Stage 1 rebuilds when a script changes.
+    # -r keeps an empty tree from hashing stdin; paths are included so renames count.
+    BUILD_FILES_SHA="$(cd "{{ justfile_directory() }}" && find build_files -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum | sha256sum | cut -d' ' -f1)"
     BUILD_ARGS+=("--build-arg" "BUILD_FILES_SHA=${BUILD_FILES_SHA}")
     if [[ -z "$(git status -s)" ]]; then
         BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -8,6 +8,7 @@ metadata:
     - .github/workflows/build-image-testing.yml
   context7-sources:
     - /websites/github_en_actions
+    - /podman-container-tools/buildah
 ---
 
 # CI
@@ -33,6 +34,9 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 
 Read the actual workflow before describing or changing its behavior. Shared
 logic belongs in the reusable workflow that owns it; callers should stay thin.
+
+Containerfile stages that consume source through bind mounts need an explicit
+content-hash build argument when their cache must change with those inputs.
 
 Every open Bluefin PR is discovered by the lab's five-minute PR poller. The lab
 runs smoke QA against `bluefin:testing` and sends bounded

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -35,8 +35,10 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 Read the actual workflow before describing or changing its behavior. Shared
 logic belongs in the reusable workflow that owns it; callers should stay thin.
 
-Containerfile stages that consume source through bind mounts need an explicit
-content-hash build argument when their cache must change with those inputs.
+Containerfile stages that consume source through bind mounts inherit the mounted
+stage's image ID as part of their cache key. Give the package stage its own
+narrow `scratch` context so unrelated edits do not invalidate it, and pass an
+explicit content-hash build argument as a second guard.
 
 Every open Bluefin PR is discovered by the lab's five-minute PR poller. The lab
 runs smoke QA against `bluefin:testing` and sends bounded


### PR DESCRIPTION
## Summary

Make the Stage 1 package-install cache key depend on a content hash of `build_files/`. This prevents bind-mounted package manifests from reusing stale registry cache layers.

## Validation

- Content-hash regression check confirms a manifest change changes the build argument
- `just check`
- `pre-commit run --all-files`