### PR TITLE
docs(workflow): replace placeholder bonedigger TODO with real tracking issue

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -19,8 +19,9 @@ permissions:
 
 jobs:
   lifecycle:
-    # TODO: restore pull_request: opened trigger once bonedigger lifecycle handles PRs
-    # (tracked in projectbluefin/bluefin#TBD)
+    # NOTE: the pull_request: opened trigger above dispatches this workflow, but the
+    # bonedigger lifecycle has no pull_request jobs yet, so every job is skipped.
+    # Tracked in projectbluefin/bluefin#981.
     uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603 # v1
     with:
       brand_name: "Bluefin"


### PR DESCRIPTION
Split out of #895, which is blocked upstream.

The TODO comment above the `lifecycle` job in `.github/workflows/bonedigger.yml` was stale on two counts:

1. It said the `pull_request: opened` trigger should be *restored*, but that trigger is still present in the `on:` block.
2. It referenced `projectbluefin/bluefin#TBD`, a placeholder that resolves to nothing.

Verified against `projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d530767` (v1): it defines only `on-issue-opened` (guarded `github.event_name == 'issues'`) and `on-issue-comment`. There is no `pull_request` handling, so PR-opened events dispatch the reusable workflow and every job is skipped.

Replaced with an accurate NOTE pointing at #981, which tracks the actual decision (drop the trigger, or add PR jobs upstream).

Validation: `just check` and `pre-commit run --all-files` both pass (includes actionlint and the action-pinning linters).