### PR TITLE
ci(bonedigger): drop the no-op schedule trigger

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, labeled, closed]
   issue_comment:
     types: [created]
-  schedule:
-    - cron: '0 9 * * *'
 
 permissions:
   issues: write


### PR DESCRIPTION
Follow-up to #981 / #1011.

## Context

#981 asked to either drop the no-op `pull_request` trigger from the bonedigger caller, or keep it and add PR lifecycle jobs upstream in `projectbluefin/bonedigger`. That decision was made and landed in #1011, which removed the `pull_request` block and is now merged into `testing` and promoted to `main`.

One trigger of the identical no-op class remains: the daily `schedule` dispatch (`0 9 * * *`). The pinned bonedigger lifecycle workflow (`@d530767`, `# v1`) defines exactly two jobs — `on-issue-opened` and `on-issue-comment` — both guarded on `github.event_name` being `issues` or `issue_comment`. It has no `schedule` handling (verified at both the pinned SHA and bonedigger HEAD), so every scheduled run is a fully skipped, wasted dispatch.

## Change

Drop the `schedule` block from the caller so the workflow only fires on events the reusable workflow actually handles.

## Validation

- `npx yaml-lint .github/workflows/bonedigger.yml` passes
- The reusable workflow still receives `issues` and `issue_comment` events, which is what its jobs are guarded on

Refs #981

Assisted-by: DeepSeek V4 Flash via pi