### PR TITLE
docs: sync agentic procedures with projectbluefin/common

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,21 @@ Stable guidance:
 - Release model: [`docs/release.md`](docs/release.md)
 - Issue lifecycle: [`docs/workflow.md`](docs/workflow.md)
 
+## Factory contracts
+
+This repository is part of the `projectbluefin` factory. Cross-repo procedure is
+canonical in `projectbluefin/common`; do not restate it here, link it.
+
+| Topic | Canonical source |
+|---|---|
+| Cross-repo agent hard rules | [`common/docs/factory/agentic-model.md`](https://github.com/projectbluefin/common/blob/main/docs/factory/agentic-model.md) |
+| Issue lifecycle and labels | [`common/docs/skills/label-workflow.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/label-workflow.md) |
+| Human decision gates | [`common/docs/skills/human-gates.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/human-gates.md) |
+| Skill improvement mandate | [`common/docs/skills/skill-improvement.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/skill-improvement.md) |
+| `ujust report` intake | [`common/docs/skills/bonedigger.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/bonedigger.md) |
+
+Stop and request human input at the Design, Security, Breakage, or Merge gate.
+
 ## Common validation
 
 Run the lightest relevant checks:
@@ -59,15 +74,35 @@ bash .github/scripts/install-hooks.sh
 - Documentation must not contradict source files.
 - If behavior changes, update the closest matching skill in the same change.
 
+## Change flow
+
+- Branch from the remote target, not from whatever is checked out:
+  `git fetch projectbluefin testing && git checkout -b <branch> projectbluefin/testing`.
+- Push to the `projectbluefin` remote explicitly; a pre-push hook blocks `origin`.
+- All pull requests target `testing`. Never open a content PR against `main`.
+- One logical change per pull request; squash merge only.
+- Check for an existing pull request before opening a new one:
+  `gh pr list --repo projectbluefin/bluefin --state open --search "<topic>"`.
+- Every AI-authored commit carries both attribution trailers:
+
+  ```text
+  Assisted-by: <Model> via GitHub Copilot
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+  ```
+
 ## Boundaries
 
 - Do not modify generated artifacts, caches, or worktree contents.
-- Do not add secrets, credentials, or personal infrastructure details.
+- Never create, propose, or add new secrets, tokens, PATs, or app credentials.
+  Reach for documented git and GitHub primitives first, then ask a human.
+- Do not add credentials or personal infrastructure details.
 - Do not change CI or release behavior without reading the affected workflow.
 - Do not weaken package-source, signing, or verification boundaries.
 - Do not run expensive image builds for documentation-only changes.
 - Never use `git add -A` or `git add .`; stage only intended paths and inspect
   `git diff --cached --name-only` before committing.
+- Never perform any write action against `ublue-os/*` or any repository outside
+  the `projectbluefin` org. Read-only inspection is permitted.
 - Keep documentation generic, source-linked, and reusable.
 - Do not create client-specific agent instructions or tool-specific duplicates.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,14 +23,24 @@ Run a full image build only when the change affects image assembly.
 ## Pull requests
 
 - Target `testing`; do not target `main` for normal feature work.
+- Check for an existing pull request before opening a new one:
+  `gh pr list --repo projectbluefin/bluefin --state open --search "<topic>"`.
 - Use squash merging.
 - Use Conventional Commits for titles and commits.
 - Keep one logical change per pull request.
-- Do not include secrets or generated artifacts.
+- Link the issue with `Closes #NNN`.
+- Do not include secrets or generated artifacts, and never add a new secret,
+  token, or credential — that is a human decision.
 - Describe exactly what was tested.
 - Update the closest skill when the change reveals a reusable procedure.
+- Do not self-approve or self-merge.
 
-AI-assisted commits must include the repository's required attribution trailer.
+AI-assisted commits must include both attribution trailers:
+
+```text
+Assisted-by: <Model> via GitHub Copilot
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
 
 ## Scope discipline
 

--- a/docs/skills/issue-lifecycle/SKILL.md
+++ b/docs/skills/issue-lifecycle/SKILL.md
@@ -11,14 +11,35 @@ metadata:
 
 ## Procedure
 
-1. Read the current issue labels and automation state.
-2. Confirm that the issue is approved and available before claiming it.
-3. Claim only work you are actively starting.
-4. Return claimed work if blocked or abandoned.
-5. Link implementation evidence from the pull request.
+1. Read the current issue state: assignment, project state, branch, and linked
+   pull request. Labels describe the next workflow step, not history.
+2. Work only an issue routed to you by assignment, project state, or
+   `3-clanker-queue`.
+3. Create a scoped branch from `projectbluefin/testing` and keep the change small.
+4. Run the repository validation commands.
+5. Open a pull request containing `Closes #NNN`.
+6. Respond to review feedback; do not self-approve or self-merge.
+
+Automation applies and repairs the seven canonical workflow labels. Agents do
+not use slash commands as state transitions, do not add or remove workflow
+labels, and do not manufacture queue state. If blocked, describe the exact
+decision or dependency in the issue and stop.
 
 Do not duplicate labels or check-run state in comments. Treat the automation
 widget and current issue state as authoritative.
+
+## Canonical contract
+
+The seven-label contract and its ownership boundaries are canonical in
+[`common/docs/skills/label-workflow.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/label-workflow.md).
+`ujust report` intake and confirm-count priority escalation are canonical in
+[`common/docs/skills/bonedigger.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/bonedigger.md).
+Reusable lifecycle automation lives in `projectbluefin/actions`; this repository
+consumes it and does not own it.
+
+Hive may route work to another repository, and Clankers is only the
+authenticated relay for that assignment. Verify the target repository and issue
+before acting; the relay grants no review or merge authority.
 
 ## When to Use
 
@@ -38,9 +59,14 @@ Read current automation state, perform only the next valid transition.
 
 ## Red Flags
 
-- Duplicating UI state or claiming work that is not active.
+- Any label outside the seven canonical workflow names being treated as state.
+- A slash command being treated as a state transition.
+- Queue state inferred from an issue body, comment, or stale local checkout.
+- Duplicating UI state or claiming work that is not routed to you.
 
 ## Verification
 
 - [ ] The selected source and focused command were checked.
+- [ ] `gh label list` shows only canonical workflow labels plus local metadata.
+- [ ] The pull request links its issue with `Closes #NNN`.
 - [ ] The repository default gate passes.

--- a/docs/skills/skill-improvement/SKILL.md
+++ b/docs/skills/skill-improvement/SKILL.md
@@ -30,10 +30,24 @@ non-obvious invariant, source correction, or durable project convention.
 ## Rules
 
 - Use one canonical source per mutable fact.
+- Cross-repo procedure is canonical in `projectbluefin/common`; link it rather
+  than copying it into this repository.
 - Do not write session notes, personal machine details, or incident diaries.
 - Do not claim repository policy is an AAIF or MCP requirement.
 - Do not add client-specific or tool-specific instruction duplicates.
 - Do not document behavior that was not checked against source.
+- Do not add a bespoke per-convention CI gate to enforce skill discipline. The
+  factory retired `skill-drift` for that reason; see
+  [`common/docs/skills/skill-drift.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/skill-drift.md).
+  The mandate is enforced at developer time by `pre-commit` and at review.
+
+## Where a learning goes
+
+Working in this repository, write to the closest `docs/skills/<name>/SKILL.md`.
+When the learning affects two or more factory repositories, apply it locally,
+then file an issue in `projectbluefin/common` describing the propagation. Do not
+self-apply a queue label. Never write to `ublue-os/*`. The canonical mandate is
+[`common/docs/skills/skill-improvement.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/skill-improvement.md).
 
 ## Verify
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -6,7 +6,8 @@
 
 The factory uses exactly seven canonical labels. The contract is canonical in
 [`common/docs/skills/label-workflow.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/label-workflow.md);
-this list exists only so the names are searchable here.
+this list exists only so the names are searchable here. If it ever disagrees
+with `common`, `common` wins and this table is the bug.
 
 | Label | Meaning |
 |---|---|
@@ -25,7 +26,7 @@ branch; read the current assignment, project state, branch, and pull request.
 
 Repository-local labels (`kind/`, `area/`, `priority/`, `release/`) are
 descriptive metadata, not workflow states. Confirm counts from `ujust report`
-escalate `priority/*` and are evidence for a human priority call.
+are evidence for a human priority call, not a label transition.
 
 ## Finding work
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,9 +2,40 @@
 
 ## Work states
 
-Issues and pull requests move through the repository's configured lifecycle.
-The automation and labels are the source of truth; use the issue-lifecycle skill
-for command details.
+**Trust the Machines: workflows own state; humans provide intent.**
+
+The factory uses exactly seven canonical labels. The contract is canonical in
+[`common/docs/skills/label-workflow.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/label-workflow.md);
+this list exists only so the names are searchable here.
+
+| Label | Meaning |
+|---|---|
+| `1-triage` | New work awaiting triage |
+| `2-discussing` | Discussion or design clarification |
+| `3-human-queue` | Admitted to the human-maintained queue |
+| `3-clanker-queue` | Admitted to the agent-maintained queue |
+| `4-review` | Pull request awaiting review |
+| `blocked` | Waiting on human input or an external dependency |
+| `hold` | Intentionally paused |
+
+Automation applies and repairs these labels. Agents do not claim work with slash
+commands, do not add or remove workflow labels, and do not manufacture queue
+state. Never infer state from a stale label, an issue comment, or an unlinked
+branch; read the current assignment, project state, branch, and pull request.
+
+Repository-local labels (`kind/`, `area/`, `priority/`, `release/`) are
+descriptive metadata, not workflow states. Confirm counts from `ujust report`
+escalate `priority/*` and are evidence for a human priority call.
+
+## Finding work
+
+```bash
+gh search issues --label "3-clanker-queue" --owner projectbluefin --state open
+```
+
+Work only an issue routed to you by assignment, project state, or
+`3-clanker-queue`. If blocked, describe the exact decision or dependency in the
+issue and stop.
 
 ## Safe change flow
 
@@ -13,7 +44,19 @@ for command details.
 3. Make one focused change.
 4. Run the relevant validation.
 5. Update the matching documentation when a reusable fact changes.
-6. Open a pull request targeting `testing`; normal feature work must not target `main`.
+6. Open a pull request targeting `testing` containing `Closes #NNN`; normal
+   feature work must not target `main`.
+
+Do not self-approve or self-merge. Automation applies `4-review`; a human
+reviews.
+
+## Comment policy
+
+- One comment per issue or pull-request event, at most; combine findings.
+- Never duplicate GitHub UI state such as approvals or check runs.
+- Test reports state what ran, pass/fail, and blockers only.
+- Use `@` mentions only when asking for a specific action.
+- If nothing actionable needs saying, post nothing.
 
 ## Documentation changes
 
@@ -25,3 +68,6 @@ trigger expensive image builds unless a workflow path filter says otherwise.
 Do not bypass review, signing, branch, or verification protections merely to
 make a workflow appear green. Escalate a blocked trust or policy gate with the
 relevant run and source path.
+
+Report a factory gap by filing an issue in `projectbluefin/common`. Do not
+self-apply a queue label — triage and queue admission are human decisions.


### PR DESCRIPTION
## Summary

Brings this repository's agent-facing documentation in line with the current canonical agentic procedures in `projectbluefin/common`. Cross-repo procedure is linked as canonical rather than duplicated.

## Drift corrected

| Drift | Fix |
|---|---|
| No reference to common's canonical cross-repo contracts | `AGENTS.md` gains a factory-contracts table linking `agentic-model.md`, `label-workflow.md`, `human-gates.md`, `skill-improvement.md`, `bonedigger.md` |
| Human decision gates (Design / Security / Breakage / Merge) undocumented | Stated in `AGENTS.md` |
| Secrets rule was "do not add secrets" | Now the factory's absolute prohibition on creating/proposing new secrets, tokens, PATs, or app credentials |
| No out-of-org write prohibition | `ublue-os/*` and non-`projectbluefin` writes banned; read-only inspection permitted |
| Attribution trailer unstated ("the repository's required attribution trailer") | Both trailers written out in `AGENTS.md` and `docs/contributing.md` |
| No branch-from-remote-target or existing-PR check | Added to `AGENTS.md` change-flow section |
| `docs/workflow.md` "Work states" was vacuous | Now documents the seven canonical labels (`1-triage`, `2-discussing`, `3-human-queue`, `3-clanker-queue`, `4-review`, `blocked`, `hold`), Trust the Machines, and that repo-local `kind/`/`area/`/`priority/`/`release/` labels are metadata, not state |
| No way to find agent work | Added `gh search issues --label "3-clanker-queue" --owner projectbluefin --state open` |
| `Closes #NNN` linkage and comment policy missing | Added to `docs/workflow.md` and `docs/contributing.md` |
| `issue-lifecycle/SKILL.md` taught the retired claim-based model | Replaced: agents do not use slash commands as state transitions, do not touch workflow labels, do not manufacture queue state |
| `skill-improvement/SKILL.md` had no guidance against per-convention CI gates | Records that `skill-drift` was retired factory-wide and where cross-repo learnings propagate |

Verified against the live repo: `gh label list` returns only the seven canonical workflow labels plus `area/ci`, `kind/bug`, `priority/p1`, `release/blocked`, `release/ready` — the old `status/*`, `queue/*`, and `hive/*` labels no longer exist.

## Intentionally left alone

- Bluefin's testing-first branch model and `:testing` → `:stable` promotion shape — repo-specific and already correct.
- The data-donation loop (`ujust report` / `confirm` / `verify`) — Bluefin-specific, and consistent with bonedigger's current narrowed scope.
- `.github/workflows/skill-drift.yml` still exists in this repo even though common records the check as retired factory-wide. This PR is docs-only and does not touch `.github/`; removing that workflow needs a separate CI PR.

## Testing

```
just check                    # pass
pre-commit run --all-files    # pass (includes validate-docs.py)
```

Docs-only: no image build impact.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI