### PR TITLE
fix(ci): run base-branch guard on main-targeted PRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,8 +2,11 @@ name: PR Validation — testsuite
 
 on:
   pull_request:
+    # Also trigger on `main` so check-base-branch can reject mis-targeted PRs;
+    # with a testing-only trigger a main-targeted PR silently gets zero checks.
     branches:
       - testing
+      - main
   merge_group:
 
 permissions:

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -65,13 +65,15 @@ The instrumented rerun does not gate the job — `Run unit tests` owns pass/fail
 Tests that `source` a library into the BATS process itself are not traced.
 
 A pull request whose head branch lives on a fork reports **zero** checks until a
-maintainer approves the run. That looks identical to "checks still queued", so
-confirm the state before waiting on it:
+maintainer approves the run — identical to "checks still queued", so confirm:
 
 ```bash
 gh pr view PR --repo projectbluefin/bluefin --json headRepositoryOwner,maintainerCanModify
 gh api -X POST repos/projectbluefin/bluefin/actions/runs/RUN_ID/approve
 ```
+
+Zero checks with no pending approval means the PR targets `main`. Retarget
+with `gh pr edit PR --base testing`; rebuild branches cut from `main`.
 
 `maintainerCanModify: true` also means fix commits can be pushed straight to the
 contributor's branch.

--- a/docs/skills/issue-lifecycle/SKILL.md
+++ b/docs/skills/issue-lifecycle/SKILL.md
@@ -32,7 +32,9 @@ metadata:
    `3-clanker-queue`.
 3. Create a scoped branch from `projectbluefin/testing` and keep the change small.
 4. Run the repository validation commands.
-5. Open a pull request containing `Closes #NNN`.
+5. Open a pull request targeting `testing` containing `Closes #NNN`
+   (`gh pr create --base testing ...`; `gh pr create` defaults to the
+   repository's default branch `main`, which the base-branch guard rejects).
 6. Respond to review feedback; do not self-approve or self-merge.
 
 Automation applies and repairs the seven canonical workflow labels. Agents do


### PR DESCRIPTION
## Why

Two queue PRs (#1018, #1037) were opened against `main` and silently got **zero** checks: `pr-validation.yml` only triggered on `testing`, so the `check-base-branch` job that exists to reject main-targeted PRs never ran. Both had to be retargeted and rebuilt manually.

## What

- Trigger `pr-validation.yml` on `main` too; `validate`/`unit-tests` already skip themselves when `check-base-branch` fails, so the only cost on a mis-targeted PR is the guard job.
- `docs/skills/issue-lifecycle/SKILL.md`: spell out `gh pr create --base testing` (gh defaults to the repo default branch).
- `docs/skills/ci/SKILL.md`: record the zero-checks-on-`main` failure mode and the rebuild-on-`testing` remedy.

Assisted-by: Kimi K3 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>