### PR TITLE
docs(ci): record that ping has no cap_net_raw on Fedora by design

### DIFF
--- a/docs/skills/ci/references/failure-modes.md
+++ b/docs/skills/ci/references/failure-modes.md
@@ -28,6 +28,42 @@ The behave summary line (`N scenarios passed, N failed`) and the
 `Failing scenarios:` block name the exact feature file and line. That is the
 only evidence that identifies the failure; job names do not.
 
+## `cap_net_raw` missing on `/usr/bin/ping` is not an image regression
+
+`system_health.feature` "composefs preserves file capabilities on newuidmap,
+newgidmap, and ping" fails deterministically on smoke-b with:
+
+```
+composefs file-capability regression — missing capabilities:
+  ["/usr/bin/ping: expected 'cap_net_raw' in ''"]
+```
+
+This has been triaged twice as a possible bluefin image-content defect. It is
+not one. Fedora's `iputils` deliberately ships `ping` with **no file
+capabilities** — it relies on unprivileged ICMP sockets via
+`net.ipv4.ping_group_range`, which systemd sets by default. Only two binaries
+in that package carry capabilities (`iputils.spec`, `f44`):
+
+```spec
+%attr(0755,root,root) %caps(cap_net_raw=p) %{_bindir}/clockdiff
+%attr(0755,root,root) %caps(cap_net_raw=p) %{_bindir}/arping
+%attr(0755,root,root) %{_bindir}/ping
+```
+
+There is no xattr on `ping` to preserve or strip, so the assertion cannot pass
+on any Fedora-based image regardless of what composefs does.
+
+The same failure proves composefs is working. The other two binaries in the
+assertion do carry capabilities — `shadow-utils` sets `cap_setuid=ep` on
+`newuidmap` and `cap_setgid=ep` on `newgidmap` — and both pass. Capability
+preservation is fine; the expectation list is wrong.
+
+Do not "fix" this by adding `setcap cap_net_raw` to `ping` in the image. That
+diverges from Fedora for no functional gain — `ping` already works. The fix is
+in `projectbluefin/testsuite`: drop `ping` from the assertion, or better, swap
+it for `arping` or `clockdiff`, which genuinely carry `cap_net_raw=p` and so
+make the scenario a real composefs test rather than a vacuous one.
+
 ## The `oras` screenshot error is not the failure
 
 In `projectbluefin/testsuite`'s `e2e.yml@v1`, the `Push desktop screenshot to


### PR DESCRIPTION
## What problem are you solving?

One of the four threads blocking `:testing` promotion is the smoke-b composefs assertion failing on `/usr/bin/ping`. It has been triaged twice now as *possibly* a bluefin image defect — most recently on #989 as "an image-content finding on bluefin (or a mis-scoped re-activation in testsuite)". It is the second one, and the evidence settles it conclusively. This records that so it stops being re-litigated, and so nobody "fixes" it in the image.

- [x] I am using an agent and I take responsibility for this PR

---

## The evidence

Fedora's `iputils` ships `ping` with **no file capabilities at all**. From `iputils.spec` on the `f44` branch — the exact package this image gets:

```spec
%attr(0755,root,root) %caps(cap_net_raw=p) %{_bindir}/clockdiff
%attr(0755,root,root) %caps(cap_net_raw=p) %{_bindir}/arping
%attr(0755,root,root) %{_bindir}/ping
```

`clockdiff` and `arping` get `cap_net_raw=p`. `ping` is a bare `%attr` — it works through unprivileged ICMP sockets via `net.ipv4.ping_group_range`, which systemd sets by default. **There is no xattr on `ping` to preserve or strip**, so:

```
["/usr/bin/ping: expected 'cap_net_raw' in ''"]
```

cannot pass on any Fedora-based image regardless of what composefs does.

**The same failure proves composefs is healthy.** The other two binaries in that assertion genuinely do carry capabilities — `shadow-utils` sets `cap_setuid=ep` on `newuidmap` and `cap_setgid=ep` on `newgidmap` — and both now pass, where earlier runs failed all three. Capability preservation is working. The expectation list is what's wrong.

That also explains the narrowing noted on #929: the assertion went from naming three binaries to naming only `ping`. That wasn't partial progress on a composefs bug — it was the two real capability-carrying binaries starting to pass, leaving behind the one that never had a capability.

## Changes

One section in `docs/skills/ci/references/failure-modes.md`, next to the existing "The `oras` screenshot error is not the failure" entry — same genre of "this red line is not your bug".

It includes an explicit **do not** : don't add `setcap cap_net_raw` to `ping` in the image to turn the test green. That diverges from Fedora for no functional gain, since `ping` already works. And a constructive alternative for the testsuite side: assert on `arping` or `clockdiff` instead, which really do carry `cap_net_raw=p` — that would make the scenario an actual composefs test rather than one that can only ever fail.

## Scope — what this does and does not do

This does **not** unblock the gate. `firefox.feature` (thread 1) is still the deterministic blocker and needs live-session AT-SPI instrumentation in testsuite; nothing in this repo addresses it.

What it does is correctly reassign thread 2 away from bluefin, with proof, so the remaining work is scoped to testsuite.

I also want to flag the circuit-breaker proposal in the last issue comment. Option A adds a `force_promote` dispatch input so `promote-to-testing` can run when `run-e2e` failed. That is the outcome this issue's own **"Explicitly NOT the fix"** section rules out — "Do not add `always()`, `continue-on-error`, or drop `run-e2e` from `promote-to-testing`'s `needs:`. That promotes an unverified digest and is the failure mode a sibling PR was already closed for." A manual bypass reaches the same end by a different mechanism, and it is especially risky here given §1 of the issue: `:testing` already points at an e2e-**failing** digest, so the gate is leaking without anyone adding a bypass. I have not implemented it.

## Testing

- [x] `python3 .github/scripts/validate-docs.py` → `documentation ok: 13 skills, 41 Markdown files`
- [x] Capability claims read from Fedora dist-git `f44` branches of `iputils` and `shadow-utils`, not from memory
- [x] No trailing whitespace or tabs
- [ ] Not verified against a running image — no container/VM toolchain here. The claim is about what the RPM ships, which the spec settles; a `getcap /usr/bin/ping` on a booted image would confirm it returns empty, as expected.

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] Docs only — no workflow, gate, or image change

Refs #989. Does not close it.
