### PR TITLE
docs(ci): document the :testing stream-tag leak triage path for #989

### DIFF
--- a/docs/skills/ci/references/failure-modes.md
+++ b/docs/skills/ci/references/failure-modes.md
@@ -155,3 +155,35 @@ single failing leg blocking it is the actual root cause of the stable
 promotion backlog, not whatever else changed between the frozen digest and
 `main` HEAD. Fixing only the other legs' known issues will not move
 `:testing` or unblock `Execute Release` until that leg passes.
+## `:testing` can carry a stream tag even when `promote-to-testing` is skipped
+
+Do not assume the bare `:testing` tag only ever moves through
+`promote-to-testing` in `post-testing-e2e.yml`. `build-image-testing.yml`
+passes `publish_stream_tag: "false"` to
+`projectbluefin/actions/.github/workflows/reusable-build.yml@v1` specifically
+so a `main`/`testing`-branch build does not publish the bare stream tag ahead
+of the e2e gate — but this repo does not control whether that input is
+actually honored by the push step in that reusable workflow.
+
+Reported on #989 (2026-08-07): the digest tagged `:testing` in the registry
+was the exact digest a `run-e2e` run had just failed against, in a run where
+`promote-to-testing` was `skipped`. That means either `compute-push-tags`'
+excluded-tag output was not honored by the later push step, or something else
+in the reusable workflow re-tags after the fact (for example `just
+tag-images` tagging `DEFAULT_TAG` locally and a later step publishing all
+local tags regardless of the computed set).
+
+Before trusting `promote-to-testing: skipped` as proof `:testing` is still
+the last known-good digest, verify what the registry actually serves:
+
+```bash
+skopeo inspect docker://ghcr.io/projectbluefin/bluefin:testing
+```
+
+Compare the returned digest against the `IMAGE:` value logged by the most
+recent `run-e2e` run for that digest. A mismatch, or a match against a
+*failing* run, means the leak reproduced again. The fix (making
+`publish_stream_tag: "false"` actually prevent the bare-tag push, plus a
+regression guard) belongs in `projectbluefin/actions`, not here — this repo
+only supplies the input; it does not control the push step that is supposed
+to honor it.


### PR DESCRIPTION
## What problem are you solving?

#989's blast-radius analysis identified four blocking threads for the frozen `:testing` promotion. Threads 1-3 (the `firefox.feature` AT-SPI regression and related testsuite flakes) are already tracked in `docs/skills/ci/references/failure-modes.md` via the open docs PR for this issue. Thread 4 — the bare `:testing` tag landing on an e2e-failing digest even when `promote-to-testing` is `skipped` — has no entry anywhere in this repo's docs, so the next person triaging a stale/wrong `:testing` tag has to re-derive the evidence from scratch.

- [x] I am using an agent and I take responsibility for this PR

## Changes

- `docs/skills/ci/references/failure-modes.md`: add a "`:testing` can carry a stream tag even when `promote-to-testing` is skipped" section documenting:
  - why `build-image-testing.yml` passes `publish_stream_tag: "false"` to `projectbluefin/actions`'s `reusable-build.yml@v1`
  - the reported 2026-08-07 evidence that the bare tag landed anyway on a digest that had just failed `run-e2e`
  - the `skopeo inspect` verification command to check whether the leak has reproduced
  - that the actual fix belongs in `projectbluefin/actions`, since this repo only supplies the input and does not control the push step that's supposed to honor it

## Explicitly not changed

Per #989's own guidance, this does not touch `promote-to-testing`'s gating logic, and it does not attempt a fix in `projectbluefin/actions` (out of this repo's scope) — it's a documentation-only addition so the stream-tag-leak thread has the same triage record the other three threads already have.

## Validation

- `python3 .github/scripts/validate-docs.py` — passes (`13 skills, 41 Markdown files`).
- Documentation-only change; no image build required per `AGENTS.md`.

Refs #989.