### PR TITLE
ci(bonedigger): drop the no-op pull_request trigger

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -1,14 +1,10 @@
-name: issue and PR lifecycle
+name: issue lifecycle
 
 on:
   issues:
     types: [opened, labeled, closed]
   issue_comment:
     types: [created]
-  pull_request:
-    types: [opened]
-    branches-ignore:
-      - main
   schedule:
     - cron: '0 9 * * *'
 
@@ -19,9 +15,6 @@ permissions:
 
 jobs:
   lifecycle:
-    # NOTE: the pull_request: opened trigger above dispatches this workflow, but the
-    # bonedigger lifecycle has no pull_request jobs yet, so every job is skipped.
-    # Tracked in projectbluefin/bluefin#981.
     uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603 # v1
     with:
       brand_name: "Bluefin"


### PR DESCRIPTION
## What problem are you solving?
<!-- Write this in your own words. One paragraph. No AI. -->

Every non-`main` pull request opened against this repo started a `bonedigger.yml` run that did nothing at all — the reusable workflow it calls has no `pull_request` jobs, so the whole run resolved to `skipped`. It is wasted CI dispatch and noise in the Actions list, and the comment explaining it pointed at a placeholder issue. #981 asked for a decision between dropping the trigger and adding PR jobs upstream; this takes the smaller option, since nothing in this repo needs PR lifecycle behavior today.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

Removes the `pull_request: types: [opened]` trigger and the TODO comment from `.github/workflows/bonedigger.yml`, and renames the workflow `issue and PR lifecycle` → `issue lifecycle` to match what it actually handles.

`pull-requests: write` is deliberately **kept**: `issue_comment` fires on pull requests too, so that permission is still reachable.

### Evidence

The pinned callee, `projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603` (= tag `v1`, verified via `gh api repos/projectbluefin/bonedigger/git/ref/tags/v1`), defines exactly two jobs:

```
30:  on-issue-opened:
31:    if: github.event_name == 'issues' && github.event.action == 'opened'
107:  on-issue-comment:
108:    if: >-
109:      github.event_name == 'issue_comment' && ...
```

There is no `pull_request` job and no other `event_name` comparison, which matches the issue description.

Observed run history confirms the no-op:

```
$ gh run list -R projectbluefin/bluefin --workflow=bonedigger.yml -L 15 \
    --json event,conclusion,databaseId
pull_request skipped 31190297397
pull_request skipped 31177999157
...
```

Every `pull_request` run is `skipped`. (Note the `issues` and `schedule` runs are currently `skipped` as well — that is a separate condition and is **not** addressed here.)

`bonedigger.yml` is not a required status check: the only ruleset (`main`) requires `validate`, so removing this trigger cannot block merges.

## Testing

- [x] `just check` passes
- [ ] `pre-commit run --all-files` — not run; `pre-commit` is not installed in this runtime (`command -v pre-commit` is empty).
- [x] Documentation updated when a reusable procedure or source-of-truth fact changed — no doc change needed; `docs/skills/issue-lifecycle/SKILL.md` does not document the `pull_request` trigger.
- [ ] Build tested locally — not applicable, no image change.

Not verified: I cannot dispatch a workflow on the upstream repo, so the post-merge absence of `pull_request` runs is unverified. It is directly observable after merge via the `gh run list` command above.

## Checklist

- [x] Conventional commit message (`feat:`, `fix:`, `chore:`, etc.)
- [x] No hardcoded secrets or credentials
- [x] Package additions follow COPR isolation rules — not applicable

## Community verification (bug-fix PRs)

CI-only change; nothing ships to users in an image.

Closes #981
