### PR TITLE
docs(skills): note release input trust and worktree merge cleanup

### DIFF
--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -108,6 +108,10 @@ A job listed in `needs:` without `always()` makes its dependents `skipped` when
 it fails. Confirm whether a promotion job is *failing* or *never running*; the
 two look the same in the UI and have different fixes.
 
+`cmd | tee results.tap` reports the exit status of `tee`, not of `cmd`, so a
+failing test run passes the step. Set `pipefail` or check `PIPESTATUS` whenever
+a test command is piped.
+
 ## Hard rules
 
 - Verify the pull request base branch before debugging missing checks.

--- a/docs/skills/release-artifacts/SKILL.md
+++ b/docs/skills/release-artifacts/SKILL.md
@@ -59,6 +59,12 @@ Filter the stream tag out of the list itself.
 Never re-point or delete a published stream tag to "repair" this — that is
 user-visible and belongs to a human.
 
+Release consumes `:testing` as its **input**: the release job resolves the
+digest behind that tag rather than re-running end-to-end validation. The gate
+on `:testing` is therefore the only functional gate, and anything it admits
+propagates to `:stable` unchallenged. A gate step that reports `skipped` must
+never be accepted as a pass — treat only an explicit success as a pass.
+
 ## Red flags
 
 - Re-pulling a large image during release only to generate metadata.

--- a/docs/skills/worktrees/SKILL.md
+++ b/docs/skills/worktrees/SKILL.md
@@ -106,6 +106,7 @@ whether a branch is finished. `worktree.sh` asks the forge via `gh` instead.
 | Untracked `.worktrees/` in `git status` | Hook and ignore rules predate this setup | Confirm `.worktrees/` is in `.gitignore` |
 | Uncommitted work blocks `done` | Real changes in the worktree | Commit them, or `git worktree remove <path> --force` to discard |
 | A repo script reports zero files | It filters `.worktrees` out by path and is running inside one | Run it from the main checkout, or fix the filter to be checkout-relative |
+| `gh pr merge --delete-branch` fails locally after merging | The branch is still checked out in a worktree | The remote merge succeeded; finish with `worktree.sh done <branch>` |
 
 Tooling that excludes `.worktrees/` by absolute path components silently matches
 *everything* when it runs from inside a worktree. A validator that passes with a


### PR DESCRIPTION
Two more learnings from the same PR-queue sweep, both discovered after #994 was already open.

## `release-artifacts`
The audit behind projectbluefin/bluefin#995 established that `reusable-execute-release.yml` resolves the digest **behind `:testing`** rather than independently re-validating. That makes the gate on `:testing` the only functional gate, and anything it admits propagates to `:stable` unchallenged — which is exactly how an image that never passed e2e reached `:stable`.

Also records the related fail-open pattern: a gate step reporting `skipped` must not be counted as a pass, only an explicit success.

## `worktrees`
`gh pr merge --delete-branch` fails to delete the local branch when it is still checked out in a worktree. Hit this merging #994. The remote merge has already succeeded at that point, so the correct recovery is `worktree.sh done <branch>` — not re-running the merge.

## Validation
`validate-docs.py` passes (13 skills, 39 Markdown files). worktrees 128/180, release-artifacts 101/180.

Docs-only; no image build.