### PR TITLE
fix(build): fully isolate Stage 2 and ISO contexts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,9 +20,25 @@ FROM scratch AS ctx-build
 COPY /build_files /build_files
 COPY /image-versions.yml /image-versions.yml
 
+# ISO context. Same reasoning as `ctx-build`: the ISO RUN reads exactly two
+# files, so giving it its own scratch stage keeps an edit to
+# 21-container-native-iso.sh from invalidating Stage 2, and keeps an edit to
+# any other build_files script from invalidating the ISO layer.
+FROM scratch AS ctx-iso
+COPY /build_files/base/21-container-native-iso.sh /build_files/base/21-container-native-iso.sh
+COPY /build_files/shared/utils/ghcurl /build_files/shared/utils/ghcurl
+
+# Overlay context for extension-builder and Stage 2. Carries system_files plus
+# only the build_files that run after Stage 1; the package-install scripts
+# (03/04/05) are deliberately absent so editing them cannot invalidate Stage 2.
+# A script added to Stage 2 must be added here too, or the build fails loudly.
 FROM scratch AS ctx
 COPY /system_files /system_files
-COPY /build_files /build_files
+COPY /build_files/shared /build_files/shared
+COPY /build_files/base/00-image-info.sh /build_files/base/00-image-info.sh
+COPY /build_files/base/17-cleanup.sh /build_files/base/17-cleanup.sh
+COPY /build_files/base/19-initramfs.sh /build_files/base/19-initramfs.sh
+COPY /build_files/base/20-tests.sh /build_files/base/20-tests.sh
 COPY --from=common /system_files/shared /system_files/shared
 COPY --from=common /system_files/bluefin /system_files/shared
 COPY --from=brew /system_files /system_files/shared
@@ -105,8 +121,10 @@ COPY --from=extension-builder /usr/share/gnome-shell/extensions /usr/share/gnome
 COPY --from=extension-builder /usr/share/glib-2.0/schemas /usr/share/glib-2.0/schemas
 
 # Stage 2: overlay system_files, finalize extensions, clean up, and finalize the image.
-# Narrow mount (system_files/ + build_files/shared) means package-script changes
-# do NOT invalidate this stage when build_files/base is unchanged.
+# Mounts from `ctx`, which excludes the package-install scripts, so an edit to
+# 03/04/05-*.sh cannot invalidate this stage. Editing any file this stage does
+# read — system_files/, build_files/shared/, or one of the four base scripts
+# below — still rebuilds it, which is correct.
 RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=bind,from=ctx,source=/system_files,target=/ctx/system_files \
     --mount=type=bind,from=ctx,source=/build_files/shared,target=/ctx/build_files/shared \
@@ -132,8 +150,8 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
 
 # Embed the Stable container-native ISO contract after Stage 2. This runs
 # without the /boot tmpfs so Titanoboa can consume the committed EFI payload.
-RUN --mount=type=bind,from=ctx,source=/build_files/base/21-container-native-iso.sh,target=/ctx/build_files/base/21-container-native-iso.sh \
-    --mount=type=bind,from=ctx,source=/build_files/shared/utils/ghcurl,target=/ctx/build_files/shared/utils/ghcurl \
+RUN --mount=type=bind,from=ctx-iso,source=/build_files/base/21-container-native-iso.sh,target=/ctx/build_files/base/21-container-native-iso.sh \
+    --mount=type=bind,from=ctx-iso,source=/build_files/shared/utils/ghcurl,target=/ctx/build_files/shared/utils/ghcurl \
     --mount=type=secret,id=GITHUB_TOKEN \
     bash -euo pipefail -c ' \
         mkdir -p /var/cache/bluefin-iso/helpers && \

--- a/Containerfile
+++ b/Containerfile
@@ -29,12 +29,17 @@ COPY /build_files/base/21-container-native-iso.sh /build_files/base/21-container
 COPY /build_files/shared/utils/ghcurl /build_files/shared/utils/ghcurl
 
 # Overlay context for extension-builder and Stage 2. Carries system_files plus
-# only the build_files that run after Stage 1; the package-install scripts
-# (03/04/05) are deliberately absent so editing them cannot invalidate Stage 2.
+# only the build_files that run after Stage 1; package-install scripts and
+# shared package helpers are absent so editing them cannot invalidate Stage 2.
 # A script added to Stage 2 must be added here too, or the build fails loudly.
 FROM scratch AS ctx
 COPY /system_files /system_files
-COPY /build_files/shared /build_files/shared
+COPY /build_files/shared/build-gnome-extensions.sh /build_files/shared/build-gnome-extensions.sh
+COPY /build_files/shared/clean-stage.sh /build_files/shared/clean-stage.sh
+COPY /build_files/shared/disable-repos.sh /build_files/shared/disable-repos.sh
+COPY /build_files/shared/finalize-gnome-extensions.sh /build_files/shared/finalize-gnome-extensions.sh
+COPY /build_files/shared/utils/ghcurl /build_files/shared/utils/ghcurl
+COPY /build_files/shared/validate-repos.sh /build_files/shared/validate-repos.sh
 COPY /build_files/base/00-image-info.sh /build_files/base/00-image-info.sh
 COPY /build_files/base/17-cleanup.sh /build_files/base/17-cleanup.sh
 COPY /build_files/base/19-initramfs.sh /build_files/base/19-initramfs.sh
@@ -123,7 +128,7 @@ COPY --from=extension-builder /usr/share/glib-2.0/schemas /usr/share/glib-2.0/sc
 # Stage 2: overlay system_files, finalize extensions, clean up, and finalize the image.
 # Mounts from `ctx`, which excludes the package-install scripts, so an edit to
 # 03/04/05-*.sh cannot invalidate this stage. Editing any file this stage does
-# read — system_files/, build_files/shared/, or one of the four base scripts
+# read — system_files/, a copied shared helper, or one of the four base scripts
 # below — still rebuilds it, which is correct.
 RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=bind,from=ctx,source=/system_files,target=/ctx/system_files \

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ci
 version: "1.0"
-last_updated: 2026-08-06
+last_updated: 2026-08-07
 id: ci
 one_line_purpose: Debug and change repository GitHub Actions workflows.
 entry_point: docs/skills/ci/SKILL.md
@@ -77,9 +77,11 @@ gh api -X POST repos/projectbluefin/bluefin/actions/runs/RUN_ID/approve
 contributor's branch.
 
 Containerfile stages that consume source through bind mounts inherit the mounted
-stage's image ID as part of their cache key. Give the package stage its own
-narrow `scratch` context so unrelated edits do not invalidate it, and pass an
-explicit content-hash build argument as a second guard.
+stage's image ID as part of their cache key. Give each consuming stage its own
+narrow `scratch` context covering only the paths it reads — `ctx-build` for the
+package stage, `ctx` for the overlay stages, `ctx-iso` for the ISO layer — and
+pass an explicit content-hash build argument as a second guard. A shared wide
+context silently couples every stage to every input directory.
 
 Every open Bluefin PR is discovered by the lab's five-minute PR poller. The lab
 runs smoke QA against `bluefin:testing` and sends bounded

--- a/tests/unit/containerfile_contexts_test.bats
+++ b/tests/unit/containerfile_contexts_test.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+CONTAINERFILE="${SCRIPT_DIR}/../../Containerfile"
+
+@test "Stage 2 context contains only its build_files inputs" {
+    run python3 -c '
+from pathlib import Path
+import sys
+
+lines = Path(sys.argv[1]).read_text().splitlines()
+start = lines.index("FROM scratch AS ctx")
+end = next(index for index in range(start + 1, len(lines)) if lines[index].startswith("FROM "))
+copies = {
+    line.split()[1]
+    for line in lines[start + 1:end]
+    if line.startswith("COPY /build_files/")
+}
+expected = {
+    "/build_files/base/00-image-info.sh",
+    "/build_files/base/17-cleanup.sh",
+    "/build_files/base/19-initramfs.sh",
+    "/build_files/base/20-tests.sh",
+    "/build_files/shared/build-gnome-extensions.sh",
+    "/build_files/shared/clean-stage.sh",
+    "/build_files/shared/disable-repos.sh",
+    "/build_files/shared/finalize-gnome-extensions.sh",
+    "/build_files/shared/utils/ghcurl",
+    "/build_files/shared/validate-repos.sh",
+}
+if copies != expected:
+    print(f"unexpected ctx build inputs: {sorted(copies ^ expected)}", file=sys.stderr)
+    raise SystemExit(1)
+' "${CONTAINERFILE}"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "ISO context contains only the ISO script and ghcurl" {
+    run python3 -c '
+from pathlib import Path
+import sys
+
+lines = Path(sys.argv[1]).read_text().splitlines()
+start = lines.index("FROM scratch AS ctx-iso")
+end = next(index for index in range(start + 1, len(lines)) if lines[index].startswith("FROM "))
+copies = {
+    line.split()[1]
+    for line in lines[start + 1:end]
+    if line.startswith("COPY ")
+}
+expected = {
+    "/build_files/base/21-container-native-iso.sh",
+    "/build_files/shared/utils/ghcurl",
+}
+if copies != expected:
+    print(f"unexpected ctx-iso inputs: {sorted(copies ^ expected)}", file=sys.stderr)
+    raise SystemExit(1)
+
+iso_mounts = [
+    line for line in lines
+    if "source=/build_files/base/21-container-native-iso.sh" in line
+    or "source=/build_files/shared/utils/ghcurl" in line
+]
+if len(iso_mounts) != 2 or any("from=ctx-iso" not in line for line in iso_mounts):
+    print("ISO inputs must mount from ctx-iso", file=sys.stderr)
+    raise SystemExit(1)
+' "${CONTAINERFILE}"
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- retain the `ctx-iso` split proposed in #1016
- narrow the Stage 2 context to the exact base scripts and shared helpers it consumes
- add Bats coverage that locks both context stages to their required inputs

## Why this differs from #1016

#1016 still copies all of `build_files/shared` into the Stage 2 context. That includes Stage 1-only inputs such as `copr-helpers.sh`, `package-lib.sh`, and `read-packages`, so edits to those files still change the mounted context image and invalidate Stage 2. This branch builds on #1016 but enumerates the five shared scripts plus `utils/ghcurl` that the extension builder and Stage 2 actually read.

Closes #996

## Validation

- [x] Full `just build bluefin testing main`
- [x] `just check`
- [x] `uvx pre-commit run --all-files`
- [x] `bats tests/unit/containerfile_contexts_test.bats tests/unit/21-container-native-iso_test.bats`
- [ ] Full Bats suite: existing `04-install-kernel-akmods_test.bats` fixtures fail locally because no `v4l2loopback` RPM matches; all 134 other tests, including the new coverage, pass