### PR TITLE
test(brew): assert the brew-preinstall delivery path ships in the image

### DIFF
--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -24,6 +24,20 @@ done
 
 test -f /usr/share/ublue-os/homebrew/fonts.Brewfile
 
+# bluefinctl and the default CLI set (fzf, starship, htop, ...) are not baked
+# into the image — they are installed per-user at first graphical login by the
+# brew-preinstall user service. The whole delivery path is inherited from the
+# pinned `common` image, whose digest Renovate bumps automatically, so a rename
+# or drop upstream would silently stop shipping bluefinctl with no other signal.
+# Assert the pieces the service actually needs: the Brewfiles it reads, the
+# binary its ExecStart points at, the unit, and the preset that enables it.
+# See: https://github.com/projectbluefin/bluefin/issues/965
+test -f /usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile
+test -f /usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile
+test -x /usr/bin/brew-preinstall
+test -f /usr/lib/systemd/user/brew-preinstall.service
+grep -q '^enable brew-preinstall\.service$' /usr/lib/systemd/user-preset/01-brew-preinstall.preset
+
 # If this file is not on the image bazaar will automatically be removed from users systems :(
 # See: https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-preinstall
 test -f /usr/share/flatpak/preinstall.d/bazaar.preinstall

--- a/tests/unit/20-tests_test.bats
+++ b/tests/unit/20-tests_test.bats
@@ -15,6 +15,9 @@ setup() {
         "${TEST_ROOT}/usr/share/ublue-os/homebrew" \
         "${TEST_ROOT}/usr/share/flatpak/preinstall.d" \
         "${TEST_ROOT}/usr/lib/modprobe.d" \
+        "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d" \
+        "${TEST_ROOT}/usr/lib/systemd/user" \
+        "${TEST_ROOT}/usr/lib/systemd/user-preset" \
         "${TEST_ROOT}/usr/lib/systemd/system"
 
     touch "${TEST_ROOT}/etc/containers/signing-key.pub" \
@@ -29,6 +32,14 @@ setup() {
         "${TEST_ROOT}/usr/share/ublue-os/just/update.just"
     echo 'options cros_charge_control probe_with_fwk_charge_control=1' \
         > "${TEST_ROOT}/usr/lib/modprobe.d/fw-charge-control.conf"
+    # brew-preinstall delivery path (bluefinctl + default CLI set) — see #965
+    touch "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile" \
+        "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile" \
+        "${TEST_ROOT}/usr/lib/systemd/user/brew-preinstall.service"
+    touch "${TEST_ROOT}/usr/bin/brew-preinstall"
+    chmod +x "${TEST_ROOT}/usr/bin/brew-preinstall"
+    echo 'enable brew-preinstall.service' \
+        > "${TEST_ROOT}/usr/lib/systemd/user-preset/01-brew-preinstall.preset"
     cat > "${TEST_ROOT}/etc/containers/policy.json" <<'EOF'
 {"transports":{"docker":{"ghcr.io/ublue-os":[{"keyPaths":["signing-key.pub","backup-key.pub"]}]}}}
 EOF
@@ -116,6 +127,33 @@ EOF
 @test "20-tests: rejects a Framework charge control conf with the wrong option" {
     echo 'options cros_charge_control probe_with_fwk_charge_control=0' \
         > "${TEST_ROOT}/usr/lib/modprobe.d/fw-charge-control.conf"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}
+
+@test "20-tests: rejects an image missing the bluefinctl Brewfile" {
+    # #965: bluefinctl reaches users only through preinstall.d. If `common`
+    # renames or drops this file, the build must fail rather than ship an
+    # image where bluefinctl silently never installs.
+    rm -f "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}
+
+@test "20-tests: rejects an image missing the brew-preinstall ExecStart binary" {
+    rm -f "${TEST_ROOT}/usr/bin/brew-preinstall"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}
+
+@test "20-tests: rejects a preset that does not enable brew-preinstall" {
+    # A shipped-but-disabled preset is the silent failure mode: every file is
+    # present, the service just never starts for the user.
+    echo 'disable brew-preinstall.service' \
+        > "${TEST_ROOT}/usr/lib/systemd/user-preset/01-brew-preinstall.preset"
 
     run bash "${PATCHED_SCRIPT}"
     [ "$status" -ne 0 ]


### PR DESCRIPTION
## What problem are you solving?

I picked up #965 to fix the three reported gaps and found that only the first one was ever bluefin's, and it is already fixed. The other two are real, but they are Dakota's, not this repo's — the code simply does not exist here. Rather than leave that as a claim in a comment, this PR closes the one thing on the bluefin side that is genuinely unguarded: nothing in CI checks that bluefinctl's delivery mechanism is still on the image.

- [x] I am using an agent and I take responsibility for this PR

---

## Triage of #965 against this repo

| Reported | Applies to bluefin? |
|---|---|
| 1. `fzf` missing, `ujust --choose` fails | **Was ours, already fixed.** #1057 added `fzf` to `build_files/packages/base.toml` and to `IMPORTANT_PACKAGES` in `20-tests.sh`. Composes correctly with common's `ujust` wrapper, which gates on `command -v fzf` and only brew-bootstraps when it's absent — so the RPM short-circuits the bootstrap instead of racing it. |
| 2. `bluefinctl` not installed | **Not a bluefin defect.** Delivered via common's `preinstall.d/bluefinctl.Brewfile` + `brew-preinstall.service`, both under `system_files/shared`, which this repo inherits. The preset is `enable brew-preinstall.service`, the unit's `ExecStart=/usr/bin/brew-preinstall`, and the Brewfile taps and installs `bluefinctl`. The path is intact — but untested. **This PR guards it.** |
| 3. `ujust dx-group` adds no groups | **Not in this repo at all.** bluefin ships `devmode` / `toggle-devmode`; there is no `dx-group` recipe. `grep -rn 'dx-group\|/usr/lib/group\|incus-admin'` over this checkout returns nothing. |

The broken `dx-group` — the one that produces `grep: /usr/lib/group: No such file or directory` — lives in `projectbluefin/dakota:files/just-overrides/system.just` and `projectbluefin/iso:just/bluefin-system.just`:

```bash
append_group() {
    local group_name="$1"
    if ! grep -q "^$group_name:" /etc/group; then
        echo "Appending $group_name to /etc/group"
        grep "^$group_name:" /usr/lib/group | tee -a /etc/group > /dev/null
    fi
}
```

`/usr/lib/group` does not exist on Fedora-based images, so `append_group` is a no-op and the following `usermod -aG` fails with `group '...' does not exist`. Common's equivalent already hardened this to `grep ... 2>/dev/null ... || true`. **I have not changed that here — it is not this repo's file.** Items 2 and 3 need to be routed to `projectbluefin/dakota`.

## Changes

`build_files/base/20-tests.sh` runs at the end of Stage 2 against the real image root, and already guards two other common-provided files whose loss would silently degrade users (`fonts.Brewfile`, `bazaar.preinstall`). The bluefinctl path had no equivalent:

```bash
test -f /usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile
test -f /usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile
test -x /usr/bin/brew-preinstall
test -f /usr/lib/systemd/user/brew-preinstall.service
grep -q '^enable brew-preinstall\.service$' /usr/lib/systemd/user-preset/01-brew-preinstall.preset
```

**Why this is worth guarding:** none of it is authored here. It all arrives from the pinned `common` image, whose digest Renovate bumps automatically — so an upstream rename or removal lands in bluefin with no review of this repo and nothing that fails. The outcome would be #965 item 2 verbatim: bluefinctl not installed, found by a user instead of by CI.

**Why the preset is content-checked, not existence-checked:** a shipped-but-*disabled* preset is the interesting failure — every file present, service never starts. `test -f` would pass; the `grep` won't.

`system-cli.Brewfile` is included because it is, per common's own docs, "the only file that auto-installs packages for every user on every variant" — it carries the default CLI set including the brew copy of `fzf`.

## Testing

- [x] `bats tests/unit/` — **157/157 pass** (154 before, 3 new)
- [x] All three new negative tests verified to actually bite: with the `20-tests.sh` change stashed they fail (`not ok 3/4/5`), with it applied they pass
- [x] `bash -n build_files/base/20-tests.sh` clean
- [x] `just check` unaffected — no `.just` files touched
- [ ] Build tested locally — not run; this is a build-time assertion, covered by the bats harness above

## Note on overlap

This touches the same two files as my open #1080. The hunks are in different regions and should merge cleanly, but whichever lands second may want a trivial rebase.

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] No package additions

## Community verification (bug-fix PRs)

No runtime change — this prevents a regression rather than fixing live breakage. On bluefin, after first graphical login:

```
systemctl --user status brew-preinstall.service
command -v bluefinctl
```

Refs #965. **Does not close it** — items 2 and 3 as the reporter hit them are Dakota-side and still need a fix there.

— hive: backend=agy agy=1.1.22