### PR TITLE
docs(ci): explain nested testsuite workflow refs

### DIFF
--- a/docs/skills/ci/references/failure-modes.md
+++ b/docs/skills/ci/references/failure-modes.md
@@ -7,5 +7,12 @@
 | Workflow did not trigger | Event, branch, and path filters in the YAML |
 | Promotion is blocked | Exact digest, required check, and merge-group state |
 | Shared action behaves incorrectly | Reusable workflow source and its callers |
+| Tests update but E2E setup stays stale | Compare the reusable workflow `uses` ref with its test checkout ref |
 
 Always inspect the failed run logs before changing a workflow.
+
+A reusable testsuite workflow has two independent refs: `uses` selects the
+workflow definition and `test_ref` selects the test tree it checks out. A
+managed `test_ref` does not deliver workflow-level fixes such as VM disk sizing
+when `uses` is pinned to an older commit. Keep both layers on the documented
+managed ref, and verify the nested workflow shown in the run log.


### PR DESCRIPTION
## What problem are you solving?

Stable-promotion triage can mistake `test_ref: v1` for proof that every testsuite fix is current. The nested reusable workflow has a separate `uses` ref, so workflow-level fixes such as VM disk sizing remain stale when that ref is pinned. This documents the distinction found while investigating #929 and provides consumer validation for the owner-side `projectbluefin/actions` fix.

- [x] I am using an agent and I take responsibility for this PR

## Changes

- add the nested workflow/test checkout ref split to the CI failure-mode table
- direct promotion triage to verify the reusable workflow shown in the run log

## Testing

- `just check`
- `python3 .github/scripts/validate-docs.py`
- `pre-commit run --files docs/skills/ci/references/failure-modes.md`

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] Documentation updated for the reusable CI procedure
- [x] No image or release-gate behavior changed

Refs #929

Owner-side fix: projectbluefin/actions#409