### PR TITLE
fix(build): give Stage 2 and the ISO stage narrow ctx mounts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,9 +20,25 @@ FROM scratch AS ctx-build
 COPY /build_files /build_files
 COPY /image-versions.yml /image-versions.yml
 
+# ISO context. Same reasoning as `ctx-build`: the ISO RUN reads exactly two
+# files, so giving it its own scratch stage keeps an edit to
+# 21-container-native-iso.sh from invalidating Stage 2, and keeps an edit to
+# any other build_files script from invalidating the ISO layer.
+FROM scratch AS ctx-iso
+COPY /build_files/base/21-container-native-iso.sh /build_files/base/21-container-native-iso.sh
+COPY /build_files/shared/utils/ghcurl /build_files/shared/utils/ghcurl
+
+# Overlay context for extension-builder and Stage 2. Carries system_files plus
+# only the build_files that run after Stage 1; the package-install scripts
+# (03/04/05) are deliberately absent so editing them cannot invalidate Stage 2.
+# A script added to Stage 2 must be added here too, or the build fails loudly.
 FROM scratch AS ctx
 COPY /system_files /system_files
-COPY /build_files /build_files
+COPY /build_files/shared /build_files/shared
+COPY /build_files/base/00-image-info.sh /build_files/base/00-image-info.sh
+COPY /build_files/base/17-cleanup.sh /build_files/base/17-cleanup.sh
+COPY /build_files/base/19-initramfs.sh /build_files/base/19-initramfs.sh
+COPY /build_files/base/20-tests.sh /build_files/base/20-tests.sh
 COPY --from=common /system_files/shared /system_files/shared
 COPY --from=common /system_files/bluefin /system_files/shared
 COPY --from=brew /system_files /system_files/shared
@@ -105,8 +121,10 @@ COPY --from=extension-builder /usr/share/gnome-shell/extensions /usr/share/gnome
 COPY --from=extension-builder /usr/share/glib-2.0/schemas /usr/share/glib-2.0/schemas
 
 # Stage 2: overlay system_files, finalize extensions, clean up, and finalize the image.
-# Narrow mount (system_files/ + build_files/shared) means package-script changes
-# do NOT invalidate this stage when build_files/base is unchanged.
+# Mounts from `ctx`, which excludes the package-install scripts, so an edit to
+# 03/04/05-*.sh cannot invalidate this stage. Editing any file this stage does
+# read — system_files/, build_files/shared/, or one of the four base scripts
+# below — still rebuilds it, which is correct.
 RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=bind,from=ctx,source=/system_files,target=/ctx/system_files \
     --mount=type=bind,from=ctx,source=/build_files/shared,target=/ctx/build_files/shared \
@@ -132,8 +150,8 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
 
 # Embed the Stable container-native ISO contract after Stage 2. This runs
 # without the /boot tmpfs so Titanoboa can consume the committed EFI payload.
-RUN --mount=type=bind,from=ctx,source=/build_files/base/21-container-native-iso.sh,target=/ctx/build_files/base/21-container-native-iso.sh \
-    --mount=type=bind,from=ctx,source=/build_files/shared/utils/ghcurl,target=/ctx/build_files/shared/utils/ghcurl \
+RUN --mount=type=bind,from=ctx-iso,source=/build_files/base/21-container-native-iso.sh,target=/ctx/build_files/base/21-container-native-iso.sh \
+    --mount=type=bind,from=ctx-iso,source=/build_files/shared/utils/ghcurl,target=/ctx/build_files/shared/utils/ghcurl \
     --mount=type=secret,id=GITHUB_TOKEN \
     bash -euo pipefail -c ' \
         mkdir -p /var/cache/bluefin-iso/helpers && \

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ci
 version: "1.0"
-last_updated: 2026-08-06
+last_updated: 2026-08-07
 id: ci
 one_line_purpose: Debug and change repository GitHub Actions workflows.
 entry_point: docs/skills/ci/SKILL.md
@@ -77,9 +77,11 @@ gh api -X POST repos/projectbluefin/bluefin/actions/runs/RUN_ID/approve
 contributor's branch.
 
 Containerfile stages that consume source through bind mounts inherit the mounted
-stage's image ID as part of their cache key. Give the package stage its own
-narrow `scratch` context so unrelated edits do not invalidate it, and pass an
-explicit content-hash build argument as a second guard.
+stage's image ID as part of their cache key. Give each consuming stage its own
+narrow `scratch` context covering only the paths it reads — `ctx-build` for the
+package stage, `ctx` for the overlay stages, `ctx-iso` for the ISO layer — and
+pass an explicit content-hash build argument as a second guard. A shared wide
+context silently couples every stage to every input directory.
 
 Every open Bluefin PR is discovered by the lab's five-minute PR poller. The lab
 runs smoke QA against `bluefin:testing` and sends bounded


### PR DESCRIPTION
Closes #996. Follow-up to #964, which established the `ctx-build` pattern and deliberately left these two stages out of scope.

## Problem

Both remaining consumers mounted from the wide `ctx`, which carried `build_files/` **and** `system_files/`. Since buildah folds the mounted stage's image ID into the consuming `RUN`'s cache key (the mechanism #964 verified empirically), an edit anywhere in either directory invalidated Stage 2 and the ISO layer together.

## Change

Two edits, no behaviour change:

- **`ctx` narrowed to what Stage 2 actually reads** — `system_files/`, `build_files/shared/`, and the four `build_files/base` scripts the stage invokes (`00-image-info.sh`, `17-cleanup.sh`, `19-initramfs.sh`, `20-tests.sh`). The package-install scripts (`03`/`04`/`05`) are gone from it, so editing them can no longer invalidate Stage 2.
- **New `ctx-iso` scratch stage** — the ISO `RUN` reads exactly two files (`21-container-native-iso.sh` and `shared/utils/ghcurl`), so it gets a context holding only those.

The `--mount` lines and every `/ctx/...` path inside the `RUN` payloads are unchanged; only the `from=` stage and what each context copies changed.

## Why `ctx` keeps `build_files/shared` whole

`17-cleanup.sh` does `source /ctx/build_files/shared/disable-repos.sh` (line 49), and Stage 2 invokes `finalize-gnome-extensions.sh`, `validate-repos.sh`, and `clean-stage.sh` from that directory. Enumerating those files individually would add four more `COPY` lines that must be kept in sync with the payload for no cache benefit — the whole directory is 5 scripts plus `utils/`.

## Verification

I could not run the empirical two-build cache check the issue asks for. **This runtime has no container tooling** — `command -v podman buildah` both return nothing, and there is no package manager to install them. That check needs a maintainer or CI.

What I did verify:

- **Every bind mount resolves against its context stage.** Script-checked all 12 `--mount=type=bind` lines against the `COPY` destinations of the three `scratch` stages: all resolve. Every `COPY` source also exists in the working tree.
- **No unmounted `/ctx/...` reference.** Script-extracted every `/ctx/…` path from each `RUN` payload and confirmed it falls under one of that `RUN`'s own mount targets. A missing script would fail the build loudly at that `RUN`, not silently.
- **`build_files/base/18-workarounds.sh` is intentionally absent** — `grep -n 18-workarounds Containerfile` finds nothing; it is only referenced by the unused `build_files/shared/build.sh`. Not a regression from this change.
- `just check` passes. `python3 .github/scripts/validate-docs.py` passes (13 skills, 39 files).
- **Not run:** `hadolint` and `pre-commit` are not installed here. `shellcheck` is scoped to `^(build_files|system_files)/.*\.sh$` and no shell script changed.

## Risk

If a future edit adds a `build_files/base` script to Stage 2 without adding it to `ctx`, the build fails at that `RUN` with a missing path — noisy, not silent. I noted that in the stage comment.

Assisted-by: Claude via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
