### PR TITLE
ci: consumer validation for projectbluefin/actions#392 ($/ self-repository syntax)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -763,3 +763,5 @@ retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
     for image in bluefin-nvidia; do
       $skopeo copy docker://ghcr.io/projectbluefin/${image}:{{ working_tag }} docker://ghcr.io/projectbluefin/${image}:{{ stream }}
     done
+
+# consumer-validation: $/ self-repository composition in projectbluefin/actions PR #392


### PR DESCRIPTION
Consumer validation PR for [projectbluefin/actions#392](https://github.com/projectbluefin/actions/pull/392).

That PR migrates internal composition inside `projectbluefin/actions` from hand-bumped `projectbluefin/actions/...@<sha>` self-pins to GitHub's new `$/` self-repository syntax (announced 2026-07-30, requires runner >= 2.336.0). It removes 14 stale SHA pins currently frozen on `main`.

Nothing in this repo changes behaviourally — the marker comment appended to the `Justfile` exists only to produce a real CI run against the `@v1` references this repo already uses. Per `docs/skills/consumer-validation.md`, that run is the required evidence.

Opened non-draft deliberately: a draft PR produces no CI run in this repo.

Closes nothing; safe to close once actions#392 lands.