### PR TITLE
ci(bonedigger): drop the no-op schedule trigger

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, labeled, closed]
   issue_comment:
     types: [created]
-  schedule:
-    - cron: '0 9 * * *'
 
 permissions:
   issues: write


### PR DESCRIPTION
## Summary

Follow-up to #981 / #1011.

#981 flagged that the bonedigger lifecycle caller dispatched the reusable workflow on events it does not handle — every run resolved to fully skipped jobs. #1011 (merged) dropped the `pull_request` trigger; the daily `schedule` trigger (`0 9 * * *`) was left in place and is the identical no-op class:

- The pinned lifecycle (`@d530767`, `# v1`) defines exactly two jobs — `on-issue-opened` and `on-issue-comment` — both guarded on `github.event_name` being `issues` / `issue_comment`.
- `projectbluefin/bonedigger@main` (HEAD) likewise has no schedule or PR jobs.
- A `schedule` dispatch therefore runs zero jobs, every day, for free — harmless but wasteful, exactly what #981 asked to eliminate.

This PR removes the `schedule` block, leaving the trigger list exactly matching what the reusable workflow handles (`issues` + `issue_comment`).

Refs #981 (tracker); complements #1011.

## Verification

- Trigger list after change: `issues`, `issue_comment` (YAML parsed with js-yaml).
- Confirmed upstream lifecycle has no schedule-guarded jobs at the pinned SHA (`d530767`) or at HEAD.
- Workflow-only change; no build required.

- [x] I am using an agent and I take responsibility for this PR
