### PR TITLE
fix(framework): remove stale hid_sensor_hub karg from AMD Framework laptops

### DIFF
--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+# Removes the stale module_blacklist=hid_sensor_hub kernel argument from
+# AMD Framework laptops. This karg was set by an older image version that
+# incorrectly applied an Intel-specific rule to all Framework hardware.
+# On AMD Framework systems this module has no known purpose on the blacklist
+# and may suppress unrelated USB HID sensor functionality.
+#
+# This is a one-time migration cleanup. The kernel driver fix for battery
+# charge threshold control on AMD Framework is in fw-charge-control.conf
+# (bluefin#879); this script only removes a stale karg side-effect.
+
+# shellcheck source=/dev/null
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script framework-amd-kargs-cleanup privileged 1 || exit 0
+
+set -euo pipefail
+
+VENDOR_PATH="/sys/devices/virtual/dmi/id/chassis_vendor"
+PRODUCT_PATH="/sys/devices/virtual/dmi/id/product_name"
+STALE_KARG="module_blacklist=hid_sensor_hub"
+
+if [[ ! -r "${VENDOR_PATH}" || ! -r "${PRODUCT_PATH}" ]]; then
+    echo "Framework AMD kargs cleanup: DMI information not available, skipping."
+    exit 0
+fi
+
+vendor="$(<"${VENDOR_PATH}")"
+product_name="$(<"${PRODUCT_PATH}")"
+
+# Only run on Framework hardware
+[[ "${vendor}" == "Framework" ]] || exit 0
+
+# Positive AMD match: only act on Framework laptops that name AMD in the product
+# string.  This avoids mutating boot config on Intel or future unknown Framework
+# hardware.
+[[ "${product_name}" =~ AMD ]] || exit 0
+
+if ! command -v rpm-ostree >/dev/null 2>&1; then
+    echo "Warning: rpm-ostree not found; unable to clean up stale AMD Framework kargs."
+    exit 0
+fi
+
+if ! rpm-ostree kargs | grep -Fq "${STALE_KARG}"; then
+    echo "AMD Framework: ${STALE_KARG} not present — nothing to do."
+    exit 0
+fi
+
+rpm-ostree kargs --delete="${STALE_KARG}"
+echo "Removed stale AMD Framework karg: ${STALE_KARG}. Reboot to activate."
+

--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh
@@ -48,4 +48,3 @@ fi
 
 rpm-ostree kargs --delete="${STALE_KARG}"
 echo "Removed stale AMD Framework karg: ${STALE_KARG}. Reboot to activate."
-

--- a/tests/unit/12-framework-amd-kargs-cleanup_test.bats
+++ b/tests/unit/12-framework-amd-kargs-cleanup_test.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# Unit tests for system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh
+# Run with: bats tests/unit/12-framework-amd-kargs-cleanup_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+HOOK_SCRIPT="${SCRIPT_DIR}/../../system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/12-framework-amd-kargs-cleanup.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    mkdir -p "${STUB_BIN}"
+    export PATH="${STUB_BIN}:${PATH}"
+
+    # Default rpm-ostree stub: kargs returns no blacklist entry, deletes log calls
+    cat > "${STUB_BIN}/rpm-ostree" <<'EOF'
+#!/usr/bin/bash
+echo "rpm-ostree $*" >> "${STUB_BIN}/rpm-ostree.log"
+if [[ "$1" == "kargs" && "$#" -eq 1 ]]; then
+    echo "quiet rhgb"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm-ostree"
+
+    PATCHED_SCRIPT="${TEST_ROOT}/12-framework-amd-kargs-cleanup-patched.sh"
+    sed \
+        -e "s|source /usr/lib/ublue/setup-services/libsetup.sh|version-script() { return 0; }|g" \
+        -e "s|/sys/devices/virtual/dmi/id/chassis_vendor|${TEST_ROOT}/chassis_vendor|g" \
+        -e "s|/sys/devices/virtual/dmi/id/product_name|${TEST_ROOT}/product_name|g" \
+        "${HOOK_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+    export PATCHED_SCRIPT TEST_ROOT STUB_BIN
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+@test "12-framework-amd-kargs-cleanup: non-Framework systems are skipped" {
+    echo "ACME Corp" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (AMD Ryzen 7040 Series)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "${STUB_BIN}/rpm-ostree.log" ]
+}
+
+@test "12-framework-amd-kargs-cleanup: Intel Framework systems are skipped" {
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (Intel Core Ultra Series 1)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "${STUB_BIN}/rpm-ostree.log" ]
+}
+
+@test "12-framework-amd-kargs-cleanup: unknown Framework product is skipped" {
+    # Positive AMD match: a future Framework SKU with no AMD in the name must not
+    # have its boot config mutated.
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 15 (RISC-V Edition)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "${STUB_BIN}/rpm-ostree.log" ]
+}
+
+@test "12-framework-amd-kargs-cleanup: AMD Framework without stale karg exits cleanly" {
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (AMD Ryzen 7040 Series)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"nothing to do"* ]]
+    ! grep -q -- "--delete" "${STUB_BIN}/rpm-ostree.log" 2>/dev/null
+}
+
+@test "12-framework-amd-kargs-cleanup: AMD Framework with stale karg deletes it" {
+    # Stub: kargs output includes the stale blacklist entry
+    cat > "${STUB_BIN}/rpm-ostree" <<'EOF'
+#!/usr/bin/bash
+echo "rpm-ostree $*" >> "${STUB_BIN}/rpm-ostree.log"
+if [[ "$1" == "kargs" && "$#" -eq 1 ]]; then
+    echo "quiet rhgb module_blacklist=hid_sensor_hub"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm-ostree"
+
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 16 (AMD Ryzen 7040 Series)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    grep -q "kargs --delete=module_blacklist=hid_sensor_hub" "${STUB_BIN}/rpm-ostree.log"
+    [[ "$output" == *"Removed stale AMD Framework karg"* ]]
+}
+
+@test "12-framework-amd-kargs-cleanup: AMD Ryzen AI product name is matched" {
+    cat > "${STUB_BIN}/rpm-ostree" <<'EOF'
+#!/usr/bin/bash
+echo "rpm-ostree $*" >> "${STUB_BIN}/rpm-ostree.log"
+if [[ "$1" == "kargs" && "$#" -eq 1 ]]; then
+    echo "quiet rhgb module_blacklist=hid_sensor_hub"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm-ostree"
+
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (AMD Ryzen AI 300 Series)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    grep -q "kargs --delete=module_blacklist=hid_sensor_hub" "${STUB_BIN}/rpm-ostree.log"
+}
+
+@test "12-framework-amd-kargs-cleanup: missing rpm-ostree exits with warning" {
+    rm -f "${STUB_BIN}/rpm-ostree"
+    export PATH="${STUB_BIN}:/usr/bin:/bin"
+
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (AMD Ryzen 7040 Series)" > "${TEST_ROOT}/product_name"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning: rpm-ostree not found"* ]]
+}
+
+@test "12-framework-amd-kargs-cleanup: missing DMI info exits cleanly" {
+    # Neither chassis_vendor nor product_name file exists
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DMI information not available"* ]]
+}
+

--- a/tests/unit/12-framework-amd-kargs-cleanup_test.bats
+++ b/tests/unit/12-framework-amd-kargs-cleanup_test.bats
@@ -145,4 +145,3 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"DMI information not available"* ]]
 }
-


### PR DESCRIPTION
Follow-up to #1019 which added `fw-charge-control.conf` — the primary battery charge control fix for AMD Framework laptops.

## Problem

Users who upgraded before #1019 may still have `module_blacklist=hid_sensor_hub` set as a karg. This karg was originally intended for Intel Framework hardware but was incorrectly applied to AMD systems in older image versions. It is no longer in the codebase but persists in the bootloader config of previously-upgraded systems and can interfere with battery health controls.

## Solution

A new one-time privileged setup hook that removes the stale karg from affected machines.

### `system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh`

- Runs once per image version via `version-script framework-amd-kargs-cleanup privileged 1`
- Detects Framework hardware via `chassis_vendor == "Framework"`
- Uses **positive AMD detection** — `product_name =~ AMD` — to avoid touching unknown future Framework SKUs
- Checks whether the karg exists before attempting to delete it (idempotent)
- Removes `module_blacklist=hid_sensor_hub` with `rpm-ostree kargs --delete`

AMD Framework product names all contain "AMD" (e.g. "Laptop 13 (AMD Ryzen 7040 Series)", "Laptop 16 (AMD Ryzen 7040 Series)", "Laptop 13 (AMD Ryzen AI 300 Series)"), making this a safe positive match.

### `tests/unit/12-framework-amd-kargs-cleanup_test.bats`

8 bats unit tests following the sandbox pattern from `11-framework-ucsi-workaround_test.bats`:
- Non-Framework hardware → skip
- Intel Framework → skip (positive AMD-only detection)
- Unknown product name → skip
- AMD Framework without the karg → no-op (no kargs command invoked)
- AMD Framework with stale karg → karg deleted
- AMD Ryzen AI product name → also detected and cleaned up
- Missing `rpm-ostree` → warning logged
- Missing DMI path → early exit

Closes #879

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
