### PR TITLE
ci: document the :testing tag gate on the reusable-build caller

### DIFF
--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -61,5 +61,7 @@ jobs:
           || '["main", "nvidia"]'
         }}
       stream_name: testing
+      # Gate the mutable :testing pointer behind post-testing-e2e.yml's
+      # promote-to-testing job. This build must publish version alias tags only.
       publish_stream_tag: "false"
       pr_number: ${{ inputs.pr_number }}


### PR DESCRIPTION
Consumer validation PR for the stream-tag leak fix in `projectbluefin/actions` (`fix/ci/gate-stream-tag-leak`).

Exercises `reusable-build.yml@v1` with `publish_stream_tag: "false"` and adds a comment documenting why the bare `:testing` tag must not be pushed at build time. No behavior change in this repo.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>