### PR TITLE
ci: gate stable promotion to Tuesday window

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -21,7 +21,43 @@ permissions:
   statuses: write
 
 jobs:
+  release_window:
+    name: Check stable release window
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_enqueue: ${{ steps.window.outputs.should_enqueue }}
+    steps:
+      - name: Determine whether to enqueue the promotion
+        id: window
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              echo "Manual dispatch — allowing the hotfix release escape hatch."
+              echo "should_enqueue=true" >> "$GITHUB_OUTPUT"
+              ;;
+            schedule)
+              weekday=$(date -u +%u)
+              if [[ "$weekday" == "2" ]]; then
+                echo "Tuesday UTC schedule — allowing the weekly stable release."
+                echo "should_enqueue=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "Non-Tuesday schedule — refreshing promotion gates without enqueueing."
+                echo "should_enqueue=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "Push trigger — refreshing the promotion PR without enqueueing."
+              echo "should_enqueue=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
   promote:
+    needs: [release_window]
     uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@v1
     with:
       variants: >-
@@ -31,5 +67,5 @@ jobs:
       run_e2e: false
       # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked.
       # use_merge_queue: true calls enqueuePullRequest GraphQL instead.
-      use_merge_queue: true
+      use_merge_queue: ${{ needs.release_window.outputs.should_enqueue == 'true' }}
     secrets: inherit

--- a/docs/skills/release-artifacts/SKILL.md
+++ b/docs/skills/release-artifacts/SKILL.md
@@ -33,6 +33,18 @@ metadata:
 4. Never bypass a failed trust or verification gate.
 5. Report the run ID and exact verification commands.
 
+## Weekly stable promotion window
+
+`.github/workflows/promote-testing-to-main.yml` keeps its push and daily
+schedule triggers so the testing-to-main promotion PR and its gates stay fresh.
+Only a Tuesday UTC scheduled run enables the merge-queue enqueue step. A
+`workflow_dispatch` run remains an explicit hotfix escape hatch; push events
+and non-Tuesday scheduled runs refresh the PR without releasing stable.
+
+The release window is enforced before the reusable promotion workflow receives
+`use_merge_queue`; do not make that input unconditional or remove the daily
+heartbeat when changing the caller.
+
 ```bash
 gh run list --repo projectbluefin/bluefin --limit 20
 gh run view RUN_ID --repo projectbluefin/bluefin --log-failed


### PR DESCRIPTION
## What does this change?

Gate the testing-to-main promotion's merge-queue enqueue step to the Tuesday
UTC stable release window while keeping the daily promotion heartbeat.

## Why?

Issue #1066 establishes Tuesday as Bluefin's weekly stable release day. The
current caller invokes the shared promotion workflow daily and unconditionally
enqueues the promotion PR, allowing stable releases whenever the merge queue
accepts it. This change adds a caller-side release-window job:

- Tuesday scheduled runs enqueue the promotion PR.
- Manual `workflow_dispatch` remains a documented hotfix escape hatch.
- Push events and non-Tuesday scheduled runs continue refreshing the promotion
  PR and its gates without releasing stable.

The existing signing, E2E, promotion, and merge-queue logic remains in the
shared reusable workflow.

## Validation

- `actionlint .github/workflows/*.yml`
- YAML parse and release-window/`needs` contract assertion
- `just check`
- `python3 .github/scripts/validate-docs.py`
- `git diff --check`
- `pre-commit` was unavailable in the environment (`command not found`)

Refs #1066

— hive: backend=agy agy=1.1.22