### PR TITLE
ci(lab-check): surface actionable error when MergeRaptor token mint is denied

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -15,14 +15,26 @@ jobs:
       github.event.client_payload.sha != ''
     runs-on: ubuntu-24.04
     steps:
+      # continue-on-error: when the app installation lacks the requested
+      # permission, create-github-app-token fails with only the annotation
+      # "The permissions requested are not granted to this installation."
+      # Keep the run alive so the next step can surface an actionable message
+      # instead of a bare red X (bluefin#939). The job still fails either way.
       - name: Get MergeRaptor token
         id: app-token
+        continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
           permission-checks: write
           permission-contents: read
+
+      - name: Fail with actionable message if token minting was denied
+        if: steps.app-token.outcome == 'failure' || steps.app-token.outputs.token == ''
+        run: |
+          echo "::error::MergeRaptor token mint failed — the GitHub App installation almost certainly lacks the requested 'checks: write' permission. This cannot be fixed from the repository; an org owner must grant it (Organization settings → GitHub Apps → MergeRaptor → Permissions). Verify current grants with: gh api orgs/projectbluefin/installations --jq '.installations[] | select(.app_slug == \"mergeraptor\") | .permissions' — see docs/skills/ci/references/mergeraptor-checks.md."
+          exit 1
 
       - name: Create or update lab check
         env:


### PR DESCRIPTION
## Summary

bluefin#939 tracks `lab-check.yml` failing before it can create/update the `testing-lab / bluefin` check: the MergeRaptor GitHub App installation has not been granted `checks: write`, so `actions/create-github-app-token` fails with only the annotation *"The permissions requested are not granted to this installation."*

The root fix is org-admin work — an org owner must grant **Checks: write** to the MergeRaptor app installation (GitHub UI; documented in `docs/skills/ci/references/mergeraptor-checks.md`). No repository change can grant an app permission, and per repo policy no credentials are created/rotated.

**This PR makes the repeated failure self-documenting:** the token step now runs with `continue-on-error` so a follow-up step can emit a prominent `::error::` that names (1) the exact missing permission, (2) the org-owner fix path, (3) the verification command (`gh api orgs/projectbluefin/installations --jq '.installations[] | select(.app_slug == "mergeraptor") | .permissions'`), and (4) the reference doc. The job still exits 1 either way — the gate behavior is unchanged, and once an org owner grants the permission the diagnostic simply never fires.

This does not resolve the issue's root cause (unautomatable org admin action) — it converts a bare red X into an actionable message so the next triager knows exactly what to do.

## Verification

- YAML parsed with js-yaml; structure unchanged (3 steps: token → diagnostic → check update).
- Diagnostic shell snippet executed locally; escaping/`::error::` format verified.
- Workflow-only change; no build required.

- [x] I am using an agent and I take responsibility for this PR
