### PR TITLE
ci(bonedigger): drop the remaining no-op triggers and dead permission

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -1,14 +1,21 @@
 name: issue lifecycle
 
+# Triggers are deliberately narrower than they look like they could be. The
+# pinned bonedigger lifecycle has exactly two jobs, `issues.opened` and
+# `issue_comment.created`, so subscribing to any other activity type dispatches
+# the reusable workflow only to skip every job in it (bluefin#981). Widen this
+# only alongside a bonedigger release that actually handles the new type.
 on:
   issues:
-    types: [opened, labeled, closed]
+    types: [opened]
   issue_comment:
     types: [created]
 
+# Scoped to what the callee declares (issues: write, contents: read). It reads
+# `event.issue.pull_request` straight from the payload and never calls the pulls
+# API, so no pull-requests scope is needed.
 permissions:
   issues: write
-  pull-requests: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## What problem are you solving?

The decision #981 asked for was made — drop the trigger — and #1011 did that. But #1011 only removed the `pull_request` block, and two leftovers of exactly the same class survived it. The workflow still subscribes to `issues.labeled` and `issues.closed`, which no job in the pinned bonedigger lifecycle matches, and it still grants `pull-requests: write`, which nothing has needed since the PR trigger left. Both are the same "dispatch the reusable workflow only to skip it" waste the issue was filed about.

- [x] I am using an agent and I take responsibility for this PR

---

## The finding

The pinned lifecycle (`d530767`, `v1`) defines exactly two jobs:

```yaml
on-issue-opened:
  if: github.event_name == 'issues' && github.event.action == 'opened'
on-issue-comment:
  if: github.event_name == 'issue_comment' && github.event.action == 'created' && ...
```

The caller subscribed to `issues: types: [opened, labeled, closed]`. `labeled` and `closed` match nothing, so each such event starts a run whose only outcome is skipping both jobs.

**Measurable, not theoretical.** Of the last 15 `issues`-event runs, **11 concluded `skipped`**. The pattern is visible in the timestamps — opening an issue and labelling it produces a success and a skip in the same second:

```
2026-08-09T02:02  skipped   run=31289493537
2026-08-09T02:02  success   run=31289493445
2026-08-08T22:43  skipped   run=31282367858
2026-08-08T22:43  success   run=31282367595
```

**Checked before removing:** `labeled`/`closed` handling does not exist at the pinned SHA *or* on bonedigger `main` HEAD — both have the same two jobs. This is not removing a trigger that upstream is about to start using.

**The dead permission.** `pull-requests: write` was added in #332, when this workflow handled PRs. The callee declares only `issues: write` / `contents: read`, and it reads `event.issue.pull_request` from the event payload rather than calling the pulls API — I grepped the pinned workflow for `gh pr` / `/pulls` and there are none. So the scope has been unused since #1011.

## What I deliberately did not touch

`issue_comment` runs also show frequent skips, but those are **not** a caller bug — the reusable workflow filters PR comments internally with `github.event.issue.pull_request == null`, and a trigger cannot distinguish an issue comment from a PR comment. Narrowing there is impossible from this side, so I left it alone.

## Changes

`.github/workflows/bonedigger.yml`, two edits plus the comments explaining why each constraint exists, so neither gets widened back by someone reading the trigger list as arbitrarily narrow:

```diff
   issues:
-    types: [opened, labeled, closed]
+    types: [opened]
 permissions:
   issues: write
-  pull-requests: write
   contents: read
```

No behaviour change for the jobs that actually run. `issues.opened` and `issue_comment.created` are untouched, and the effective permission set is unchanged — a reusable workflow's jobs are already capped at what the callee declares, which never included `pull-requests`.

## Testing

- [x] Verified the pinned lifecycle's complete job set (2 jobs) and their `if` guards, at `d530767` and at bonedigger `main`
- [x] Confirmed no `gh pr` / `/pulls` usage anywhere in the pinned reusable workflow
- [x] Quantified the waste from run history (11/15 `issues` dispatches skipped)
- [x] Structural check: stripping comments from the new file and diffing against the original with only the two intended edits applied gives an exact match — no indentation or ordering drift
- [ ] `actionlint` / YAML parse — not run locally; no YAML tooling in this environment (no `yq`, `actionlint`, `pyyaml`, `js-yaml`). CI's `check-yaml` and `actionlint` pre-commit hooks cover it, and the diff-based check above is why I am reasonably confident regardless.

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] Action pinning preserved (`@d530767 # v1` untouched); permission change only *removes* unused write scope

Closes #981.
