### PR TITLE
test(ci): lock ctx-build stage 1 context to its required inputs

### DIFF
--- a/tests/unit/containerfile_contexts_test.bats
+++ b/tests/unit/containerfile_contexts_test.bats
@@ -3,6 +3,42 @@
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
 CONTAINERFILE="${SCRIPT_DIR}/../../Containerfile"
 
+@test "Stage 1 context (ctx-build) contains only build_files and image-versions.yml" {
+    run python3 -c '
+from pathlib import Path
+import sys
+
+lines = Path(sys.argv[1]).read_text().splitlines()
+start = lines.index("FROM scratch AS ctx-build")
+end = next(index for index in range(start + 1, len(lines)) if lines[index].startswith("FROM "))
+copies = {
+    line.split()[1]
+    for line in lines[start + 1:end]
+    if line.startswith("COPY ") and not line.startswith("COPY --from")
+}
+expected = {
+    "/build_files",
+    "/image-versions.yml",
+}
+if copies != expected:
+    print(f"unexpected ctx-build inputs: {sorted(copies ^ expected)}", file=sys.stderr)
+    raise SystemExit(1)
+
+# The whole build_files dir and image-versions.yml are Stage 1-only mounts.
+# Lock them to ctx-build so an accidental rewiring to the wide ctx fails
+# loudly instead of silently coupling Stage 1 to every system_files edit.
+stage1_mounts = [
+    line for line in lines
+    if "source=/build_files,target=" in line or "source=/image-versions.yml" in line
+]
+if len(stage1_mounts) != 2 or any("from=ctx-build" not in line for line in stage1_mounts):
+    print("build_files and image-versions.yml must mount from ctx-build only", file=sys.stderr)
+    raise SystemExit(1)
+' "${CONTAINERFILE}"
+
+    [ "$status" -eq 0 ]
+}
+
 @test "Stage 2 context contains only its build_files inputs" {
     run python3 -c '
 from pathlib import Path


### PR DESCRIPTION
## Summary

bluefin#996 (narrow ctx mounts for Stage 2 and the ISO stage) is already fixed on `testing`: #1020 merged the narrowed `ctx` (Stage 2) and `ctx-iso` (ISO) contexts with Bats coverage locking both to their exact inputs, and #964's `ctx-build` (Stage 1) context predates it.

**Gap this PR closes:** `ctx-build` — the third context stage, and the one whose whole purpose is the documented "saves 20-80 min" granular cache benefit — has **no regression lock**. #1020's `containerfile_contexts_test.bats` covers `ctx` and `ctx-iso` only. If a future edit widens `ctx-build` (e.g. adds `COPY /system_files` to it), nothing fails, and every `system_files` edit would silently bust Stage 1's cache key — exactly the failure class #996 exists to prevent.

Adds a third case to `containerfile_contexts_test.bats`:
- `ctx-build` copies exactly `/build_files` and `/image-versions.yml` (nothing else).
- The whole-`build_files` dir and `image-versions.yml` bind-mounts come from `ctx-build`, never from the wide `ctx`.

Verified:
- `bats tests/unit/containerfile_contexts_test.bats` → all 3 cases pass (bats-core 1.14.0).
- Negative check: widening `ctx-build` with `COPY /system_files` makes the new case fail; other two remain green.

Refs #996 (tracking), complements #1020 and #964.

## Verification

- [x] `bats tests/unit/containerfile_contexts_test.bats` — 3/3 pass
- [x] Negative test: widened `ctx-build` correctly fails the new case
- [x] Test-only change; no build required

- [x] I am using an agent and I take responsibility for this PR
