### PR TITLE
ci: restore lifecycle upgrade test promotion gate

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -54,29 +54,23 @@ jobs:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common
 
-  # run-upgrade-test: DISABLED — TODO(#400)
-  # lifecycle suite fails under GNOME 50 AT-SPI changes, causing post-testing-e2e
-  # to mark as 'failure' and blocking promotion.
-  # Disabled until testsuite lifecycle scenarios are stable on GNOME 50.
-  # To restore: uncomment the job below.
-  #
-  # run-upgrade-test:
-  #   needs: [e2e]
-  #   permissions:
-  #     packages: write
-  #     contents: read
-  #   uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@v1
-  #   with:
-  #     image: ${{ needs.e2e.outputs.image }}
-  #     suites: lifecycle
+  run-upgrade-test:
+    needs: [e2e]
+    permissions:
+      packages: write
+      contents: read
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@v1
+    with:
+      image: ${{ needs.e2e.outputs.image }}
+      suites: lifecycle
 
   promote-to-testing:
-    # Promote all tested flavors to :testing only after e2e passes.
-    # This ensures :testing always points to a digest that has passed gate e2e.
-    # run-upgrade-test removed from needs — lifecycle suite is non-blocking (see TODO above).
-    needs: [e2e, run-e2e]
+    # Promote all tested flavors to :testing only after e2e and lifecycle pass.
+    # This ensures :testing always points to a digest that has passed all gate suites.
+    needs: [e2e, run-e2e, run-upgrade-test]
     if: >-
       needs.run-e2e.result == 'success' &&
+      needs.run-upgrade-test.result == 'success' &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary

- Re-enable the lifecycle `run-upgrade-test` job in `post-testing-e2e.yml`.
- Require lifecycle success alongside smoke/common E2E before promoting to `:testing`.
- Closes #400.

## Validation

- `git diff --check`
- Python workflow assertions

`pre-commit` and `just` were unavailable in the contributor environment.