### PR TITLE
docs(workflow): note Closes #NNN only fires on the default branch

### DIFF
--- a/docs/skills/issue-lifecycle/SKILL.md
+++ b/docs/skills/issue-lifecycle/SKILL.md
@@ -37,6 +37,17 @@ metadata:
    repository's default branch `main`, which the base-branch guard rejects).
 6. Respond to review feedback; do not self-approve or self-merge.
 
+`Closes #NNN` only auto-closes the issue once its commit reaches the
+repository's default branch (`main`), because GitHub evaluates the closing
+keyword against the default branch regardless of which branch the PR merged
+into. Merging to `testing` does not close the issue immediately; the issue
+stays open until `promote-testing-to-main.yml` carries that commit to `main`.
+Do not read a `Closes`-linked issue still being open after a `testing` merge
+as a bug in the PR, the automation, or the link itself — confirm whether the
+commit has reached `main` yet before concluding anything is wrong. See
+[`projectbluefin/bluefin#995`](https://github.com/projectbluefin/bluefin/issues/995)
+for a case where this produced exactly that confusion.
+
 Automation applies and repairs the seven canonical workflow labels. Agents do
 not use slash commands as state transitions, do not add or remove workflow
 labels, and do not manufacture queue state. If blocked, describe the exact

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -46,7 +46,10 @@ issue and stop.
 4. Run the relevant validation.
 5. Update the matching documentation when a reusable fact changes.
 6. Open a pull request targeting `testing` containing `Closes #NNN`; normal
-   feature work must not target `main`.
+   feature work must not target `main`. That keyword only auto-closes the
+   issue once the commit reaches the default branch `main` — see
+   [issue-lifecycle](skills/issue-lifecycle/SKILL.md) — so the issue stays
+   open through the `testing` merge until `promote-testing-to-main.yml` runs.
 
 Do not self-approve or self-merge. Automation applies `4-review`; a human
 reviews.


### PR DESCRIPTION
## Summary

Follow-up to the read-only audit in #995. That audit's most recent comment
flagged a "mechanical note worth a human decision": PR #1049 merged
`Closes #995` to `testing` on 2026-08-09, but #995 stayed open, because
`bluefin`'s default branch is `main` and GitHub only evaluates a closing
keyword against the default branch — not the branch the PR actually merged
into. The issue will only auto-close once that commit reaches `main` via
`promote-testing-to-main.yml`.

This is a genuine, reusable documentation gap, not a bug: `docs/workflow.md`
and `docs/skills/issue-lifecycle/SKILL.md` both instruct contributors to open
PRs targeting `testing` with `Closes #NNN`, but neither previously explained
that the close will lag behind the `testing` merge until the next promotion.
Without this note, a future contributor or agent could reasonably read a
still-open, `Closes`-linked issue after a `testing` merge as broken
automation, a bad link, or a PR mistake.

## Changes

- `docs/skills/issue-lifecycle/SKILL.md` — add the explanation directly after
  the `Closes #NNN` step (the source-of-truth for that step), with a pointer
  to #995 as the concrete example.
- `docs/workflow.md` — add a one-line cross-reference in its summary of the
  same step, linking to the fuller explanation in the skill.

## Explicitly not changed

No workflow, label automation, or release behavior changes. Items 1–3 from
#995 (repairing the e2e gate, and any re-pointing of `:testing`/`:stable`)
remain explicit human decisions and are out of scope here; item 4 (tightening
the `release-gate == 'skipped'` fail-open) lives in `projectbluefin/actions`
and is also out of scope for this repo.

## Validation

- `python3 .github/scripts/validate-docs.py` — passes (`13 skills, 41 Markdown
  files`).
- Documentation-only change; no image build required per `AGENTS.md`.

Refs #995.
