### PR TITLE
ci: document renovate auto-merge delegation contract

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -1,5 +1,9 @@
 name: Renovate Auto-merge
 
+# Delegates to projectbluefin/actions. The reusable workflow qualifies the PR
+# (Renovate/MergeRaptor author, not draft, not conflicting) and waits for the
+# full check rollup to go green before squash-merging, so triggering from this
+# single CI workflow is safe even when sibling checks finish later.
 on:
   workflow_run:
     workflows: ["PR Validation — testsuite"]


### PR DESCRIPTION
Consumer validation PR for [projectbluefin/actions#398](https://github.com/projectbluefin/actions/pull/398), which fixes and hardens `reusable-renovate-automerge.yml`.

This repo calls that reusable workflow with only `head_sha`, so the two new inputs (`require_auto_merge`, `check_timeout_seconds`) both default to the previous behaviour. The change is additive for this repo.

Draft — exists to exercise CI against `projectbluefin/actions@v1`. Not for merge on its own.