### PR TITLE
fix(ci): propagate BATS failures

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -140,7 +140,9 @@ jobs:
           kcov --version
 
       - name: Run unit tests
-        run: bats --formatter tap tests/unit/ | tee results.tap
+        run: |
+          set -o pipefail
+          bats --formatter tap tests/unit/ | tee results.tap
 
       - name: Generate BATS coverage report
         env:

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -110,7 +110,9 @@ two look the same in the UI and have different fixes.
 
 `cmd | tee results.tap` reports the exit status of `tee`, not of `cmd`, so a
 failing test run passes the step. Set `pipefail` or check `PIPESTATUS` whenever
-a test command is piped.
+a test command is piped. The authoritative BATS run in `pr-validation.yml`
+enables `pipefail` before teeing `results.tap`; the separate instrumented rerun
+collects coverage but does not own pass/fail.
 
 ## Hard rules
 

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "pr-validation.yml"
+
+
+class PrValidationTests(unittest.TestCase):
+    def test_bats_tee_pipeline_enables_pipefail_first(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        marker = "      - name: Run unit tests\n"
+        self.assertIn(marker, workflow)
+
+        step = workflow.split(marker, 1)[1].split("\n      - name: ", 1)[0]
+        self.assertIn("set -o pipefail", step)
+        self.assertIn("bats --formatter tap tests/unit/ | tee results.tap", step)
+        self.assertLess(step.index("set -o pipefail"), step.index("| tee results.tap"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/04-install-kernel-akmods_test.bats
+++ b/tests/unit/04-install-kernel-akmods_test.bats
@@ -102,6 +102,12 @@ if [[ -n "${target}" ]]; then
     chmod +x "${target}/rpms/ublue-os/nvidia-install.sh"
     mkdir -p "${target}/rpms/kmods/zfs"
     touch "${target}/rpms/kmods/zfs/kmod-zfs-${KERNEL}-1.rpm"
+    touch "${target}/rpms/kmods/zfs/libnvpair1-1.rpm"
+    touch "${target}/rpms/kmods/zfs/libuutil1-1.rpm"
+    touch "${target}/rpms/kmods/zfs/libzfs1-1.rpm"
+    touch "${target}/rpms/kmods/zfs/libzpool1-1.rpm"
+    touch "${target}/rpms/kmods/zfs/python3-pyzfs-1.rpm"
+    touch "${target}/rpms/kmods/zfs/zfs-1.rpm"
 fi
 exit 0
 STUBEOF
@@ -178,6 +184,7 @@ EOF
     # Redirect absolute system paths into the sandbox.
     PATCHED_SCRIPT="${TEST_ROOT}/04-patched.sh"
     sed \
+        -e "s|\"/tmp\"|\"${TEST_ROOT}/tmp\"|g" \
         -e "s|/tmp/|${TEST_ROOT}/tmp/|g" \
         -e "s|/etc/yum.repos.d/|${TEST_ROOT}/etc/yum.repos.d/|g" \
         -e "s|/etc/pki/akmods/|${TEST_ROOT}/etc/pki/akmods/|g" \


### PR DESCRIPTION
## What problem are you solving?

The required `Unit tests` step pipes BATS through `tee` without `pipefail`, so it reports `tee`'s success even when BATS fails. On current `testing`, 16 tests still failed because the kernel-akmods fixture did not fully follow the Python rewrite; the Framework and Titanoboa failures from the original report had already been fixed.

- [x] I am using an agent and I take responsibility for this PR

## Changes

- repair the kernel-akmods sandbox extraction root and complete its fake ZFS RPM payload
- enable `pipefail` before the authoritative BATS-to-TAP pipeline
- add a Python regression test requiring `pipefail` before `tee`
- document the authoritative BATS/coverage pass-fail contract

No tests are quarantined or weakened.

## Testing

- `bats --formatter tap tests/unit/` — 148 passed
- `python3 -m unittest discover -s tests -p "test_*.py"` — 3 passed
- `actionlint .github/workflows/pr-validation.yml`
- `pre-commit run --files` for all changed paths
- `just check`
- `python3 .github/scripts/validate-docs.py`

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] CI documentation updated with the behavior change
- [x] No image assembly behavior changed

Closes #1000