### PR TITLE
fix(ci): run gitlink check against github.sha

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Check for undeclared gitlinks
         shell: bash
         env:
-          TARGET_TREEISH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Use github.sha (the checked-out PR merge / merge-group commit).
+          # pull_request.head.sha is not fetched by a depth-1 checkout of
+          # refs/pull/N/merge, so ls-tree on it fails with "not a tree object".
+          TARGET_TREEISH: ${{ github.sha }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
The gitlink guard in pr-validation.yml used `pull_request.head.sha`, but a depth-1 checkout of `refs/pull/N/merge` does not include the head commit, so `git ls-tree` fails with `fatal: not a tree object` and blocks the validate job (seen on #1010).

`github.sha` is the checked-out merge commit for `pull_request` and the merge-group commit for `merge_group`, so it is always present locally.

Assisted-by: Kimi K3 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>