### PR TITLE
test(build): regression-guard missing IMPORTANT_PACKAGES entries (#965)

### DIFF
--- a/tests/unit/20-tests_test.bats
+++ b/tests/unit/20-tests_test.bats
@@ -84,6 +84,32 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "20-tests: rejects an image missing a required IMPORTANT_PACKAGES entry" {
+    # #965 item 1: fzf was missing from the image, breaking `ujust --choose` on
+    # first boot. #1057 added fzf to IMPORTANT_PACKAGES, but nothing asserted
+    # that the script actually fails when rpm reports it (or any other
+    # required package) absent — the existing "unwanted package" test below
+    # only exercises the UNWANTED_PACKAGES list. Guard the missing-package path
+    # directly so a future edit can't silently drop an entry with no coverage.
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+if [[ "$*" == *"%{VENDOR}"* ]]; then
+    echo "negativo17.org"
+    exit 0
+fi
+case "$*" in
+    *fedora-flathub-remote*|*fedora-logos*|*fedora-third-party*|*gnome-software*|*podman-docker*) exit 1 ;;
+    *fzf*) exit 1 ;;
+esac
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing package: fzf"* ]]
+}
+
 @test "20-tests: rejects an unwanted package" {
     cat > "${STUB_BIN}/rpm" <<'EOF'
 #!/usr/bin/bash


### PR DESCRIPTION
## What problem are you solving?

#965 reported (item 1) that `fzf` was missing from Dakota alpha 5, breaking `ujust --choose` on first boot. That was traced back to bluefin and fixed in #1057, which added `fzf` to both `build_files/packages/base.toml` and the `IMPORTANT_PACKAGES` array in `build_files/base/20-tests.sh`.

While verifying that fix, I found there is no regression test asserting the *behavior* the fix depends on: that `20-tests.sh` actually fails the build when `rpm -q` reports a required package absent. The existing `tests/unit/20-tests_test.bats` only has:

- a happy-path test where every package is treated as installed, and
- `"rejects an unwanted package"`, which exercises the separate `UNWANTED_PACKAGES` list, not `IMPORTANT_PACKAGES`.

So nothing in CI currently protects the `IMPORTANT_PACKAGES` gate itself — a future edit could silently drop `fzf` (or any other entry) from the array, or a change to the loop, and no test would catch it, reproducing #965 item 1 with a build that still goes green.

## Changes

Adds one bats test to `tests/unit/20-tests_test.bats`:

- `"20-tests: rejects an image missing a required IMPORTANT_PACKAGES entry"` — stubs `rpm -q` to report `fzf` (and the other packages already treated as absent for `UNWANTED_PACKAGES`) missing, runs the patched script, and asserts a non-zero exit with the `Missing package: fzf` message the script emits.

No production code changed — `build_files/base/20-tests.sh` and `build_files/packages/base.toml` already have the #1057 fix; this only closes the test gap around it.

## Validation

```
$ bats tests/unit/20-tests_test.bats
1..4
ok 1 20-tests: passes when required image state is present
ok 2 20-tests: rejects an image missing a required IMPORTANT_PACKAGES entry
ok 3 20-tests: rejects an unwanted package
ok 4 20-tests: checks NVIDIA packages for NVIDIA images
```

Refs #965

- [x] I am using an agent and I take responsibility for this PR