### PR TITLE
test(framework): lock fw-charge-control.conf battery health fix

### DIFF
--- a/tests/unit/fw-charge-control_test.bats
+++ b/tests/unit/fw-charge-control_test.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# Unit tests for system_files/shared/usr/lib/modprobe.d/fw-charge-control.conf
+# (bluefin#879 — Framework battery charge threshold control via cros_charge-control)
+# Run with: bats tests/unit/fw-charge-control_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+CONF_FILE="${SCRIPT_DIR}/../../system_files/shared/usr/lib/modprobe.d/fw-charge-control.conf"
+
+@test "fw-charge-control.conf is shipped in the image" {
+    [ -f "${CONF_FILE}" ]
+}
+
+@test "fw-charge-control.conf enables Framework probing for cros_charge-control" {
+    # The cros_charge-control kernel driver (v6.14+, built by Fedora as
+    # CONFIG_CHARGER_CROS_CONTROL=m) intentionally refuses Framework ECs unless
+    # probe_with_fwk_charge_control=1 is set. Without this option, AMD Framework
+    # systems have no charge_control_end_threshold sysfs node, so the Battery
+    # Health Charging extension reports missing dependencies (bluefin#879).
+    grep -q "^options cros_charge_control probe_with_fwk_charge_control=1$" "${CONF_FILE}"
+}
+
+@test "fw-charge-control.conf contains exactly one option line" {
+    # Keep the file auditable: one module, one option, nothing else.
+    run grep -c "^options " "${CONF_FILE}"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

bluefin#879 (Battery Health controls broken on AMD Framework after upgrade) is already fixed on `testing` by #1019: it ships `system_files/shared/usr/lib/modprobe.d/fw-charge-control.conf` with `options cros_charge_control probe_with_fwk_charge_control=1`. I verified the fix is technically sound:

- The `probe_with_fwk_charge_control` module param exists in the upstream driver (`drivers/power/supply/cros_charge-control.c`) since kernel v6.14.
- Fedora builds the driver as a module (`CONFIG_CHARGER_CROS_CONTROL=m`), so modprobe.d options apply at load.
- On Framework hardware the `cros-charge-control` MFD cell is registered, and with the param set the driver binds and exposes `charge_control_end_threshold` / `charge_control_start_threshold` — the sysfs interface the Battery Health Charging extension uses.

**Gap this PR closes:** the #1019 fix shipped with no regression test, unlike every other hardware hook in this repo (`11-framework-ucsi-workaround`, `20-framework`, `disable-repos`, …). A typo, rename, or drop of the conf would silently kill battery charge control with no CI signal.

Adds `tests/unit/fw-charge-control_test.bats`:
- asserts the conf ships in the image path;
- locks the exact option line (module + probe flag), with a comment documenting the kernel/driver requirement;
- asserts the file contains exactly one option line.

Verified with bats-core 1.14.0: all 3 new cases pass, negative check (wrong option value) fails the lock, and the 22 existing framework/disable-repos unit tests still pass.

Refs #879 (tracking); complements #1019 (the fix itself).

## Verification

- [x] `bats tests/unit/fw-charge-control_test.bats` — 3/3 pass
- [x] Negative check: altered option value correctly fails the lock
- [x] Framework-related unit tests (11-framework-ucsi-workaround, 20-framework, disable-repos) — all pass
- [x] Test-only change; no build required

- [x] I am using an agent and I take responsibility for this PR
