### PR TITLE
ci: bump testsuite v1 pin to pick up Firefox AT-SPI fix

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write  # testsuite pushes screenshot OCI artifacts to GHCR
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9fa3f29af15e5f64ca7ab2558ee0b8b61f4c6bff # v1
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@94923c5fff0ce7475f9ad17e94d4503e6a8dd58f # v1
     with:
       image: ${{ inputs.image }}
       suites: ${{ inputs.suites }}


### PR DESCRIPTION
## What

Bumps the pinned SHA for `projectbluefin/testsuite/.github/workflows/e2e.yml` in `.github/workflows/run-testsuite.yml` from `9fa3f29a` to `94923c5f` (current `v1` tag head).

## Why

Fixes #989.

`run-e2e / smoke,common / GNOME 50 — smoke-a` has been failing deterministically since 2026-06-25 on every `firefox.feature` scenario, because Firefox's AT-SPI accessibility tree was never populated (missing `GNOME_ACCESSIBILITY`/`ACCESSIBILITY_ENABLED`/`GTK_A11Y` env at launch) and `_firefox_window()` was falsely accepting an empty `filler` node as a healthy window. This has kept `promote-to-testing` in `post-testing-e2e.yml` `skipped` for ~46 days, per the issue's blast-radius analysis (209 failures / 89 skips / 2 successes over the last 300 runs).

The root cause and fix live in `projectbluefin/testsuite`, not this repo (confirmed: Firefox is shipped unchanged as an RPM here, and no bluefin-side change correlates with the 06-22 → 06-25 regression window). [projectbluefin/testsuite#692](https://github.com/projectbluefin/testsuite/pull/692) landed the fix (Firefox launch env + tightened `_firefox_window()` populated-tree check) and merged into `testsuite`'s `main`/`v1` today. This repo's workflow still SHA-pins the reusable e2e workflow to the pre-fix commit, so the fix hasn't reached any bluefin CI run yet.

This PR only re-pins to the already-merged, already-tagged `v1` head so the next `post-testing-e2e` run actually exercises the fixed test code.

## Verification

- `.github/workflows/run-testsuite.yml` parses as valid YAML.
- New SHA (`94923c5fff0ce7475f9ad17e94d4503e6a8dd58f`) is confirmed to be both the current `testsuite` `main` HEAD and the current `v1` tag target, and to include PR projectbluefin/testsuite#692, which explicitly cross-links this issue.
- No other workflow in this repo references the old testsuite SHA.
- Per the issue's explicit guidance, this PR does not touch `promote-to-testing`'s gating logic (no `always()`, no `continue-on-error`, `run-e2e` still required) — it only unblocks the underlying test fix from being picked up.

## Follow-up (out of scope here)

- The issue's §1 secondary finding (bare `:testing` tag landing on a failing digest despite `publish_stream_tag: "false"`) is a separate `projectbluefin/actions` bug and needs its own fix/regression guard there.
- One green `post-testing-e2e` run with `promote-to-testing: success` after this merges is the closing criterion for #989.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
