### PR TITLE
fix(lab-check): find the existing check run on busy commits

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -82,9 +82,15 @@ jobs:
           STARTED_AT=$(jq -r '.started_at // empty' <<<"${CHECK_JSON}")
           COMPLETED_AT=$(jq -r '.completed_at // empty' <<<"${CHECK_JSON}")
 
+          # check_name filters server-side. Without it the first page is 100
+          # check runs of every name, newest first, so on a busy commit the
+          # existing lab check falls off the page and this lookup returns
+          # nothing -- which silently turns every update into a duplicate
+          # check run (bluefin#939).
           CHECK_ID=$(
             gh api --method GET \
               "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
+              -f check_name="${CHECK_NAME}" \
               -f per_page=100 \
               --jq '.check_runs
                 | map(select(.name == "'"${CHECK_NAME}"'" and .app.slug == "'"${APP_SLUG}"'"))

--- a/tests/test_lab_check.py
+++ b/tests/test_lab_check.py
@@ -1,0 +1,195 @@
+"""Tests for the check-run reporting script in lab-check.yml.
+
+The workflow has never run to completion in CI -- every dispatch so far dies at
+the MergeRaptor token mint (bluefin#939) -- so the script below is exercised
+here against a stub ``gh`` instead.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "lab-check.yml"
+STEP = "      - name: Create or update lab check\n"
+REPOSITORY = "projectbluefin/bluefin"
+CHECK_NAME = "testing-lab / bluefin"
+SHA = "a" * 40
+
+# Stands in for `gh api`: serves the check-runs listing from GH_STUB_CHECK_RUNS
+# with the same semantics as the real endpoint -- newest first, truncated to
+# per_page, filtered by check_name when asked -- and records every request.
+STUB_GH = '''#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+
+arguments = sys.argv[1:]
+method = "GET"
+fields = {}
+jq_expression = None
+endpoint = None
+
+index = 0
+while index < len(arguments):
+    argument = arguments[index]
+    if argument == "--method":
+        method = arguments[index + 1]
+        index += 2
+    elif argument in ("-f", "--raw-field"):
+        key, _, value = arguments[index + 1].partition("=")
+        fields[key] = value
+        index += 2
+    elif argument == "--jq":
+        jq_expression = arguments[index + 1]
+        index += 2
+    elif argument == "--input":
+        index += 2
+    elif argument == "api" or argument.startswith("-"):
+        index += 1
+    else:
+        endpoint = argument
+        index += 1
+
+
+def record(entry):
+    with open(os.environ["GH_STUB_LOG"], "a", encoding="utf-8") as log:
+        log.write(json.dumps(entry) + "\\n")
+
+
+if method in ("POST", "PATCH"):
+    record({"method": method, "endpoint": endpoint,
+            "body": json.loads(sys.stdin.read())})
+    print(json.dumps({"id": 0}))
+    sys.exit(0)
+
+if endpoint.endswith("/check-runs"):
+    runs = json.loads(os.environ["GH_STUB_CHECK_RUNS"])
+    name = fields.get("check_name")
+    if name is not None:
+        runs = [run for run in runs if run["name"] == name]
+    page = runs[: int(fields.get("per_page", 30))]
+    record({"method": method, "endpoint": endpoint, "check_name": name,
+            "returned": len(page)})
+    payload = json.dumps({"total_count": len(runs), "check_runs": page})
+    if jq_expression is None:
+        print(payload)
+        sys.exit(0)
+    result = subprocess.run(["jq", "-r", jq_expression], input=payload,
+                            capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    sys.exit(result.returncode)
+
+record({"method": method, "endpoint": endpoint})
+print("{}")
+'''
+
+
+def report_script() -> str:
+    """Return the shell body of the 'Create or update lab check' step."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    step = workflow.split(STEP, 1)[1].split("\n      - name: ", 1)[0]
+    return textwrap.dedent(step.split("        run: |\n", 1)[1])
+
+
+def check_run(identifier: int, name: str = CHECK_NAME,
+              slug: str = "mergeraptor") -> dict:
+    return {"id": identifier, "name": name, "app": {"slug": slug}}
+
+
+class LabCheckReportTests(unittest.TestCase):
+    def run_report(self, existing: list[dict], check: dict) -> list[dict]:
+        """Run the step against `existing` check runs, newest first."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            stub = root / "gh"
+            stub.write_text(STUB_GH, encoding="utf-8")
+            stub.chmod(0o755)
+            log = root / "requests.jsonl"
+            log.touch()
+
+            environment = dict(os.environ)
+            environment.update(
+                PATH=f"{root}{os.pathsep}{environment['PATH']}",
+                GITHUB_REPOSITORY=REPOSITORY,
+                SHA=SHA,
+                CHECK_JSON=json.dumps(check),
+                GH_TOKEN="stub-token",
+                GH_STUB_LOG=str(log),
+                GH_STUB_CHECK_RUNS=json.dumps(existing),
+            )
+
+            result = subprocess.run(
+                ["bash", "-c", report_script()],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return [
+                json.loads(line)
+                for line in log.read_text(encoding="utf-8").splitlines()
+            ]
+
+    def test_updates_existing_check_buried_past_the_first_page(self) -> None:
+        # A commit that has collected more check runs than one page holds: the
+        # lab check is the oldest, so an unfiltered listing would never see it.
+        existing = [check_run(9000 + index, name="e2e") for index in range(150)]
+        existing.append(check_run(1234))
+
+        requests = self.run_report(
+            existing,
+            {"state": "completed", "conclusion": "success",
+             "summary": "All lab suites passed."},
+        )
+
+        writes = [r for r in requests if r.get("method") in ("POST", "PATCH")]
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0]["method"], "PATCH")
+        self.assertTrue(writes[0]["endpoint"].endswith("/check-runs/1234"))
+        # head_sha is immutable on an existing run; sending it is rejected.
+        self.assertNotIn("head_sha", writes[0]["body"])
+        self.assertEqual(writes[0]["body"]["conclusion"], "success")
+
+        listing = next(r for r in requests if r["endpoint"].endswith("check-runs"))
+        self.assertEqual(listing["check_name"], CHECK_NAME)
+
+    def test_creates_check_when_the_commit_has_none(self) -> None:
+        requests = self.run_report(
+            [check_run(9001, name="e2e")],
+            {"state": "in_progress", "title": "Lab validation",
+             "summary": "Lab run started.",
+             "details_url": "https://lab.example/run/7"},
+        )
+
+        writes = [r for r in requests if r.get("method") in ("POST", "PATCH")]
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0]["method"], "POST")
+        body = writes[0]["body"]
+        self.assertEqual(body["name"], CHECK_NAME)
+        self.assertEqual(body["head_sha"], SHA)
+        self.assertEqual(body["status"], "in_progress")
+        self.assertNotIn("conclusion", body)
+        self.assertEqual(body["details_url"], "https://lab.example/run/7")
+
+    def test_ignores_a_same_named_check_from_another_app(self) -> None:
+        requests = self.run_report(
+            [check_run(4321, slug="some-other-app")],
+            {"state": "completed", "conclusion": "failure",
+             "summary": "Lab run failed."},
+        )
+
+        writes = [r for r in requests if r.get("method") in ("POST", "PATCH")]
+        self.assertEqual(writes[0]["method"], "POST")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`.github/workflows/lab-check.yml` decides between creating and updating the `testing-lab / <product>` check run by listing check runs on the commit and filtering client-side:

```bash
gh api --method GET "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
  -f per_page=100 \
  --jq '.check_runs | map(select(.name == ... and .app.slug == ...)) | sort_by(.id) | last | .id // empty'
```

That reads **one page of 100 check runs of every name**, and the endpoint returns them **newest first**.

## Why it breaks

Bluefin commits accumulate far more than 100 check runs:

```console
$ for sha in $(git rev-list -n 4 upstream/main); do
    gh api --method GET "repos/projectbluefin/bluefin/commits/$sha/check-runs" \
      -f per_page=1 --jq '.total_count'
  done
227
257
50
57
```

On `2f4dada` the first page of 100 spans `2026-08-13T20:05` back to `2026-08-11T20:17` — about two days — and contains only 22 distinct names; names such as `Scorecard analysis` and `Vulnerability scan / …` exist only on later pages.

The lab check is created early in a commit's life, so once ~100 newer check runs land on that commit it falls off page 1. `CHECK_ID` then comes back empty and the script **POSTs a new check run instead of PATCHing the existing one**. Each lifecycle event (`queued` → `in_progress` → `completed`) creates another duplicate `testing-lab / <product>` entry, and the earlier ones are left stranded in `in_progress` — a check that never completes, which is worse than the missing one.

## The fix

Pass `check_name` so the endpoint filters server-side. Verified against the live API:

```console
$ gh api --method GET "repos/projectbluefin/bluefin/commits/2f4dada.../check-runs" \
    -f check_name="Update MergeRaptor check" -f per_page=100 \
    --jq '{total: .total_count, names: (.check_runs|map(.name)|unique)}'
{"total":39,"names":["Update MergeRaptor check"]}
```

The response then holds only same-named runs, and the existing `sort_by(.id) | last` still picks the newest. `--paginate` is deliberately not added: it would run the `--jq` expression once per page and emit several ids.

## Tests

This path **has never executed in CI**. Every Lab check dispatch since the workflow landed fails at the MergeRaptor token mint (#939) — the last 12+ runs, most recently `31730816503` (2026-08-13T18:27Z) — so the bug could not have been observed from a run log.

`tests/test_lab_check.py` extracts the step's shell body from the workflow and runs it against a stub `gh` that reproduces the endpoint's newest-first ordering, `per_page` truncation and `check_name` filtering:

- update path — the lab check sits behind 150 newer check runs; asserts a single `PATCH` to the existing id, and that `head_sha` is omitted (immutable on an existing run)
- create path — asserts `POST` with `head_sha`, `status`, and no `conclusion` while `in_progress`
- a same-named check run from a different app is ignored

Without the workflow change the first test fails with `AssertionError: 'POST' != 'PATCH'`.

```console
$ python3 -m unittest discover -s tests -p 'test_*.py'
Ran 8 tests in 0.567s

OK
$ actionlint .github/workflows/lab-check.yml   # clean
```

## Relationship to #939

This does **not** resolve #939 — that still needs an org owner to declare and grant **Checks: write** on the MergeRaptor app, which is UI-only and unautomatable. It fixes a defect on the other side of that grant: as written, the first thing to happen after the permission lands would be duplicate lab checks. It is independent of #1079 (which corrects the failure *message*) and touches no line that PR touches.

Refs #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)
