### PR TITLE
test(framework): assert fw-charge-control.conf ships in the built image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ devcontainer
 # Scratch checkouts of sibling projectbluefin repos
 .common-ref/
 
+# Per-test scratch roots created by the bats unit suite. Tests that abort
+# leave theirs behind, and an unsuspecting `git add -A` commits hundreds of
+# stub files.
+tests/unit/.bats-sandbox/
+
 # Python cache
 __pycache__/
 *.py[cod]

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -31,6 +31,15 @@ test -f /usr/share/flatpak/preinstall.d/bazaar.preinstall
 # Make sure this garbage never makes it to an image
 test -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service && false
 
+# Framework laptops need this modprobe option to get battery charge limiting.
+# The in-tree cros_charge-control driver refuses to bind when the EC advertises
+# Framework's own charge control, so without the option there is no
+# charge_control_end_threshold sysfs node and charge limiting silently
+# disappears on Framework hardware.
+# See: https://github.com/projectbluefin/bluefin/issues/879
+test -f /usr/lib/modprobe.d/fw-charge-control.conf
+grep -q '^options cros_charge_control probe_with_fwk_charge_control=1$' /usr/lib/modprobe.d/fw-charge-control.conf
+
 IMPORTANT_PACKAGES=(
     anaconda-live
     distrobox

--- a/tests/unit/20-tests_test.bats
+++ b/tests/unit/20-tests_test.bats
@@ -14,6 +14,7 @@ setup() {
         "${TEST_ROOT}/usr/share/ublue-os/just" \
         "${TEST_ROOT}/usr/share/ublue-os/homebrew" \
         "${TEST_ROOT}/usr/share/flatpak/preinstall.d" \
+        "${TEST_ROOT}/usr/lib/modprobe.d" \
         "${TEST_ROOT}/usr/lib/systemd/system"
 
     touch "${TEST_ROOT}/etc/containers/signing-key.pub" \
@@ -26,6 +27,8 @@ setup() {
         "${TEST_ROOT}/usr/share/ublue-os/just/default.just" \
         "${TEST_ROOT}/usr/share/ublue-os/just/system.just" \
         "${TEST_ROOT}/usr/share/ublue-os/just/update.just"
+    echo 'options cros_charge_control probe_with_fwk_charge_control=1' \
+        > "${TEST_ROOT}/usr/lib/modprobe.d/fw-charge-control.conf"
     cat > "${TEST_ROOT}/etc/containers/policy.json" <<'EOF'
 {"transports":{"docker":{"ghcr.io/ublue-os":[{"keyPaths":["signing-key.pub","backup-key.pub"]}]}}}
 EOF
@@ -96,6 +99,23 @@ fi
 exit 0
 EOF
     chmod +x "${STUB_BIN}/rpm"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}
+
+@test "20-tests: rejects an image missing the Framework charge control conf" {
+    # bluefin#879: losing this file silently kills battery charge limiting on
+    # Framework laptops, so the build must fail rather than ship without it.
+    rm -f "${TEST_ROOT}/usr/lib/modprobe.d/fw-charge-control.conf"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}
+
+@test "20-tests: rejects a Framework charge control conf with the wrong option" {
+    echo 'options cros_charge_control probe_with_fwk_charge_control=0' \
+        > "${TEST_ROOT}/usr/lib/modprobe.d/fw-charge-control.conf"
 
     run bash "${PATCHED_SCRIPT}"
     [ "$status" -ne 0 ]


### PR DESCRIPTION
## What problem are you solving?

The Framework battery charge control fix from #1019 is one modprobe.d file overlaid out of `system_files/`. The only thing guarding it is a unit test that greps that file in the repo checkout, so we can prove the source is in git but not that it made it into the image anyone boots. #879 is still open partly because nobody can point at a shipped image and say the node is there. This makes the build itself answer that question.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

`build_files/base/20-tests.sh` runs at the very end of Stage 2, after the `rsync` of `system_files/shared/` and after `17-cleanup.sh`/`clean-stage.sh`, against the real image root. That is where the repo already keeps its "this must ship or users break" assertions (`bazaar.preinstall`, `fonts.Brewfile`, the signing keys). The Framework conf had no equivalent.

Added there:

```bash
test -f /usr/lib/modprobe.d/fw-charge-control.conf
grep -q '^options cros_charge_control probe_with_fwk_charge_control=1$' /usr/lib/modprobe.d/fw-charge-control.conf
```

Both the presence and the exact option line are locked, because a wrong value is as bad as a missing file — `probe_with_fwk_charge_control` is a `bool` module param, and with it unset (or `0`) the in-tree driver deliberately bails out:

```c
if (ret > 0 && !probe_with_fwk_charge_control) {
    dev_info(dev, "Framework charge control detected, preventing load\n");
    return -ENODEV;
}
```
<sub><code>drivers/power/supply/cros_charge-control.c</code></sub>

…which leaves no `charge_control_end_threshold` sysfs node at all. That node is precisely what the Battery Health Charging extension keys off for Framework hardware — its detector is pure sysfs, no `framework_tool` required, so `/usr/bin/framework_tool` being absent is a red herring:

```js
const BAT1_END_PATH = '/sys/class/power_supply/BAT1/charge_control_end_threshold';
const BAT1_START_PATH = '/sys/class/power_supply/BAT1/charge_control_start_threshold';
...
if (!dmiVendor()?.includes('Framework')) return false;
if (!fileExists(BAT1_START_PATH)) return false;
if (!fileExists(BAT1_END_PATH)) return false;
```
<sub><code>devices/Framework.js</code>, <code>FrameworkSingleBatteryEndStartBAT1</code></sub>

Also extended `tests/unit/20-tests_test.bats` (the harness for this script) with the conf in its fake image root plus two negative cases: file missing, and file present with the wrong option value.

Unrelated drive-by, one line: `tests/unit/.bats-sandbox/` is now gitignored. Several tests in the suite leave their scratch root behind, so running `just test-unit` and then `git add -A` stages a few hundred stub files. It bit me while preparing this PR.

**Why not just extend `tests/unit/fw-charge-control_test.bats`?** That test reads the git working tree. It cannot fail for the failure mode that actually matters here — an rsync exclude, a cleanup pass, or a Stage 2 path rename dropping the file from the image while the source stays put. This check runs against the built rootfs, so it gates every `testing` → `main` → `stable` build.

## Testing

- [x] `bats tests/unit/` — **156/156 pass**
- [x] Both new negative tests verified to actually bite: with the `20-tests.sh` change stashed they fail (`not ok 3`, `not ok 4`), with it applied they pass. They are not passing for an unrelated reason.
- [x] `bash -n build_files/base/20-tests.sh` clean
- [x] `just check` unaffected — no `.just` files touched
- [ ] Build tested locally — not run; this is a build-time assertion whose behaviour is covered by the bats harness above

Kernel/driver claims above were checked against current upstream source rather than taken from the earlier issue discussion: the module builds as `cros_charge-control.o` (hyphen), and `options cros_charge_control` (underscores) still matches because kmod normalises `-`/`_` in module names.

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] No package additions

## Community verification (bug-fix PRs)

This PR does not change runtime behaviour — #1019 is the fix, this keeps it from silently disappearing. On a Framework laptop after the next build ships:

```
cat /sys/class/power_supply/BAT1/charge_control_end_threshold
```

If that prints a number, charge control is live and the Battery Health Charging extension should list **sysfs** as a supported configuration. If the file is missing, `modinfo cros_charge-control` and `cat /sys/module/cros_charge_control/parameters/probe_with_fwk_charge_control` will show whether the option took effect.

Refs #879. Complements #1019 (the fix) and #1060 (source-level lock).
