### PR TITLE
docs(security): correct CVE-2026-33186 root cause — podman is a second carrier

### DIFF
--- a/docs/skills/security/SKILL.md
+++ b/docs/skills/security/SKILL.md
@@ -50,7 +50,7 @@ do not invent a replacement key or trust path.
 
 - [COPR isolation invariant](references/copr-isolation.md)
 - [signing and verification](references/signing.md)
-- [CVE-2026-33186 grpc in buildah](references/cve-2026-33186-grpc-buildah.md)
+- [CVE-2026-33186 grpc in buildah and podman](references/cve-2026-33186-grpc-buildah.md)
 
 ## When to Use
 

--- a/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
+++ b/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
@@ -61,6 +61,15 @@ own; re-scan and confirm rather than assuming. Do not weaken the vulnerability
 scan gate or add an exception; this finding is a tracking note, not an approval
 to suppress the scan.
 
+## A new issue number is not a new problem
+
+`bootc-build/scan-image` files a fresh `fix(security): critical CVE detected …`
+issue for non-PR builds, and its duplicate check keys on the ref, so a `main`
+build does not match an existing `testing` issue. This CVE has been filed at
+least four times (#530, #638, #870, #919) — roughly monthly, not per build.
+Before triaging one of these as new, compare the CVE ID against this file. The
+dedup logic lives in `projectbluefin/actions`, not here.
+
 ## Re-checking this (do not re-derive by hand)
 
 This finding has been re-triaged several times, each time by repeating the same

--- a/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
+++ b/docs/skills/security/references/cve-2026-33186-grpc-buildah.md
@@ -1,50 +1,109 @@
-# CVE-2026-33186 (google.golang.org/grpc) in the buildah binary
+# CVE-2026-33186 (google.golang.org/grpc) in the Fedora container-tools stack
 
 Severity: **Critical** (CVSS ≥ 9.0, per the vulnerability scan gate).
 
 ## Finding
 
-CVE-2026-33186 affects `google.golang.org/grpc v1.72.2`, which is bundled in the
-`buildah` binary shipped by the Fedora container-tools stack. There is **no
-self-contained fix** that this repository can apply on the Fedora 44 target.
+CVE-2026-33186 affects `google.golang.org/grpc` before `v1.79.3`, which is
+statically bundled into Go binaries shipped by the Fedora container-tools stack.
+There is **no self-contained fix** that this repository can apply on the Fedora
+44 target.
 
 ## Root cause
 
-- The vulnerable module is bundled in `buildah`, not in an explicitly declared
-  image package. `buildah` is not listed in `build_files/packages/base.toml`; it
-  arrives as part of the standard Fedora Silverblue container-tools set
-  (podman/buildah/skopeo) and is not excluded.
-- `containers/buildah@v1.43.2/go.mod` pins `google.golang.org/grpc v1.72.2 // indirect`
-  (the vulnerable version).
-- Fedora 44's latest available buildah is `buildah-1.43.2-1.fc44` (stable since
-  `2026-06-19`), which still bundles grpc v1.72.2.
-- As of the last check (`2026-08-07`), Bodhi lists **no** F44 `buildah` update in
-  `testing` or `pending` status. There is no newer F44 RPM to pin or override to.
-- Fedora 45 carries a fixed buildah: `buildah-1.45.0-2.fc45` bundles
-  `google.golang.org/grpc v1.82.1`. The fix is therefore gated on a Fedora 45
-  migration, not on an in-repo pin.
+The vulnerable module is bundled in the binaries, not in an explicitly declared
+image package. None of these are listed in `build_files/packages/base.toml`; they
+arrive as part of the standard Fedora Silverblue container-tools set and are not
+excluded.
+
+**Two carriers ship the vulnerable version on Fedora 44, not one:**
+
+| F44 package | grpc pinned in that version | Status |
+|---|---|---|
+| `buildah-2:1.43.2-1.fc44` | `v1.72.2` | vulnerable |
+| `podman-5.8.4-1.fc44` | `v1.72.2` | vulnerable |
+| `skopeo-1.22.2-2.fc44` | `v1.79.3` | already fixed |
+
+`skopeo` is listed to show the finding is per-binary: the same stack already
+carries a fixed build, so "container-tools is vulnerable" is too coarse. Fixing
+one carrier does not clear the scan while the other remains.
 
 ## Why an in-repo pin/override does not resolve it
 
-The `Pins and Overrides` section in `build_files/base/03-packages.sh` documents the
-mechanism for `rpm-ostree override replace`, but it requires a fixed RPM that
-exists in a Fedora repo. No such F44 buildah RPM exists. Downgrading is not
-helpful (older versions are also vulnerable), and no F44 `buildah` build bumps
-grpc to `>= 1.79.3`.
+The `Pins and Overrides` section in `build_files/base/03-packages.sh` documents
+the mechanism for `rpm-ostree override replace`, but it requires a fixed RPM that
+exists in a Fedora repo. No such F44 RPM exists for either carrier. Downgrading
+does not help — older versions are also vulnerable.
+
+## Where the upstream fixes land
+
+| Project | First fixed release | grpc after fix |
+|---|---|---|
+| `buildah` | `v1.44.0` | `v1.81.1` |
+| `podman` | `v6.0.2` | `v1.81.1` |
+
+**The podman side is the blocker.** buildah's fix is a minor bump that Fedora
+could reasonably carry, but podman's fix first appears in `v6.0.2` — the latest
+`5.8.x` release, `v5.8.5`, still pins `grpc v1.72.2`. There is no podman 5.x
+release that resolves this, so clearing it on F44 would require Fedora either to
+rebase podman from 5.8.x to 6.x inside a stable release (unlikely) or to carry a
+backported grpc bump.
+
+Consequently: **an F44 `buildah` update alone will not clear this finding.** The
+realistic fix is the Fedora 45 migration, which moves both carriers to fixed
+versions at once — not a secondary note, but the primary path.
 
 ## Action
 
-Wait for/track an upstream Fedora 44 `buildah` update (>= v1.44.0, or a 1.43.x
-backport that bumps grpc to >= 1.79.3). Once that RPM reaches the F44 repos, the
-next `testing` build picks it up automatically. The durable fix is the Fedora 45
-migration. Do not weaken the vulnerability scan gate or add an exception; this
-finding is a tracking note, not an approval to suppress the scan.
+Track the Fedora 45 migration as the fix. An F44 `buildah` update is worth
+picking up when it appears but should not be expected to close the alert on its
+own; re-scan and confirm rather than assuming. Do not weaken the vulnerability
+scan gate or add an exception; this finding is a tracking note, not an approval
+to suppress the scan.
+
+## Re-checking this (do not re-derive by hand)
+
+This finding has been re-triaged several times, each time by repeating the same
+lookups. Both facts are one command each.
+
+Current F44 versions of the carriers:
+
+```bash
+for p in buildah podman skopeo; do
+  printf '%-8s ' "$p"
+  curl -s "https://mdapi.fedoraproject.org/f44/pkg/$p" | jq -r '"\(.version)-\(.release)"'
+done
+# buildah  1.43.2-1.fc44
+# podman   5.8.4-1.fc44
+# skopeo   1.22.2-2.fc44
+```
+
+Parse the JSON rather than grepping it — an mdapi response embeds a `"version"`
+field for every bundled Go module, so a bare `grep` returns hundreds of lines
+and the RPM's own version is easy to mistake for one of them.
+
+The grpc version any given upstream release bundles:
+
+```bash
+curl -s https://raw.githubusercontent.com/containers/podman/v5.8.4/go.mod |
+  grep google.golang.org/grpc
+```
+
+The finding clears when **every** carrier above resolves to a version whose
+`go.mod` pins `grpc >= v1.79.3`.
 
 ## Verification
 
-- Fedora 44 updates repo: `buildah-1.43.2-1.fc44` (no newer version).
-- Bodhi F44 buildah: no `testing` or `pending` updates as of `2026-08-07`.
-- `containers/buildah@v1.43.2/go.mod` → `google.golang.org/grpc v1.72.2 // indirect`.
-- `containers/buildah@v1.45.0/go.mod` → `google.golang.org/grpc v1.82.1`.
-- Bluefin `Containerfile` target: `ARG FEDORA_MAJOR_VERSION="44"`; the latest
-  successful testing build resolved `fedora_version=44`.
+Verified `2026-08-10` (F44 versions via `mdapi.fedoraproject.org`, grpc pins via
+each project's `go.mod` at the exact shipped tag):
+
+- `f44/buildah` → `1.43.2-1.fc44`; `containers/buildah@v1.43.2` → `grpc v1.72.2`.
+- `f44/podman` → `5.8.4-1.fc44`; `containers/podman@v5.8.4` → `grpc v1.72.2`.
+- `f44/skopeo` → `1.22.2-2.fc44`; `containers/skopeo@v1.22.2` → `grpc v1.79.3`.
+- `containers/buildah@v1.44.0` → `grpc v1.81.1` (first fixed buildah).
+- `containers/podman@v5.8.5` → `grpc v1.72.2`; `@v6.0.2` → `grpc v1.81.1`.
+- Bluefin `Containerfile` target: `ARG FEDORA_MAJOR_VERSION="44"`.
+
+Not verified here: which carrier a specific Trivy alert instance points at.
+Reading code-scanning alert locations needs permissions this check did not have,
+and it does not change the conclusion — both carriers must be fixed regardless.


### PR DESCRIPTION
## What problem are you solving?

I picked up #919 expecting to confirm the existing triage and move on. The conclusion that there is no in-repo fix is correct, but the reason recorded in our security docs is not: it names `buildah` as the only carrier of the vulnerable grpc and tells the reader that an F44 buildah update will clear the finding. It won't — `podman` ships the same vulnerable module version. Anyone tracking this per the current doc would be waiting on an update that cannot close the alert.

- [x] I am using an agent and I take responsibility for this PR

---

## The finding

Verified against the exact versions Fedora 44 ships **today (2026-08-10)**, RPM versions from `mdapi.fedoraproject.org` and grpc pins from each project's `go.mod` at the shipped tag:

| F44 package | grpc pinned | Status |
|---|---|---|
| `buildah-2:1.43.2-1.fc44` | `v1.72.2` | vulnerable |
| **`podman-5.8.4-1.fc44`** | **`v1.72.2`** | **vulnerable** |
| `skopeo-1.22.2-2.fc44` | `v1.79.3` | already fixed |

`skopeo` is in the table on purpose: the same container-tools stack already carries a fixed build, so "container-tools is vulnerable" is too coarse a statement. The exposure is per-binary, and fixing one carrier does not clear the scan while the other stands.

**The podman side is also the harder one:**

| Project | First fixed release | grpc after fix |
|---|---|---|
| `buildah` | `v1.44.0` | `v1.81.1` |
| `podman` | `v6.0.2` | `v1.81.1` |

buildah's fix is a minor bump Fedora could reasonably carry. podman's is not fixed until **v6.0.2** — the latest `5.8.x` release, `v5.8.5`, still pins `grpc v1.72.2`. There is no podman 5.x release that resolves this, so clearing it on F44 would need Fedora either to rebase podman 5.8.x → 6.x inside a stable release (unlikely) or to carry a backported grpc bump.

That inverts the doc's advice: the **Fedora 45 migration is the primary path**, not the fallback it was written as.

## Changes

Docs only — two files, no build or scan behavior touched.

- `docs/skills/security/references/cve-2026-33186-grpc-buildah.md` — corrected root cause (two carriers, with the skopeo contrast), corrected "where the fixes land" including why podman is the blocker, and reworked the Action section accordingly.
- `docs/skills/security/SKILL.md` — link text now says "buildah and podman". **Filename left alone** so the existing link and any external references keep resolving, even though it now slightly under-describes the content.

Also added a **re-check section**. This CVE has now been triaged from scratch at least four times (#870, two rounds on this issue, and this one), each time by redoing the same lookups by hand. Both facts are now one command each.

One note on that: I wrote the mdapi recipe with `grep` first, ran it, and it printed several hundred lines — an mdapi response embeds a `"version"` field for *every bundled Go module*, and the RPM's own version is easy to mistake for one of them. The committed version parses with `jq` and carries its expected output inline. Both commands in the doc were executed as written before committing.

## What I did not do

- **No suppression, no `.trivyignore`, no gate weakening.** The "do not suppress" guidance is unchanged. Accepting a critical is a Security-gate decision, not mine.
- **No package removal or pin.** There is still no fixed F44 RPM for either carrier to pin or override to.
- **No change to the auto-issue behavior.** Worth correcting one point from earlier triage while I'm here: the dedup is not filing an issue per build. Searching all issues titled "critical CVE detected" returns four in about two months (#530, #638, #870, #919), so this is roughly monthly, not per-build.

## Verification

- [x] F44 versions via `mdapi.fedoraproject.org` for buildah/podman/skopeo
- [x] grpc pins read from `go.mod` at `buildah@v1.43.2/v1.44.0`, `podman@v5.8.4/v5.8.5/v6.0.2`, `skopeo@v1.22.2`
- [x] Both commands added to the doc executed as written; the `jq` one's output is pasted into the doc
- [ ] Trivy re-scan — not run; no container toolchain in this runtime
- [ ] Which carrier a specific alert instance points at — reading code-scanning alert locations returned HTTP 403 for me. It does not change the conclusion, since both carriers must be fixed regardless, and the doc says so explicitly rather than implying I checked.

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] Docs updated (this is the docs update)

Refs #919. **Does not close it** — the CVE is still present and still has no in-repo fix. This makes the tracking note accurate about *what* to track.
