### PR TITLE
ci: restore upgrade-test (lifecycle) as a promotion gate (#400)

### DIFF
--- a/.github/workflows/post-testing-e2e.yml
+++ b/.github/workflows/post-testing-e2e.yml
@@ -54,29 +54,23 @@ jobs:
       image: ${{ needs.e2e.outputs.image }}
       suites: smoke,common
 
-  # run-upgrade-test: DISABLED — TODO(#400)
-  # lifecycle suite fails under GNOME 50 AT-SPI changes, causing post-testing-e2e
-  # to mark as 'failure' and blocking promotion.
-  # Disabled until testsuite lifecycle scenarios are stable on GNOME 50.
-  # To restore: uncomment the job below.
-  #
-  # run-upgrade-test:
-  #   needs: [e2e]
-  #   permissions:
-  #     packages: write
-  #     contents: read
-  #   uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@v1
-  #   with:
-  #     image: ${{ needs.e2e.outputs.image }}
-  #     suites: lifecycle
+  run-upgrade-test:
+    needs: [e2e]
+    permissions:
+      packages: write
+      contents: read
+    uses: projectbluefin/actions/.github/workflows/upgrade-test.yml@v1
+    with:
+      image: ${{ needs.e2e.outputs.image }}
+      suites: lifecycle
 
   promote-to-testing:
     # Promote all tested flavors to :testing only after e2e passes.
     # This ensures :testing always points to a digest that has passed gate e2e.
-    # run-upgrade-test removed from needs — lifecycle suite is non-blocking (see TODO above).
-    needs: [e2e, run-e2e]
+    needs: [e2e, run-e2e, run-upgrade-test]
     if: >-
       needs.run-e2e.result == 'success' &&
+      needs.run-upgrade-test.result == 'success' &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary

Restores `run-upgrade-test` as a hard gate on `promote-to-testing` per issue #400.

### Changes

- **Uncommented** the `run-upgrade-test` job (calls `projectbluefin/actions/.github/workflows/upgrade-test.yml@v1` with `suites: lifecycle`)
- **Added** `run-upgrade-test` to `promote-to-testing`'s `needs:` array
- **Restored** the gate condition: `needs.run-upgrade-test.result == 'success'`
- **Removed** the TODO(#400) comment block and stale decoupling note

### Why this is safe now

The lifecycle suite is **SSH-based** (no AT-SPI or GUI interaction required — see `tests/lifecycle/features/steps/steps.py`: "Runner: plain SSH behave (no qecore/AT-SPI needed)"). The `GNOME 50 AT-SPI` blocker was a misdiagnosis.

The testsuite has received multiple fixes since the original failure:
- `b289463` — fix dbus autolaunch and session state snapshot on failure (#737)
- `a0a944f` — survive GDM restart in GNOME shell readiness gate (#727)
- `920787a` — restore Bluefin release gate reliability (#731)
- `fd61133` — scope composefs capability check to Fedora-shipped caps (#749)

### Workflow impact

`promote-to-testing` now requires **all three** conditions:
1. `needs.run-e2e.result == 'success'` (smoke + common suites)
2. `needs.run-upgrade-test.result == 'success'` (lifecycle suite)
3. `github.event.workflow_run.head_branch == 'main'` (main-only promotion guard)

All three run in parallel after `e2e` completes. If any fails, `promote-to-testing` is skipped.

### Linked issue

Closes #400
