### PR TITLE
ci(lab-check): point the Checks-permission fix at the right screen

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Fail with actionable message if token minting was denied
         if: steps.app-token.outcome == 'failure' || steps.app-token.outputs.token == ''
         run: |
-          echo "::error::MergeRaptor token mint failed — the GitHub App installation almost certainly lacks the requested 'checks: write' permission. This cannot be fixed from the repository; an org owner must grant it (Organization settings → GitHub Apps → MergeRaptor → Permissions). Verify current grants with: gh api orgs/projectbluefin/installations --jq '.installations[] | select(.app_slug == \"mergeraptor\") | .permissions' — see docs/skills/ci/references/mergeraptor-checks.md."
+          echo "::error::MergeRaptor token mint failed — the app lacks the requested 'checks: write' permission. This cannot be fixed from the repository; an org owner must grant it in the GitHub UI, and it may take TWO steps. Step 1, only if 'checks' is absent from 'gh api /apps/mergeraptor --jq .permissions': Organization settings → Developer settings → GitHub Apps → MergeRaptor → Permissions & events → Repository permissions → Checks: Read and write → Save. Until that is done the installation page has nothing to approve. Step 2: approve the resulting request under Organization settings → GitHub Apps → MergeRaptor → Review request. Verify with: gh api orgs/projectbluefin/installations --jq '.installations[] | select(.app_slug == \"mergeraptor\") | .permissions' — see docs/skills/ci/references/mergeraptor-checks.md."
           exit 1
 
       - name: Create or update lab check

--- a/docs/skills/ci/references/mergeraptor-checks.md
+++ b/docs/skills/ci/references/mergeraptor-checks.md
@@ -61,3 +61,14 @@ fallback that lets `lab-check.yml` pass without reporting: a check that silently
 skips is worse than one that fails loudly, because the gap stops being visible.
 `lab-check.yml` requests exactly `permission-checks: write` and
 `permission-contents: read`, which is the minimum the check-run API needs.
+
+## Reading a failed run
+
+The job summary shows **`Get MergeRaptor token: success`** directly above a
+failing diagnostic step. That is not a second bug and the mint did not
+half-succeed. `continue-on-error: true` makes a step report *conclusion*
+`success` while its *outcome* stays `failure`; the diagnostic keys off
+`outcome`, which is correct. Confirm the real result in the step log — a denied
+mint logs `##[error]The permissions requested are not granted to this
+installation` and an HTTP `422` from
+`POST /app/installations/{id}/access_tokens`.

--- a/docs/skills/ci/references/mergeraptor-checks.md
+++ b/docs/skills/ci/references/mergeraptor-checks.md
@@ -5,12 +5,59 @@ installation already holds; anything else fails the run with `The permissions
 requested are not granted to this installation.` The MergeRaptor installation
 on `projectbluefin` therefore needs **Checks: write** for `lab-check.yml`, in
 addition to the contents/pull-requests/workflows grants `track-common.yml`
-uses. Confirm the current grants before debugging the workflow YAML:
+uses.
+
+## Diagnose before fixing: App definition vs. installation
+
+A permission lives at two levels, and the same error message covers both. Check
+both before touching anything — the fix differs, and the installation-level fix
+is a dead end when the App itself has not declared the permission.
+
+**1. What the App declares** — the menu of permissions it is allowed to ask for:
+
+```bash
+gh api /apps/mergeraptor --jq '{owner: .owner.login, permissions}'
+```
+
+**2. What this org's installation grants** — what it actually holds:
 
 ```bash
 gh api orgs/projectbluefin/installations \
   --jq '.installations[] | select(.app_slug == "mergeraptor") | .permissions'
 ```
 
+Both commands need an org-owner token (`admin:org`); a contributor token returns
+`404`/`Not Found`, which is not evidence either way.
+
+Read the two together:
+
+| `checks` in App permissions | `checks` in installation permissions | What it means |
+|---|---|---|
+| absent | absent | The App cannot request it yet. **Both steps below are required.** Re-installing or re-approving does nothing — there is no pending request to approve. |
+| present | absent | Only step 2 — an org owner approves the pending permission request. |
+| present | `write` | Grant is in place; `lab-check.yml` should mint its token. Investigate elsewhere. |
+
+## The fix (UI only — there is no REST endpoint for this)
+
+**Step 1 — declare it on the App.** Organization settings → Developer settings →
+GitHub Apps → **MergeRaptor** → Permissions & events → Repository permissions →
+**Checks: Read and write** → Save. Skipping this is the common failure: it is a
+*different screen* from the installation page, and until it is done the
+installation page offers nothing to approve.
+
+**Step 2 — approve it on the installation.** Saving step 1 raises a permission
+request to org owners. Accept it under Organization settings → GitHub Apps →
+MergeRaptor → **Review request**.
+
+Then re-run the check with the step-2 command above; `checks` must read `write`.
+Dispatch a `lab-check` repository event (or wait for the next `track-common` QA
+run) and confirm `testing-lab / <product>` is created or updated.
+
+## Rules
+
 Granting an app permission is org-admin administration in the GitHub UI, not a
-repository change. Never work around a missing grant with a PAT.
+repository change. Never work around a missing grant with a PAT, and never add a
+fallback that lets `lab-check.yml` pass without reporting: a check that silently
+skips is worse than one that fails loudly, because the gap stops being visible.
+`lab-check.yml` requests exactly `permission-checks: write` and
+`permission-contents: read`, which is the minimum the check-run API needs.


### PR DESCRIPTION
Refs #939. **This does not grant the permission** — that is org-owner UI work, exactly as the issue says. It fixes the instructions for doing it, which are currently one step short.

## The gap

`lab-check.yml`'s error message and `docs/skills/ci/references/mergeraptor-checks.md` both send an org owner to the **installation** page:

> an org owner must grant it (Organization settings → GitHub Apps → MergeRaptor → Permissions)

But the measurement posted on #939 shows `checks` is absent from the App's **own declared permissions**, not merely ungranted on the installation:

```console
$ gh api /apps/mergeraptor --jq '.permissions'
{"contents":"write","metadata":"read","pull_requests":"write","workflows":"write"}
```

An App can only be granted what it declares. So an owner who follows the current instructions arrives at the installation page and finds **nothing to approve** — as @castrojo put it, *"re-installing or re-approving cannot help; the App definition has to request it first."* The declaration lives on a different screen: Developer settings → GitHub Apps → MergeRaptor → Permissions & events → Repository permissions.

That is a plausible reason this has stayed broken. I re-measured today and **Lab check is still failing 12 out of 12 runs**:

```console
$ gh run list --repo projectbluefin/bluefin --workflow "Lab check" --limit 12 \
    --json conclusion --jq '[.[] | .conclusion] | group_by(.) | map({(.[0]): length}) | add'
{"failure":12}
```

## What changed

- **Error message** now names both steps, gated on the diagnosis so nobody does step 1 when only step 2 is needed.
- **Reference doc** gains the App-level query (`gh api /apps/mergeraptor`) alongside the existing installation-level one, plus a table mapping the two readings to the required action — absent/absent means both steps, present/absent means approve only, present/write means look elsewhere.
- Notes that both commands need `admin:org`, and a contributor token returns `404` — which is *not* evidence the grant is missing. I hit exactly that while verifying, so it seemed worth writing down.
- Writes the **"never add a fallback that lets the job pass without reporting"** rule into the reference, so the next person does not relitigate it.

## Explicitly unchanged

@castrojo's note on the issue was that no repository change is warranted and that a fallback skipping the report would turn a loud gap into a silent one. **I agree and did neither.** The token step still requests exactly `permission-checks: write` and `permission-contents: read`; the diagnostic step still `exit 1`s; no fallback was added; no credential is created, rotated, or proposed. The only behavioral surface touched is the text inside an `echo`.

This is narrowly a documentation-accuracy fix derived from his own measurement — if he reads it as churn on an issue that just needs a click, closing it costs nothing and I won't re-open the argument.

## Verification

| Check | Result |
|---|---|
| `actionlint .github/workflows/lab-check.yml` | clean — **and clean on the base commit**, so nothing pre-existing is being masked |
| Workflow YAML parse | 3 steps intact; `permission-checks: write`, `permission-contents: read` unchanged |
| Error-message `run` block | extracted and **executed under bash**: renders with correct quoting (the escaped `\"mergeraptor\"` survives) and exits `1` |
| `python3 .github/scripts/validate-docs.py` | `documentation ok: 13 skills, 41 Markdown files` |
| Trailing whitespace / EOF newline | clean on both files |

What I could **not** verify: the App and installation permission state. Both queries need `admin:org` and my token gets `404`, so the "`checks` is not declared" premise is @castrojo's measurement, not mine — I am relying on it and have attributed it rather than restating it as my own. The 12/12 failure count is mine and is reproducible from any token.

## Still needed from an org owner

Unchanged and unautomatable: declare **Checks: Read and write** on the MergeRaptor App, then approve the resulting installation request, then dispatch a `lab-check` event to confirm `testing-lab / bluefin` updates.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `6f7e392`
