### PR TITLE
ci(lab-check): name both org-owner steps in the Checks-grant error

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Fail with actionable message if token minting was denied
         if: steps.app-token.outcome == 'failure' || steps.app-token.outputs.token == ''
         run: |
-          echo "::error::MergeRaptor token mint failed — the GitHub App installation almost certainly lacks the requested 'checks: write' permission. This cannot be fixed from the repository; an org owner must grant it (Organization settings → GitHub Apps → MergeRaptor → Permissions). Verify current grants with: gh api orgs/projectbluefin/installations --jq '.installations[] | select(.app_slug == \"mergeraptor\") | .permissions' — see docs/skills/ci/references/mergeraptor-checks.md."
+          echo "::error::MergeRaptor cannot mint a 'checks: write' token. Not fixable from this repository — it needs TWO org-owner steps in the GitHub UI, in this order: (1) DECLARE it on the app: Organization settings -> Developer settings -> GitHub Apps -> MergeRaptor -> Permissions & events -> Repository permissions -> Checks: Read and write. (2) APPROVE the request that raises on the installation: Organization settings -> GitHub Apps -> MergeRaptor. Step 2 alone does nothing while 'checks' is absent from the app definition, because there is no request to approve. To see which step you are on, compare what the app DECLARES (gh api /apps/mergeraptor) against what the installation was GRANTED (gh api orgs/projectbluefin/installations); both commands are spelled out in docs/skills/ci/references/mergeraptor-checks.md."
           exit 1
 
       - name: Create or update lab check

--- a/docs/skills/ci/references/mergeraptor-checks.md
+++ b/docs/skills/ci/references/mergeraptor-checks.md
@@ -5,12 +5,62 @@ installation already holds; anything else fails the run with `The permissions
 requested are not granted to this installation.` The MergeRaptor installation
 on `projectbluefin` therefore needs **Checks: write** for `lab-check.yml`, in
 addition to the contents/pull-requests/workflows grants `track-common.yml`
-uses. Confirm the current grants before debugging the workflow YAML:
+uses.
+
+Granting an app permission is org-admin administration in the GitHub UI, not a
+repository change. Never work around a missing grant with a PAT.
+
+## Two levels, and they fail identically
+
+A GitHub App permission exists at two levels, and the token-mint error is the
+same either way. Fixing the wrong one looks like doing nothing:
+
+| Level | What it means | Where it is changed |
+|---|---|---|
+| **Declared** on the app | The app definition *asks* for the permission | Org settings → Developer settings → GitHub Apps → MergeRaptor → Permissions & events |
+| **Granted** on the installation | An org owner *approved* what the app asked for | Org settings → GitHub Apps → MergeRaptor |
+
+An installation can never be granted a permission the app does not declare.
+When `checks` is missing from the app definition there is no pending request
+for an owner to approve, so re-installing or re-approving the app accomplishes
+nothing — the app has to ask first.
+
+## Which level are you missing?
+
+Both commands need org-owner (or app-owner) access; they 404 for everyone else,
+which is itself not a diagnosis.
 
 ```bash
+# What the app DECLARES
+gh api /apps/mergeraptor --jq '{owner: .owner.login, permissions}'
+
+# What the installation was GRANTED
 gh api orgs/projectbluefin/installations \
   --jq '.installations[] | select(.app_slug == "mergeraptor") | .permissions'
 ```
 
-Granting an app permission is org-admin administration in the GitHub UI, not a
-repository change. Never work around a missing grant with a PAT.
+- `checks` absent from **both** → start at step 1 below.
+- `checks` in the declared set but not the granted set → only step 2 is left.
+- `checks: write` in both → the permission is fine; look elsewhere.
+
+## Fix, in order
+
+1. **Declare it on the app.** Org settings → Developer settings → GitHub Apps →
+   **MergeRaptor** → Permissions & events → Repository permissions →
+   **Checks: Read and write**. Save. This raises a permission request to org
+   owners.
+2. **Approve it on the installation.** Org settings → GitHub Apps →
+   **MergeRaptor** → review and accept the request.
+
+Then re-run any Lab check, or dispatch a `lab-check` repository event, and
+confirm `testing-lab / <product>` is created or updated.
+
+## Do not paper over it
+
+`lab-check.yml` mints the token with `continue-on-error: true` purely so the
+next step can emit an actionable `::error::` instead of a bare red X; the job
+still exits 1. Note that this makes the token step *report* conclusion
+`success` while its `outcome` is `failure` — that is expected, and the
+diagnostic keys off `outcome`. Do not add a fallback that skips the report or
+downgrades the failure: a Lab check that silently passes is worse than one that
+is loudly broken.


### PR DESCRIPTION
## What problem are you solving?

The real fix for #939 is org-owner UI work and nothing in a PR can do it — I'm not trying to. But the error message we print when it fails sends the reader to the wrong settings page. It names the *approval* step, and @castrojo's own investigation on the issue showed approval is not the step that's missing: `checks` is absent from the MergeRaptor app definition, so there is no request for an owner to approve. Someone following our message lands on a page with nothing to click.

- [x] I am using an agent and I take responsibility for this PR

---

## The gap

A GitHub App permission exists at two levels, and the token-mint error is identical either way:

| Level | Meaning | Where it changes |
|---|---|---|
| **Declared** on the app | the app *asks* for it | Org settings → Developer settings → GitHub Apps → MergeRaptor → Permissions & events |
| **Granted** on the installation | an owner *approved* what was asked | Org settings → GitHub Apps → MergeRaptor |

An installation can never be granted a permission the app does not declare. From #939:

> `checks` is not merely ungranted on the installation — it is not among the App's declared permissions at all. So re-installing or re-approving cannot help; the App definition has to request it first.

Both the diagnostic from #1058 and the reference doc from #1010 point only at the second level. That was accurate as far as it went, and it is exactly the half that cannot currently be acted on.

## Changes

**`.github/workflows/lab-check.yml`** — one line, the `::error::` text. It now names both steps in order (declare on the app → approve on the installation), says in one clause why step 2 alone is a no-op, and points at the two commands that distinguish declared from granted so the reader can tell which step they still owe.

**`docs/skills/ci/references/mergeraptor-checks.md`** — the same distinction as a table, a which-level-am-I-missing recipe with the three possible readings, and the fix as two ordered steps.

I also documented something that cost me time while verifying: the token step reports **conclusion `success` while its `outcome` is `failure`**, because of `continue-on-error`. Reading a failed run, "Get MergeRaptor token: success" followed by a failing diagnostic looks like a second bug. It isn't — the `if` keys off `outcome`, correctly — but it's worth a sentence so the next person doesn't chase it. I did chase it, and confirmed from the run log that the mint genuinely 422s.

## Explicitly not doing

@castrojo's note that *"adding a fallback that skips the report would convert a loud, accurate gap into a silent one"* is right, and this PR does not do that. The step fires on the same condition, still `exit 1`s, and the gate is unchanged — the failure stays exactly as loud. The only change is that the text now describes a fix that can actually be carried out. On the "no repository change is warranted" reading: I'd offer that the message being *complete* is the one repo-side thing still worth correcting, since the current text can't be followed to completion. Happy to drop this if you'd rather keep it frozen.

## Verification

- [x] Extracted the diagnostic's `run:` block and **executed it** — emits exactly one `::error::` annotation and exits 1. Worth doing: my first draft embedded the `--jq` filters inline and the nested single-quote escaping was wrong; the committed version keeps the full commands in the doc instead.
- [x] Confirmed the current failure mode from run `31343742552` (2026-08-10): mint returns HTTP 422 `The permissions requested are not granted to this installation`, diagnostic fires, `Create or update lab check` is skipped, job fails.
- [x] Re-confirmed the state is unchanged today — last 12 Lab check runs all `failure`, most recent `2026-08-10T00:10`.
- [x] Diff is one line of workflow plus docs; no trailing whitespace or tabs; block-scalar indentation unchanged.
- [ ] `actionlint` — not run locally (unavailable here, along with any YAML parser); CI covers it. The changed line lives inside a `run: |` block scalar at unchanged indentation, so it cannot alter the document structure.
- [ ] Could not read app/installation permissions myself — both endpoints 404 without org-owner scope. That limitation is now written into the doc, since a 404 is not a diagnosis.

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials; no PAT, no credential creation or rotation
- [x] No change to the gate's pass/fail behavior

Refs #939. **Does not close it** — the org-owner grant is still required, and the check will stay red until then.
