### PR TITLE
fix(packages): add fzf to base package manifest (#965)

### DIFF
--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -38,6 +38,7 @@ IMPORTANT_PACKAGES=(
     firefox
     fish
     flatpak
+    fzf
     grub2-efi-x64-cdboot
     isomd5sum
     libblockdev-btrfs

--- a/build_files/packages/base.toml
+++ b/build_files/packages/base.toml
@@ -47,6 +47,7 @@ packages = [
     "fish",
     "flatpak-spawn",
     "firefox",
+    "fzf",
     "gcc",
     "gcc-c++",
     "git-credential-libsecret",


### PR DESCRIPTION
Closes #965

## Summary

Fixes part 1 of #965 where `ujust --choose` fails on fresh installs due to missing `fzf` binary.

- Added `fzf` to `build_files/packages/base.toml` under `[fedora]` section so it is installed in the base image.
- Added `fzf` to `IMPORTANT_PACKAGES` verification list in `build_files/base/20-tests.sh`.