### PR TITLE
docs(security): document CVE-2026-33186 in buildah (no F44 fix available)

### DIFF
--- a/docs/skills/security/SKILL.md
+++ b/docs/skills/security/SKILL.md
@@ -50,6 +50,7 @@ do not invent a replacement key or trust path.
 
 - [COPR isolation invariant](references/copr-isolation.md)
 - [signing and verification](references/signing.md)
+- [CVE-2026-33186 grpc in buildah](references/cve-2026-33186-grpc-buildah.md)
 
 ## When to Use
 

--- a/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
+++ b/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
@@ -1,0 +1,50 @@
+# CVE-2026-33186 (google.golang.org/grpc) in the buildah binary
+
+Severity: **Critical** (CVSS ≥ 9.0, per the vulnerability scan gate).
+
+## Finding
+
+CVE-2026-33186 affects `google.golang.org/grpc v1.72.2`, which is bundled in the
+`buildah` binary shipped by the Fedora container-tools stack. There is **no
+self-contained fix** that this repository can apply on the Fedora 44 target.
+
+## Root cause
+
+- The vulnerable module is bundled in `buildah`, not in an explicitly declared
+  image package. `buildah` is not listed in `build_files/packages/base.toml`; it
+  arrives as part of the standard Fedora Silverblue container-tools set
+  (podman/buildah/skopeo) and is not excluded.
+- `containers/buildah@v1.43.2/go.mod` pins `google.golang.org/grpc v1.72.2 // indirect`
+  (the vulnerable version).
+- Fedora 44's latest available buildah is `buildah-1.43.2-1.fc44` (stable since
+  `2026-06-19`), which still bundles grpc v1.72.2.
+- As of the last check (`2026-08-07`), Bodhi lists **no** F44 `buildah` update in
+  `testing` or `pending` status. There is no newer F44 RPM to pin or override to.
+- Fedora 45 carries a fixed buildah: `buildah-1.45.0-2.fc45` bundles
+  `google.golang.org/grpc v1.82.1`. The fix is therefore gated on a Fedora 45
+  migration, not on an in-repo pin.
+
+## Why an in-repo pin/override does not resolve it
+
+The `Pins and Overrides` section in `build_files/base/03-packages.sh` documents the
+mechanism for `rpm-ostree override replace`, but it requires a fixed RPM that
+exists in a Fedora repo. No such F44 buildah RPM exists. Downgrading is not
+helpful (older versions are also vulnerable), and no F44 `buildah` build bumps
+grpc to `>= 1.79.3`.
+
+## Action
+
+Wait for/track an upstream Fedora 44 `buildah` update (>= v1.44.0, or a 1.43.x
+backport that bumps grpc to >= 1.79.3). Once that RPM reaches the F44 repos, the
+next `testing` build picks it up automatically. The durable fix is the Fedora 45
+migration. Do not weaken the vulnerability scan gate or add an exception; this
+finding is a tracking note, not an approval to suppress the scan.
+
+## Verification
+
+- Fedora 44 updates repo: `buildah-1.43.2-1.fc44` (no newer version).
+- Bodhi F44 buildah: no `testing` or `pending` updates as of `2026-08-07`.
+- `containers/buildah@v1.43.2/go.mod` → `google.golang.org/grpc v1.72.2 // indirect`.
+- `containers/buildah@v1.45.0/go.mod` → `google.golang.org/grpc v1.82.1`.
+- Bluefin `Containerfile` target: `ARG FEDORA_MAJOR_VERSION="44"`; the latest
+  successful testing build resolved `fedora_version=44`.


### PR DESCRIPTION
Closes #919

## Summary

This PR documents CVE-2026-33186 (google.golang.org/grpc v1.72.2) in the
buildah binary of the Fedora 44 container-tools stack.

## Finding

There is **no self-contained fix** this repository can apply on the Fedora 44
target:

- `containers/buildah@v1.43.2/go.mod` pins `google.golang.org/grpc v1.72.2` (vulnerable).
- Fedora 44's latest available buildah is `buildah-1.43.2-1.fc44` (stable since 2026-06-19), which still bundles grpc v1.72.2.
- Bodhi lists **no** F44 `buildah` update in testing or pending status as of 2026-08-07.
- Fedora 45 carries a fixed buildah: `buildah-1.45.0-2.fc45` bundles grpc v1.82.1.

The durable fix is the Fedora 45 migration. Once a fixed F44 buildah RPM
reaches the Fedora repos, the next testing build picks it up automatically.

## Change

- Added `docs/skills/security/references/cve-2026-33186-grpc-buildah.md` documenting the root cause, why no in-repo pin works, and the action.
- Linked the reference from the security skill.

## Validation

- `python3 .github/scripts/validate-docs.py` passes.
- `just check` passes.