### PR TITLE
docs(security): make the CVE-2026-33186 note self-verifying

### DIFF
--- a/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
+++ b/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
@@ -17,12 +17,25 @@ self-contained fix** that this repository can apply on the Fedora 44 target.
 - `containers/buildah@v1.43.2/go.mod` pins `google.golang.org/grpc v1.72.2 // indirect`
   (the vulnerable version).
 - Fedora 44's latest available buildah is `buildah-1.43.2-1.fc44` (stable since
-  `2026-06-19`), which still bundles grpc v1.72.2.
-- As of the last check (`2026-08-07`), Bodhi lists **no** F44 `buildah` update in
-  `testing` or `pending` status. There is no newer F44 RPM to pin or override to.
-- Fedora 45 carries a fixed buildah: `buildah-1.45.0-2.fc45` bundles
-  `google.golang.org/grpc v1.82.1`. The fix is therefore gated on a Fedora 45
-  migration, not on an in-repo pin.
+  `2026-06-22`), which still bundles grpc v1.72.2.
+- Bodhi lists **no** F44 `buildah` update in `testing` or `pending`. There is no
+  newer F44 RPM to pin or override to. Re-check with the commands below rather
+  than trusting this sentence — it decays.
+- Fedora 45 has carried a fixed buildah since `buildah-1.44.0-1.fc45` went stable
+  on `2026-06-16`; F45 is now on `buildah-1.45.0-2.fc45`. F44 is the laggard.
+
+### The fixed-version threshold
+
+The grpc fix is in grpc-go `1.79.3`. Mapping that onto buildah releases:
+
+| buildah tag | bundled `google.golang.org/grpc` | fixed? |
+|---|---|---|
+| `v1.43.2` | `v1.72.2` (indirect) | no — this is what F44 ships |
+| `v1.44.0` | `v1.81.1` | **yes** — first fixed tag |
+| `v1.45.0` | `v1.82.1` | yes |
+
+So **`buildah >= 1.44.0`** is the bar. Any F44 RPM at or above that version
+clears this finding, as would a `1.43.x` rebuild that backports grpc `>= 1.79.3`.
 
 ## Why an in-repo pin/override does not resolve it
 
@@ -40,11 +53,61 @@ next `testing` build picks it up automatically. The durable fix is the Fedora 45
 migration. Do not weaken the vulnerability scan gate or add an exception; this
 finding is a tracking note, not an approval to suppress the scan.
 
+## Re-checking status
+
+This finding is re-detected on every scan, so it gets re-triaged often. Run these
+instead of repeating the research by hand — together they answer "has it been
+fixed yet?" in about ten seconds.
+
+**1. Has Fedora 44 shipped a newer buildah?** Anything `>= 1.44.0` clears it.
+
+```bash
+curl -sS "https://bodhi.fedoraproject.org/updates/?packages=buildah&releases=F44&rows_per_page=5" \
+  -H "Accept: application/json" |
+  python3 -c 'import json,sys
+for u in json.load(sys.stdin)["updates"]:
+    print(u["status"], u.get("date_stable") or u.get("date_pushed"),
+          ", ".join(b["nvr"] for b in u["builds"]))'
+```
+
+Check `status` too, not just the newest NVR: an update sitting in `testing` or
+`pending` means the fix is close but not yet in the build's package set.
+
+**2. Confirm which grpc a given buildah tag bundles** (substitute the tag):
+
+```bash
+curl -sS https://raw.githubusercontent.com/containers/buildah/v1.44.0/go.mod |
+  grep 'google.golang.org/grpc '
+```
+
+**3. Which Fedora does this image target?**
+
+```bash
+grep -m1 FEDORA_MAJOR_VERSION Containerfile
+```
+
+An F45 base makes the finding moot — F45 has shipped a fixed buildah since June 2026.
+
+## A new issue number is not a new problem
+
+`bootc-build/scan-image` files a fresh `fix(security): critical CVE detected …`
+issue per non-PR build, and its duplicate check keys on the ref, so a `main`
+build does not match an existing `testing` issue. This CVE has been filed at
+least four times (#530, #638, #870, #919). Before triaging one of these as new,
+compare the CVE ID against this file. The dedup logic lives in
+`projectbluefin/actions`, not here.
+
 ## Verification
 
 - Fedora 44 updates repo: `buildah-1.43.2-1.fc44` (no newer version).
-- Bodhi F44 buildah: no `testing` or `pending` updates as of `2026-08-07`.
+- Bodhi F44 buildah: latest stable `buildah-1.43.2-1.fc44` (`2026-06-22`); no
+  `testing` or `pending` update.
 - `containers/buildah@v1.43.2/go.mod` → `google.golang.org/grpc v1.72.2 // indirect`.
+- `containers/buildah@v1.44.0/go.mod` → `google.golang.org/grpc v1.81.1`.
 - `containers/buildah@v1.45.0/go.mod` → `google.golang.org/grpc v1.82.1`.
+- Bodhi F45 buildah: `buildah-1.44.0-1.fc45` stable `2026-06-16`,
+  `buildah-1.45.0-2.fc45` stable `2026-08-04`.
 - Bluefin `Containerfile` target: `ARG FEDORA_MAJOR_VERSION="44"`; the latest
   successful testing build resolved `fedora_version=44`.
+
+Last re-verified against Bodhi and `containers/buildah` upstream: `2026-08-09`.


### PR DESCRIPTION
Refs #919. **This does not fix the CVE — no in-repo fix exists.** It removes the repeated cost of re-establishing that.

## Verified state (2026-08-09)

I re-derived the facts rather than inheriting them from the two prior triage comments. They hold:

- **Fedora 44 still has no fixed buildah.** Latest is `buildah-1.43.2-1.fc44`, stable since 2026-06-22, with nothing in `testing` or `pending`. There is no RPM to pin or `override replace` to.
- **buildah is not a declared package here.** `build_files/packages/base.toml` lists `podman-docker` only; buildah arrives with the Silverblue container-tools set from `quay.io/fedora-ostree-desktops/silverblue:44`.
- **The fix threshold is buildah >= 1.44.0**, and I confirmed the mapping directly from upstream `go.mod`:

  | buildah tag | bundled grpc | fixed (>= 1.79.3)? |
  |---|---|---|
  | `v1.43.2` | `v1.72.2` | no — what F44 ships |
  | `v1.44.0` | `v1.81.1` | **yes** |
  | `v1.45.0` | `v1.82.1` | yes |

So the existing conclusion stands: wait for F44, or the F45 migration. Nothing to patch.

## What this PR changes, and why it is worth doing

This CVE has been auto-filed **four times** (#530, #638, #870, #919) and hand-triaged at least three, each round re-running the same Bodhi and `go.mod` lookups. The reference note recorded *conclusions* but not the *procedure*, and its `as of <date>` lines decay on contact — so each re-triage restarted from zero.

The note now records how to check:

1. **The fixed-version threshold, with evidence.** The note already said ">= v1.44.0" in its Action section but never showed the mapping, so the bar was unverifiable without redoing the research.
2. **Three copy-pasteable commands** answering "is it fixed yet?" — the Bodhi F44 query (including the reminder to read `status`, since an update in `testing` means close-but-not-shipped), a `go.mod` lookup for any buildah tag, and the Containerfile's target Fedora.
3. **A note that a new issue number is not a new problem** — `bootc-build/scan-image` files one issue per non-PR build and its duplicate check keys on the ref, so a `main` build never matches an existing `testing` issue. That logic lives in `projectbluefin/actions`, not here.

Two corrections found while re-verifying:

- `buildah-1.43.2-1.fc44` went stable **2026-06-22**, not 2026-06-19.
- F45 has carried a fixed buildah since **`buildah-1.44.0-1.fc45` on 2026-06-16**, not only since 1.45.0 in August. That is the number that shows how far F44 is actually lagging — nearly two months.

## Verification

- `python3 .github/scripts/validate-docs.py` → `documentation ok: 13 skills, 41 Markdown files`.
- **All three documented commands executed verbatim** and returned the values quoted in the note. Shipping an unverified command would reproduce the exact problem this change addresses.
- No trailing whitespace, single trailing newline (the `pre-commit` hygiene hooks that apply to a Markdown-only change).
- No image build run — documentation-only, per the "do not run expensive image builds for documentation-only changes" boundary.

## What I deliberately did not do

- **No scan suppression, no `.trivyignore`, no gate weakening.** Accepting a critical is a Security-gate call, and the note's own instruction is not to.
- **No removal or replacement of buildah.** User-visible feature removal, Design gate.
- **No new monitoring workflow.** Automating the Bodhi check was tempting — the repo has scheduled monitors like `pkg-cadence.yml` as precedent — but it is new CI behavior needing `issues: write`, so it is a Design-gate proposal rather than something to land unprompted. The commands are the un-gated version of the same idea. Happy to open that separately if a maintainer wants it.
- **No change to the `scan-image` dedup.** It is the root of the duplicate filings, but it lives in `projectbluefin/actions` and changing shared CI behavior across repos is a Breakage-gate call.

Issue #919 itself still needs a human disposition (track upstream vs. accept risk vs. close as duplicate of #870's conclusion); this PR does not presume one.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `89e6044`
