### PR TITLE
docs: add agent fast path and every-loop repair contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,14 @@ Stable guidance:
 - Release model: [`docs/release.md`](docs/release.md)
 - Issue lifecycle: [`docs/workflow.md`](docs/workflow.md)
 
+## Agent fast path
+
+- Read source before asserting project-internal facts such as image names, tags,
+  or workflow outputs. Use `gh api` to inspect workflows, not memory.
+- Look up external tool documentation through Context7 before quoting it.
+- When a session surfaces a non-obvious pattern or workaround, update the
+  matching skill in the same change.
+
 ## Factory contracts
 
 This repository is part of the `projectbluefin` factory. Cross-repo procedure is

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,6 +34,10 @@ Run a full image build only when the change affects image assembly.
 - Describe exactly what was tested.
 - Update the closest skill when the change reveals a reusable procedure.
 - Do not self-approve or self-merge.
+- Ask a human before opening a pull request autonomously; opening one is not an
+  implied part of a task.
+
+After pushing, verify CI: `gh run list --repo projectbluefin/bluefin --limit 5`.
 
 AI-assisted commits must include both attribution trailers:
 

--- a/docs/skills/skill-improvement/SKILL.md
+++ b/docs/skills/skill-improvement/SKILL.md
@@ -49,6 +49,21 @@ then file an issue in `projectbluefin/common` describing the propagation. Do not
 self-apply a queue label. Never write to `ublue-os/*`. The canonical mandate is
 [`common/docs/skills/skill-improvement.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/skill-improvement.md).
 
+## Every-loop repair contract
+
+Run this on every task, including tasks that succeed:
+
+1. Verify the repository, branch, and loaded skills against source.
+2. Name stale guidance explicitly instead of silently working around it.
+3. Repair the nearest authoritative skill when the correction is source-backed
+   and in scope.
+4. Validate with the checks that already exist; do not invent a new gate.
+5. Record the learning and any unresolved gap.
+6. Escalate a human gate rather than turning uncertainty into policy.
+
+A successful task still checks for reusable learning and documentation drift
+before completion.
+
 ## Verify
 
 ```bash


### PR DESCRIPTION
Follow-up to #979, which merged before these four small gaps were identified.

Folds in remaining deltas against `projectbluefin/common`'s agentic docs:

- **`AGENTS.md`** — adds common's "Agent fast path": read source before asserting project-internal facts, use `gh api` over memory, look up external tool docs via Context7, update the matching skill in the same change.
- **`docs/skills/skill-improvement/SKILL.md`** — adds common's every-loop repair contract, which runs even on success, closing with the rule that a successful task still checks for reusable learning and documentation drift.
- **`docs/contributing.md`** — requires verifying CI after pushing (`gh run list`), and asking a human before opening a pull request autonomously.

## Line budget

`.github/scripts/validate-docs.py` caps `AGENTS.md` at 150 lines and each `SKILL.md` at 180. After this change:

| File | Lines | Cap |
|---|---|---|
| `AGENTS.md` | 124 | 150 |
| `docs/skills/index.md` | 25 | 80 |
| `docs/skills/skill-improvement/SKILL.md` | 97 | 180 |

Item 4 was placed in `docs/contributing.md` rather than `AGENTS.md` to preserve headroom for #980, which also appends to `AGENTS.md`.

## Tested

`python3 .github/scripts/validate-docs.py` (11 skills, 39 Markdown files), `pre-commit run --all-files`, and `just check` all pass locally. Docs-only; no image build.

Out of scope, tracked separately: skill front-matter schema expansion, validate-docs.py schema enforcement, and a `write-a-skill` skill.