### PR TITLE
feat(ci): add BATS coverage reporting artifacts

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -79,18 +79,31 @@ jobs:
     needs: [check-base-branch]
     if: always() && (needs.check-base-branch.result == 'success' || needs.check-base-branch.result == 'skipped')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Install bats
-        run: sudo apt-get install -y bats
+      - name: Install unit test tools
+        run: sudo apt-get install -y bats kcov
 
       - name: Run unit tests
         run: bats --formatter tap tests/unit/ | tee results.tap
+
+      - name: Generate BATS coverage report
+        env:
+          INCLUDE_PATHS: ${{ github.workspace }}/build_files,${{ github.workspace }}/system_files
+          EXCLUDE_PATHS: ${{ github.workspace }}/tests,${{ github.workspace }}/.github
+        run: |
+          mkdir -p coverage/kcov
+          kcov \
+            --bash-method=DEBUG \
+            --include-path="${INCLUDE_PATHS}" \
+            --exclude-path="${EXCLUDE_PATHS}" \
+            coverage/kcov \
+            bats tests/unit/
 
       - name: Upload TAP results
         if: always()
@@ -98,6 +111,13 @@ jobs:
         with:
           name: bats-tap-results
           path: results.tap
+
+      - name: Upload BATS coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bats-kcov-report
+          path: coverage/kcov
 
       - name: Run Python unit tests
         run: python3 -m unittest discover -s tests -p 'test_*.py'

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -33,6 +33,8 @@ gh run rerun RUN_ID --repo projectbluefin/bluefin --failed-only
 
 Read the actual workflow before describing or changing its behavior. Shared
 logic belongs in the reusable workflow that owns it; callers should stay thin.
+The `unit-tests` job in `pr-validation.yml` runs BATS with kcov and publishes
+`bats-tap-results` plus `bats-kcov-report` artifacts for shell-test visibility.
 
 Every open Bluefin PR is discovered by the lab's five-minute PR poller. The lab
 runs smoke QA against `bluefin:testing` and sends bounded


### PR DESCRIPTION
## Summary
- Installs `kcov` in the PR validation `unit-tests` job.
- Runs BATS tests with coverage instrumentation targeting `build_files/` and `system_files/`.
- Uploads the coverage report as a `bats-kcov-report` artifact.
- Documents the coverage report artifact behavior in the CI skill.

Closes #518