### PR TITLE
fix(framework): enable native battery charge control

### DIFF
--- a/system_files/shared/usr/lib/modprobe.d/fw-charge-control.conf
+++ b/system_files/shared/usr/lib/modprobe.d/fw-charge-control.conf
@@ -1,0 +1,1 @@
+options cros_charge_control probe_with_fwk_charge_control=1


### PR DESCRIPTION
## Summary

- enable Framework probing in the in-tree `cros_charge_control` driver
- expose the standard battery charge threshold sysfs interface used by Battery Health Charging

The kernel driver intentionally declines Framework EC firmware unless `probe_with_fwk_charge_control=1` is set. This leaves AMD Framework systems without `charge_control_end_threshold`, so the GNOME extension reports missing dependencies even on kernels that contain the driver.

Closes #879

## Validation

- [x] `just check`
- [x] `uvx pre-commit run --all-files`
- [ ] Full image build (not run; image assembly logic is unchanged)