### PR TITLE
docs(skills): record e2e gate triage and tag verification

### DIFF
--- a/docs/skills/ci/references/failure-modes.md
+++ b/docs/skills/ci/references/failure-modes.md
@@ -9,3 +9,39 @@
 | Shared action behaves incorrectly | Reusable workflow source and its callers |
 
 Always inspect the failed run logs before changing a workflow.
+
+## Reading a failed `post-testing-e2e` run
+
+`promote-to-testing` in `.github/workflows/post-testing-e2e.yml` needs
+`run-e2e.result == 'success'`, so a single failing matrix leg makes the whole
+gate `skipped`. Identify the failing leg and its failing scenarios before
+concluding anything about the image:
+
+```bash
+gh run view RUN_ID --repo projectbluefin/bluefin --json jobs \
+  --jq '.jobs[] | [.name, .conclusion] | @tsv'
+gh run view RUN_ID --repo projectbluefin/bluefin --log \
+  | grep -A20 'Failing scenarios:'
+```
+
+The behave summary line (`N scenarios passed, N failed`) and the
+`Failing scenarios:` block name the exact feature file and line. That is the
+only evidence that identifies the failure; job names do not.
+
+## The `oras` screenshot error is not the failure
+
+In `projectbluefin/testsuite`'s `e2e.yml@v1`, the `Push desktop screenshot to
+GHCR` step builds a tag with
+`IMAGE_SLUG=$(echo "${IMAGE}" | sed 's|ghcr.io/[^/]*/||' | tr ':' '-')`.
+When the caller passes a digest reference — `post-testing-e2e.yml` passes
+`ghcr.io/<owner>/bluefin@sha256:…` — the slug keeps the `@sha256-…` suffix and
+`oras push` rejects it:
+
+```
+invalid reference: invalid digest "sha256-…"
+```
+
+That step is `continue-on-error: true`, so it produces a red `##[error]` line in
+the log without failing the job. Runs that pass `:testing` by tag (for example
+`nightly.yml`) do not show it at all. Do not report it as the cause of a
+`post-testing-e2e` failure; find the behave summary instead.

--- a/docs/skills/release-artifacts/SKILL.md
+++ b/docs/skills/release-artifacts/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release-artifacts
 version: "1.0"
-last_updated: 2026-08-06
+last_updated: 2026-08-07
 id: release-artifacts
 one_line_purpose: Prepare, verify, and troubleshoot image release and promotion.
 entry_point: docs/skills/release-artifacts/SKILL.md
@@ -50,6 +50,21 @@ skopeo inspect docker://ghcr.io/projectbluefin/bluefin:testing --format '{{.Dige
 gh run list --repo projectbluefin/bluefin --workflow post-testing-e2e.yml --limit 20
 ```
 
+Without `skopeo`, the GHCR package API resolves the same mapping and also shows
+which tags share one package version — co-located version and stream tags mean
+the build pushed the stream tag, not a promotion:
+
+```bash
+gh api "/orgs/projectbluefin/packages/container/bluefin/versions?per_page=100" \
+  --jq '.[] | select(.metadata.container.tags | index("testing"))
+        | [.name, .created_at, (.metadata.container.tags | join(","))] | @tsv'
+```
+
+Then confirm the gate actually passed for that digest: a `post-testing-e2e` run
+whose `promote-to-testing` job is `skipped` did **not** promote, whatever the
+tag now points at. See
+[ci failure modes](../ci/references/failure-modes.md) for reading those runs.
+
 A promotion job reported as `skipped` while the stream tag still advanced means
 something outside the gate is publishing it. Build-time tag computation is the
 usual source: the bare stream tag can sit in the tag list that the push step
@@ -64,6 +79,15 @@ digest behind that tag rather than re-running end-to-end validation. The gate
 on `:testing` is therefore the only functional gate, and anything it admits
 propagates to `:stable` unchallenged. A gate step that reports `skipped` must
 never be accepted as a pass — treat only an explicit success as a pass.
+
+Only `:stable` is a promotion target. `git grep -n target_tag .github/workflows`
+returns `execute-release.yml` alone, so `:latest` has no writer in this
+repository — it is a stale pointer, not a tag that release moves. Do not treat
+it as a release output.
+
+While the `:testing` gate is red, `:testing` is expected to stop advancing.
+A frozen stream tag is the gate working; re-pointing or deleting it to unfreeze
+users is a human decision, not an agent action.
 
 ## Red flags
 


### PR DESCRIPTION
Follow-up to the audit in #995. That audit is a snapshot; this PR writes down the parts that are reusable so the next reader does not have to re-derive them.

Nothing in GHCR, and no workflow, is changed here. Docs only.

## What I re-verified before writing

- `post-testing-e2e.yml` census, `gh run list --workflow post-testing-e2e.yml -L 400`: 19 `success`, 246 `failure`, 135 `skipped`. Last success `27922740150`, 2026-06-22.
- Latest failure, run [31180129956](https://github.com/projectbluefin/bluefin/actions/runs/31180129956): only `smoke-a` fails; behave reports `37 scenarios passed, 8 failed`, and the `Failing scenarios:` block names `firefox.feature:17,21,26,30,35,40`, `bluefin_desktop.feature:18`, `gnome_accessibility.feature:33` — `AssertionError: Firefox address bar not found`. Same failure set in `28148474893` (2026-06-25) and in nightly `31142888704`, so it is the long-lived failure already tracked in #989.
- `promote-to-testing` has `needs: [e2e, run-e2e]` with `needs.run-e2e.result == 'success'` (`.github/workflows/post-testing-e2e.yml:77-80`), so one red matrix leg makes the gate `skipped`, not `failure`.
- GHCR package API: exactly one `bluefin` version carries `testing`, and it carries `testing-20260804` and `testing-44.20260804` on the same version — the build pushed the stream tag.
- `git grep -n target_tag .github/workflows` returns only `execute-release.yml` lines 43-44, both `"target_tag":"stable"`. No writer for `:latest` in this repo.

## The one new fact

The `##[error]` line in every digest-referenced e2e run is a red herring, and I lost time on it before finding the behave summary:

```
Error: "ghcr.io/projectbluefin/testsuite/desktop-screenshot:bluefin@sha256-9ff5adfe…-smoke-latest": invalid reference: invalid digest
```

`projectbluefin/testsuite`'s `e2e.yml@v1` builds that tag with `IMAGE_SLUG=$(echo "${IMAGE}" | sed 's|ghcr.io/[^/]*/||' | tr ':' '-')`. A digest reference keeps its `@sha256-…` suffix, which is not a legal tag. The step is `continue-on-error: true`, so it colours the log red without failing the job, and it never appears in runs that pass `:testing` by tag (`nightly.yml`). It is a real cosmetic bug in `projectbluefin/testsuite`, not in this repo, and not the cause of any gate failure — so it is documented here as a triage trap rather than fixed here.

## Changes

- `docs/skills/ci/references/failure-modes.md` — how to find the failing matrix leg and its behave summary; the `oras` red herring.
- `docs/skills/release-artifacts/SKILL.md` — the GHCR package API as a `skopeo`-free way to resolve a stream tag and to see tag co-location; `:latest` has no writer; a frozen `:testing` under a red gate is correct behaviour and unfreezing it is a human decision.

## Not addressed

The four human decisions in #995 (re-pointing `:testing` / `:stable`, and tightening the `release-gate == 'skipped'` fail-open in `projectbluefin/actions`) are untouched. The `:testing` freeze stays frozen until #989's Firefox AT-SPI failure is repaired.

## Validation

`just check` passes. `pre-commit` and `actionlint` are not installed in this runtime, so I did not run them; no workflow YAML is touched by this change.

Assisted-by: Claude via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
