### PR TITLE
docs(skills): adopt the factory skill front-matter contract

### DIFF
--- a/.github/scripts/validate-docs.py
+++ b/.github/scripts/validate-docs.py
@@ -8,11 +8,81 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 SKILLS = ROOT / "docs" / "skills"
 MAX_LINES = {ROOT / "AGENTS.md": 150, SKILLS / "index.md": 80}
+REQUIRED_KEYS = (
+    "name",
+    "version",
+    "last_updated",
+    "id",
+    "one_line_purpose",
+    "entry_point",
+    "category",
+    "mcp_compliance_level",
+    "optimization_status",
+    "status",
+    "dependencies",
+    "tags",
+    "description",
+)
+CATEGORIES = {"ci-ops", "test-authoring", "meta"}
+STATUSES = {"active", "deprecated", "reserved"}
+DOC_TYPES = {"procedure", "reference", "runbook", "policy"}
 errors: list[str] = []
 
 
 def error(message: str) -> None:
     errors.append(message)
+
+
+def parse_front_matter(text: str) -> dict[str, str]:
+    """Read the small YAML subset used by SKILL.md front matter.
+
+    Handles top-level scalars, folded ``>-`` blocks, inline ``[a, b]`` lists,
+    and a single nested ``metadata`` mapping (exposed as ``metadata.<key>``).
+    Kept dependency-free so the validate job needs no extra packages.
+    """
+    parsed: dict[str, str] = {}
+    key: str | None = None
+    folded: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if key is not None and (indent > 0 or not stripped):
+            if stripped:
+                folded.append(stripped)
+            continue
+        if key is not None:
+            parsed[key] = " ".join(folded)
+            key, folded = None, []
+        if not stripped or stripped.startswith("#") or indent > 0 or ":" not in stripped:
+            continue
+        name, _, value = stripped.partition(":")
+        name, value = name.strip(), value.strip()
+        if value in (">-", ">", "|", "|-", ""):
+            if name == "metadata":
+                parsed.update(parse_nested(text, name))
+                continue
+            key, folded = name, []
+            continue
+        parsed[name] = value.strip("\"'")
+    if key is not None:
+        parsed[key] = " ".join(folded)
+    return parsed
+
+
+def parse_nested(text: str, block: str) -> dict[str, str]:
+    """Return ``<block>.<key>`` scalars from a nested two-space mapping."""
+    parsed: dict[str, str] = {}
+    inside = False
+    for line in text.splitlines():
+        if not line.startswith(" ") and line.strip():
+            inside = line.strip().rstrip(":") == block and line.strip().endswith(":")
+            continue
+        if not inside or not line.startswith("  ") or line.startswith("    "):
+            continue
+        name, _, value = line.strip().partition(":")
+        if value.strip():
+            parsed[f"{block}.{name.strip()}"] = value.strip().strip("\"'")
+    return parsed
 
 
 def local_target(source: Path, target: str) -> Path | None:
@@ -41,12 +111,31 @@ for directory in skill_dirs:
         error(f"missing front matter: {skill.relative_to(ROOT)}")
     else:
         front_matter = text.split("---\n", 2)[1]
-        if not re.search(r"^name:\s*[^\s].*$", front_matter, re.MULTILINE):
-            error(f"missing name metadata: {skill.relative_to(ROOT)}")
-        if not re.search(r"^description:\s*[^\s].*$", front_matter, re.MULTILINE):
-            error(f"missing description metadata: {skill.relative_to(ROOT)}")
-        if not re.search(rf"^name:\s*{re.escape(directory.name)}\s*$", front_matter, re.MULTILINE):
-            error(f"name does not match directory: {skill.relative_to(ROOT)}")
+        name = skill.relative_to(ROOT)
+        fields = parse_front_matter(front_matter)
+        for required in REQUIRED_KEYS:
+            if not fields.get(required):
+                error(f"missing {required} metadata: {name}")
+        if fields.get("name") and fields["name"] != directory.name:
+            error(f"name does not match directory: {name}")
+        if fields.get("id") and fields["id"] != directory.name:
+            error(f"id does not match directory: {name}")
+        expected_entry = f"docs/skills/{directory.name}/SKILL.md"
+        if fields.get("entry_point") and fields["entry_point"] != expected_entry:
+            error(f"entry_point must be {expected_entry}: {name}")
+        if fields.get("category") and fields["category"] not in CATEGORIES:
+            error(f"invalid category '{fields['category']}': {name}")
+        if fields.get("status") and fields["status"] not in STATUSES:
+            error(f"invalid status '{fields['status']}': {name}")
+        doc_type = fields.get("metadata.type")
+        if not doc_type:
+            error(f"missing metadata.type: {name}")
+        elif doc_type not in DOC_TYPES:
+            error(f"invalid metadata.type '{doc_type}': {name}")
+        if len(fields.get("description", "")) > 256:
+            error(f"description exceeds 256 characters: {name}")
+        if len(fields.get("one_line_purpose", "")) > 120:
+            error(f"one_line_purpose exceeds 120 characters: {name}")
     if len(text.splitlines()) > 180:
         error(f"{skill.relative_to(ROOT)} exceeds 180 lines")
 
@@ -57,12 +146,11 @@ for skill in skill_files:
     if expected not in index_text:
         error(f"skill missing from index: {expected}")
 
+EXCLUDED_DIRS = {".git", ".worktrees", ".pytest_cache"}
 markdown_files = [
     path
     for path in ROOT.rglob("*.md")
-    if ".git" not in path.parts
-    and ".worktrees" not in path.parts
-    and ".pytest_cache" not in path.parts
+    if not EXCLUDED_DIRS & set(path.relative_to(ROOT).parts)
 ]
 link_pattern = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 for source in markdown_files:

--- a/docs/skills/build/SKILL.md
+++ b/docs/skills/build/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: build
-description: Build, validate, and test image changes. Use for Containerfile, build scripts, image contents, or local validation.
+version: "1.0"
+last_updated: 2026-08-06
+id: build
+one_line_purpose: Build, validate, and test image changes locally before pushing.
+entry_point: docs/skills/build/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [build, containerfile, justfile, validation]
+description: >-
+  Covers Containerfile stages, build_files layering, local image builds, and
+  which validation gate to run for a given change. Use when editing image
+  inputs or deciding whether a full build is required.
 metadata:
+  type: procedure
   source-of-truth:
     - Containerfile
     - Justfile

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: ci
-description: Debug and change repository CI workflows. Use for triggers, checks, promotion, release, or workflow failures.
+version: "1.0"
+last_updated: 2026-08-06
+id: ci
+one_line_purpose: Debug and change repository GitHub Actions workflows.
+entry_point: docs/skills/ci/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [ci, workflows, github-actions, triggers, debugging]
+description: >-
+  Explains workflow triggers, path filters, reusable workflow calls, and how
+  to read failing runs in this repository. Use when a workflow failed, did
+  not start, or ran the wrong checks.
 metadata:
+  type: runbook
   source-of-truth:
     - .github/workflows/
     - .github/workflows/pr-validation.yml

--- a/docs/skills/dependency-automation/SKILL.md
+++ b/docs/skills/dependency-automation/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: dependency-automation
-description: Review dependency automation, Renovate configuration, and automated updates.
+version: "1.0"
+last_updated: 2026-08-06
+id: dependency-automation
+one_line_purpose: Review Renovate configuration and automated dependency updates.
+entry_point: docs/skills/dependency-automation/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [renovate, dependencies, automation, automerge]
+description: >-
+  Describes the Renovate configuration, automerge workflow, and
+  authentication model for automated updates. Use when changing dependency
+  automation config or triaging an automated update pull request.
 metadata:
+  type: procedure
   source-of-truth:
     - renovate.json
     - .github/renovate.json5

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -17,6 +17,7 @@ the selected skill directs you to do so.
 | Understand issue state | [issue-lifecycle](issue-lifecycle/SKILL.md) |
 | Work on installation artifacts | [installation-artifacts](installation-artifacts/SKILL.md) |
 | Improve or add a skill | [skill-improvement](skill-improvement/SKILL.md) |
+| Author a new skill directory | [write-a-skill](write-a-skill/SKILL.md) |
 
 ## Rules
 

--- a/docs/skills/installation-artifacts/SKILL.md
+++ b/docs/skills/installation-artifacts/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: installation-artifacts
-description: Build or promote installation artifacts that consume the image.
+version: "1.0"
+last_updated: 2026-08-06
+id: installation-artifacts
+one_line_purpose: Build and promote installation artifacts that consume the image.
+entry_point: docs/skills/installation-artifacts/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [artifacts, iso, promotion, release]
+description: >-
+  Covers dispatching artifact workflows, confirming the source image digest,
+  and promoting a verified artifact. Use when building or promoting an ISO
+  or other installation artifact derived from a published image.
 metadata:
+  type: runbook
   source-of-truth:
     - .github/workflows/
     - docs/release.md

--- a/docs/skills/issue-lifecycle/SKILL.md
+++ b/docs/skills/issue-lifecycle/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: issue-lifecycle
-description: Understand and operate the repository issue lifecycle and work queue.
+version: "1.0"
+last_updated: 2026-08-06
+id: issue-lifecycle
+one_line_purpose: Operate the repository issue lifecycle and work queue correctly.
+entry_point: docs/skills/issue-lifecycle/SKILL.md
+category: meta
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [issues, workflow, queue, labels]
+description: >-
+  Explains issue assignment, project state, label semantics, and the branch-
+  to-pull-request path used in this repository. Use when picking up,
+  updating, or closing an issue.
 metadata:
+  type: procedure
   source-of-truth:
     - docs/workflow.md
     - .github/workflows/

--- a/docs/skills/packages/SKILL.md
+++ b/docs/skills/packages/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: packages
-description: Add, remove, or classify RPM, Flatpak, COPR, and Homebrew inputs.
+version: "1.0"
+last_updated: 2026-08-06
+id: packages
+one_line_purpose: Add, remove, or classify RPM, Flatpak, COPR, and Homebrew inputs.
+entry_point: docs/skills/packages/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [packages, rpm, flatpak, copr, homebrew]
+description: >-
+  Provides the decision tree for where a package belongs and the files that
+  declare each package source. Use when adding, removing, or relocating a
+  package input.
 metadata:
+  type: procedure
   source-of-truth:
     - build_files/packages/
     - build_files/base/03-packages.sh

--- a/docs/skills/release-artifacts/SKILL.md
+++ b/docs/skills/release-artifacts/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: release-artifacts
-description: Prepare, verify, or troubleshoot image release and promotion artifacts.
+version: "1.0"
+last_updated: 2026-08-06
+id: release-artifacts
+one_line_purpose: Prepare, verify, and troubleshoot image release and promotion.
+entry_point: docs/skills/release-artifacts/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [release, promotion, signing, verification]
+description: >-
+  Covers the release and testing-to-main promotion workflows, digest and tag
+  verification, and signing gates. Use when running a release or diagnosing
+  a failed promotion.
 metadata:
+  type: runbook
   source-of-truth:
     - .github/workflows/execute-release.yml
     - .github/workflows/promote-testing-to-main.yml

--- a/docs/skills/security/SKILL.md
+++ b/docs/skills/security/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: security
-description: Review image supply-chain, signing, COPR, and secure-boot changes.
+version: "1.0"
+last_updated: 2026-08-06
+id: security
+one_line_purpose: Review supply-chain, signing, COPR, and secure-boot changes.
+entry_point: docs/skills/security/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [security, supply-chain, signing, secure-boot, copr]
+description: >-
+  States the package-source trust boundaries, signing requirements, and
+  secure-boot constraints for this image. Use when adding a package source
+  or changing verification or trust behavior.
 metadata:
+  type: policy
   source-of-truth:
     - SECURITY.md
     - build_files/shared/copr-helpers.sh

--- a/docs/skills/setup-hook-tests/SKILL.md
+++ b/docs/skills/setup-hook-tests/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: setup-hook-tests
-description: Add or extend Bats coverage for setup-hook scripts.
+version: "1.0"
+last_updated: 2026-08-06
+id: setup-hook-tests
+one_line_purpose: Add or extend Bats coverage for setup-hook scripts.
+entry_point: docs/skills/setup-hook-tests/SKILL.md
+category: test-authoring
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [testing, bats, setup-hooks, sandbox]
+description: >-
+  Describes the Bats sandbox layout, path patching, and command stubbing
+  used to test setup hooks in tests/unit. Use when adding or changing
+  coverage for a system_files setup hook.
 metadata:
+  type: procedure
   source-of-truth:
     - tests/unit/
     - system_files/

--- a/docs/skills/skill-improvement/SKILL.md
+++ b/docs/skills/skill-improvement/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: skill-improvement
-description: Add, refactor, validate, and maintain agent skills without duplicating facts.
+version: "1.0"
+last_updated: 2026-08-06
+id: skill-improvement
+one_line_purpose: Maintain and refactor agent skills without duplicating facts.
+entry_point: docs/skills/skill-improvement/SKILL.md
+category: meta
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [skills, documentation, maintenance, agents]
+description: >-
+  Explains when to update an existing skill, how to avoid duplicating
+  source-of-truth facts, and how to split oversized skills. Use when a
+  reusable fact or procedure changes and a skill must follow.
 metadata:
+  type: procedure
   audience:
     - contributor
     - maintainer

--- a/docs/skills/variants/SKILL.md
+++ b/docs/skills/variants/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: variants
-description: Determine the correct image, stream, flavor, branch, and workflow target.
+version: "1.0"
+last_updated: 2026-08-06
+id: variants
+one_line_purpose: Determine the correct image, stream, flavor, branch, and target.
+entry_point: docs/skills/variants/SKILL.md
+category: ci-ops
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [variants, images, streams, tags]
+description: >-
+  Maps image names, streams, flavors, and branches to their published tags
+  and build workflows. Use when choosing an image reference for a command,
+  report, or workflow dispatch.
 metadata:
+  type: reference
   source-of-truth:
     - Justfile
     - image-versions.yml

--- a/docs/skills/worktrees/SKILL.md
+++ b/docs/skills/worktrees/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: worktrees
-description: Keep the main checkout clean by doing all feature work in isolated git worktrees. Use before starting any change, or when the tree is dirty.
+version: "1.0"
+last_updated: 2026-08-06
+id: worktrees
+one_line_purpose: Do all feature work in isolated git worktrees.
+entry_point: docs/skills/worktrees/SKILL.md
+category: meta
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: []
+tags: [git, worktrees, workflow, agents]
+description: >-
+  Covers the worktree helper script, branch naming, and cleanup so the main
+  checkout stays clean. Use before starting any change, or when the main
+  checkout is dirty or on a stale branch.
 metadata:
+  type: procedure
   source-of-truth:
     - .github/scripts/worktree.sh
     - .github/scripts/install-hooks.sh

--- a/docs/skills/write-a-skill/SKILL.md
+++ b/docs/skills/write-a-skill/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: write-a-skill
+version: "1.0"
+last_updated: 2026-08-06
+id: write-a-skill
+one_line_purpose: Author a new skill directory that satisfies this repository's front-matter contract.
+entry_point: docs/skills/write-a-skill/SKILL.md
+category: meta
+mcp_compliance_level: partial
+optimization_status: draft
+status: active
+dependencies: [skill-improvement]
+tags: [skills, authoring, documentation, front-matter, validation]
+description: >-
+  Defines the required SKILL.md front-matter keys, size budget, index entry,
+  and validation command for a new skill in this repository. Use when adding a
+  new docs/skills directory or repairing front matter that fails validation.
+metadata:
+  type: procedure
+  source-of-truth:
+    - .github/scripts/validate-docs.py
+    - docs/skills/index.md
+    - AGENTS.md
+---
+
+# Write a skill
+
+## Use when
+
+- Adding a new `docs/skills/<name>/SKILL.md`.
+- Repairing front matter that `validate-docs.py` rejects.
+
+## Do not use when
+
+- Updating an existing skill's body: use
+  [skill-improvement](../skill-improvement/SKILL.md).
+
+## Required front matter
+
+Every `docs/skills/<name>/SKILL.md` starts with exactly these keys:
+
+```yaml
+---
+name: <kebab-case-name>          # must equal the directory name
+version: "1.0"                   # quoted semver string
+last_updated: YYYY-MM-DD
+id: <kebab-case-name>            # must equal name and the directory name
+one_line_purpose: <=120 chars, imperative, no "Use when" clause
+entry_point: docs/skills/<name>/SKILL.md
+category: ci-ops | test-authoring | meta
+mcp_compliance_level: partial
+optimization_status: draft
+status: active | deprecated | reserved
+dependencies: []                 # ids of skills that must load first
+tags: [tag1, tag2, tag3]         # 3-6 lowercase keywords
+description: >-                   # <=256 chars: capability sentence, then
+  <capability>. Use when <triggers>.
+metadata:
+  type: procedure | reference | runbook | policy
+  source-of-truth:
+    - <path that owns the mutable facts>
+---
+```
+
+`metadata.source-of-truth` is load-bearing: it tells an agent which files to
+read before documenting mutable behavior. Never drop it when editing front
+matter. `metadata` accepts additional keys (`audience`, `context7-sources`).
+
+## Procedure
+
+1. Confirm no existing skill covers the domain. Prefer updating one.
+2. Create `docs/skills/<name>/SKILL.md` with the front matter above.
+3. Write real values. `one_line_purpose` and `description` must describe this
+   skill specifically; templated filler is a defect.
+4. Add a row to [`index.md`](../index.md) linking `<name>/SKILL.md`.
+5. Move long detail to `docs/skills/<name>/references/*.md` and link it.
+6. Run the validation gate.
+
+## Body sections
+
+1. `## Use when` — concrete triggers.
+2. `## Do not use when` — pointers to the neighbouring skills.
+3. `## Procedure` or `## Decision tree` — the agent workflow.
+4. `## Verify` — commands that re-derive project-internal facts.
+
+## Local variances from projectbluefin/common
+
+This repository intentionally diverges from `projectbluefin/common`:
+
+- **Per-skill directories only.** Every skill is
+  `docs/skills/<name>/SKILL.md`. Flat `docs/skills/<name>.md` files are not
+  recognized by `validate-docs.py` and will fail the missing-`SKILL.md` check.
+- **Hard 180-line cap** per `SKILL.md`, enforced by `validate-docs.py`, rather
+  than common's 200-line soft / 500-line hard budget. `AGENTS.md` is capped at
+  150 lines and `docs/skills/index.md` at 80.
+- **Hand-curated index.** This repository does not adopt common's generated
+  `index.json`, `index.schema.json`, or `generate_skill_index.py`. The catalog
+  is small enough to curate by hand; `validate-docs.py` fails if a skill is
+  missing from `index.md`.
+- **No external YAML dependency.** `validate-docs.py` parses front matter with
+  a small hand-rolled reader, so the `validate` CI job needs no extra
+  packages. Keep new front-matter constructs simple: top-level scalars, inline
+  `[a, b]` lists, folded `>-` blocks, and one nested `metadata` mapping.
+
+## Red flags
+
+- `id`, `name`, or `entry_point` disagreeing with the directory name.
+- A `description` over 256 characters or missing its `Use when` sentence.
+- A new skill absent from `index.md`.
+- Duplicating a fact that a `source-of-truth` file already owns.
+
+## Verify
+
+```bash
+python3 .github/scripts/validate-docs.py
+wc -l docs/skills/*/SKILL.md
+pre-commit run --all-files
+```


### PR DESCRIPTION
Brings this repository's skill docs up to `projectbluefin/common`'s front-matter contract and enforces it locally.

## What changed

- Every `docs/skills/*/SKILL.md` now carries the full 14-key front matter (`name`, `version`, `last_updated`, `id`, `one_line_purpose`, `entry_point`, `category`, `mcp_compliance_level`, `optimization_status`, `status`, `dependencies`, `tags`, `description`, `metadata.type`). Existing `metadata.source-of-truth` blocks are preserved verbatim.
- `.github/scripts/validate-docs.py` enforces the contract: required keys, `id`/`entry_point` agreement with the directory, `category`/`status`/`metadata.type` enums, and the 256/120 char caps. The parser is a dependency-free YAML subset reader (folded `>-` aware), so the `validate` job needs no extra packages.
- Fixed a latent bug: the Markdown link check excluded `.worktrees` by matching absolute path parts, so it skipped **every** file when the repo was checked out under `.worktrees/`. Now `0 Markdown files` → `39 Markdown files`.
- New `docs/skills/write-a-skill/SKILL.md` documenting the authoring contract and this repo's deliberate variances from common: per-skill directories only, hard 180-line cap per `SKILL.md`, hand-curated index (no generated `index.json` / `index.schema.json` / `generate_skill_index.py`).

## Enforcement proof

Each violation was introduced temporarily and reverted; the validator failed with exit 1 in every case:

| Injected defect | Result |
|---|---|
| `category: bogus` | `invalid category 'bogus'` |
| `id: bulid` | `id does not match directory` |
| `entry_point: docs/skills/build.md` | `entry_point must be docs/skills/build/SKILL.md` |
| `status: retired` | `invalid status 'retired'` |
| `metadata.type: essay` | `invalid metadata.type 'essay'` |
| removed `version:` / `tags:` | `missing version metadata` / `missing tags metadata` |
| 130-char `one_line_purpose` | `one_line_purpose exceeds 120 characters` |
| 380-char folded `description` | `description exceeds 256 characters` |
| `name: builds` | `name does not match directory` (exit 1) |

## Validation

`just check`, `python3 .github/scripts/validate-docs.py` (13 skills, 39 Markdown files), `pre-commit run --all-files`, `bats tests/unit/` (148 tests) all pass. Line budgets: `AGENTS.md` 128/150, `docs/skills/index.md` 27/80, largest `SKILL.md` 118/180.