### PR TITLE
ci: restore testsuite v1 ref and exempt it in the effective Renovate config

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write  # testsuite pushes screenshot OCI artifacts to GHCR
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9fa3f29af15e5f64ca7ab2558ee0b8b61f4c6bff # v1
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@v1
     with:
       image: ${{ inputs.image }}
       suites: ${{ inputs.suites }}

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -121,6 +121,18 @@ a test command is piped.
 - Reference `projectbluefin/testsuite`'s reusable E2E workflow through its
   managed `@v1` tag, never an immutable digest; testsuite advances `v1` after
   each successful main-branch merge.
+- Renovate's `config:best-practices` preset (extended by `.github/renovate.json5`)
+  pins all `github-actions` refs to a digest by default, including managed `@v1`
+  tags. Renovate reads the root `renovate.json` first and ignores
+  `.github/renovate.json5` when both exist, so an exemption added only to the
+  `.github` copy has no effect. The working exemption for a `matchManagers:
+  ["github-actions"]` rule must live in the root `renovate.json`'s
+  `packageRules`, disabling the manager for that dependency's package name
+  (see the `projectbluefin/actions` and `projectbluefin/testsuite` rules
+  there). This silently re-pinned `run-testsuite.yml` to a stale digest for
+  ~46 days and froze `:testing` promotion (#989) — check the effective
+  Renovate config, not just the intended one, when a managed `@v1` ref keeps
+  reverting to a digest.
 - Update this skill when workflow behavior changes.
 
 ## Verification

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,13 @@
     {
       "description": "Do not SHA-pin projectbluefin/actions refs — they use @v1 managed tags enforced by no-sha-pins-for-internal-actions pre-commit hook",
       "matchManagers": ["github-actions"],
-      "matchPackagePatterns": ["^projectbluefin/actions"],
+      "matchPackageNames": ["/^projectbluefin/actions/"],
+      "enabled": false
+    },
+    {
+      "description": "Do not SHA-pin projectbluefin/testsuite refs — run-testsuite.yml uses the @v1 managed tag so E2E picks up testsuite fixes immediately; a digest pin here delays every fix by a Renovate cycle (see #989)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["/^projectbluefin/testsuite/"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## What problem are you solving?

#989's `:testing` promotion has been frozen for ~46 days. The Firefox AT-SPI root cause is already fixed upstream in projectbluefin/testsuite#692 (merged), but that fix cannot reach the gate: `run-testsuite.yml` calls testsuite's reusable E2E workflow through a SHA-pinned digest instead of the managed `@v1` tag, so bluefin keeps testing against a stale, pre-fix commit no matter how many fixes land in testsuite.

An open PR (#1012) already restores the `@v1` ref, but its Renovate exemption only edits `.github/renovate.json5`. Renovate evaluates the first config file it finds per repo and this repo has both `renovate.json` (root) and `.github/renovate.json5`; the root file wins, so `.github/renovate.json5`'s rules are silently ignored (also flagged independently by #1017). Without an exemption in the file Renovate actually reads, the ref would just get re-pinned again on the next Renovate cycle — which is exactly how it got broken in the first place (#941 set `@v1`, Renovate re-pinned it six days later).

- [x] I am using an agent and I take responsibility for this PR

## Changes

- `.github/workflows/run-testsuite.yml`: restore `projectbluefin/testsuite/.github/workflows/e2e.yml@v1` (was pinned to `9fa3f29`, six digest-bump PRs behind testsuite's fix).
- `renovate.json` (the effective config): add a `projectbluefin/testsuite` no-SHA-pin rule next to the existing `projectbluefin/actions` one. Also migrated that existing rule's deprecated `matchPackagePatterns` to `matchPackageNames` regex syntax — under `--strict` the migration warning fails `Validate Renovate Config` on any PR touching this file (reproduced on #1012's CI), independent of that PR's own diff.
- `docs/skills/ci/SKILL.md`: recorded the config-shadowing gotcha so a managed `@v1` ref that keeps reverting to a digest gets diagnosed against the *effective* Renovate config, not the intended one.

**Scope note:** this doesn't duplicate #1012 (same workflow-ref line, but the actually-effective Renovate fix) or #1017 (a separate, broader renovate.json/.json5 consolidation, still under review for #1006). It's self-contained and doesn't depend on either landing first — happy to close this in favor of either if a maintainer prefers to fold it into one of those instead.

**Not in scope:** the `projectbluefin/actions` `reusable-build.yml` stream-tag leak (#989 item 4) and the `bluefin_desktop.feature`/`gnome_apps.feature` first-pass flakes (item 3) — separate repo / separate concern from the delivery-path bug this PR fixes.

## Testing

- `npx --package renovate -- renovate-config-validator --strict renovate.json .github/renovate.json5` → `Config validated successfully against 2 file(s)`
- `python3 .github/scripts/validate-docs.py` → `documentation ok: 13 skills, 39 Markdown files`
- `just`/`pre-commit`/`actionlint` are not installed in this runtime; not run.
- Not verified: a green E2E run (needs testsuite's merged fix to actually execute, which is what this PR restores the path for) and that Renovate won't re-pin `run-testsuite.yml` again (only observable on the next Renovate run against this repo).

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] Documentation updated (skill doc) alongside the workflow-behavior change
- [x] No image assembly behavior changed

## Community verification (bug-fix PRs)

CI-only; nothing changes in the shipped image.

Closes #989