### PR TITLE
docs(ci): document merge-queue GH006 race and stuck-promotion diagnosis

### DIFF
--- a/docs/skills/ci/references/failure-modes.md
+++ b/docs/skills/ci/references/failure-modes.md
@@ -187,3 +187,43 @@ recent `run-e2e` run for that digest. A mismatch, or a match against a
 regression guard) belongs in `projectbluefin/actions`, not here — this repo
 only supplies the input; it does not control the push step that is supposed
 to honor it.
+## `promote-testing-to-main` fails with `GH006` while another run is enqueuing
+
+`.github/workflows/promote-testing-to-main.yml` calls
+`projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@v1`,
+which force-pushes the rebuilt squash branch and then calls the
+`enqueuePullRequest` GraphQL mutation because `use_merge_queue: true`. If two
+triggers land close together (a `push` to `testing` and the daily `schedule`,
+or two pushes to `testing` moments apart), one run can finish enqueuing before
+the other's force-push lands, and the later run fails with:
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/auto/promote-testing-to-main.
+remote: - A pull request for this branch has been added to a merge queue. Branches that
+remote:   are queued for merging cannot be updated. To modify this branch, dequeue the
+remote:   associated pull request.
+```
+
+This is noise, not a lost promotion: the workflow's `concurrency` group
+serializes runs, and the earlier run already reached the intended state
+(branch pushed, PR enqueued). Confirm with the promotion PR's timeline before
+treating the failed run as a real blocker:
+
+```bash
+gh pr view <promotion-pr> --repo projectbluefin/bluefin --json number \
+  --jq '.number' | xargs -I{} gh api repos/projectbluefin/bluefin/issues/{}/timeline \
+  --jq '.[] | select(.event | test("force_pushed|merge_queue")) | [.event, .created_at]'
+```
+
+Interleaved `head_ref_force_pushed` / `added_to_merge_queue` events around the
+same minute confirm this benign race. The retry logic that would need to
+change (retry the enqueue instead of failing outright) lives in
+`reusable-promote-squash.yml` in `projectbluefin/actions`, not in this repo's
+thin caller — do not add push-retry logic here.
+
+The GitHub merge queue itself removes a queued PR once its required checks
+resolve, including the release-gate check that re-runs the E2E suite against
+the squashed result. A promotion PR that cycles `added_to_merge_queue` then
+`removed_from_merge_queue` roughly two hours later, day after day, means the
+release gate is genuinely failing on the squashed content — diagnose the
+underlying E2E failure (see above), not the promotion workflow, in that case.


### PR DESCRIPTION
## Context

Investigating #929 ("ci: stable promotion has not completed since July 20"). Re-ran the current triage against the latest Execute Release run and the `auto/promote-testing-to-main` promotion PR to confirm what still blocks stable and to check whether anything changed since the last two triage comments on the issue.

**Confirmed still blocking, no bluefin-side lever (owned upstream):**
- `bluefin` smoke-a: `Dash to Dock panel is visible` / Firefox AT-SPI checks still fail (GDBus UnknownMethod error, object does not exist at path /org/gnome/Shell/Extensions; Firefox address bar not found). This is the same testsuite-side regression flagged in the 2026-08-10 comment; still no tracking issue in projectbluefin/testsuite as of this run.
- `bluefin` + `bluefin-nvidia` common-b: `ujust toggle-updates` failed on the 2026-08-10 run with 'unable to pick selection: could not open a new TTY'. Traced this to projectbluefin/common#966 (merged 2026-08-09), which fixes exactly this by honoring an explicit ACTION argument. `testing`'s image-versions.yml already picked up the fixed digest via Renovate (ghcr.io/projectbluefin/common@sha256:6d35613..., PR #1105) - this repo has nothing further to change here.

**New finding, not previously documented:** the promote-testing-to-main to merge-queue path itself has a benign-but-confusing failure mode. A promotion run can fail with 'GH006: Protected branch update failed ... added to a merge queue' when its force-push races another run that already enqueued the PR (confirmed via the promotion PR's timeline - interleaved head_ref_force_pushed/added_to_merge_queue events within the same minute). Distinct from that, the promotion PR itself has been cycling added_to_merge_queue -> removed_from_merge_queue roughly every two hours, day after day, which means the release-gate check is genuinely failing on the squashed testing content - i.e. it's gated on the same E2E regressions above, not a promotion-workflow bug.

## Change

Documentation-only: adds a section to docs/skills/ci/references/failure-modes.md describing this GH006 race and how to tell it apart from a genuinely stuck promotion, per AGENTS.md's 'update the matching skill when a session surfaces a non-obvious pattern.' No workflow, build, or image behavior changes.

## Validation

- Documentation-only change; no just check / pre-commit / image build tooling available in this environment, consistent with 'do not run expensive image builds for documentation-only changes.'
- Manually reviewed rendered Markdown for formatting.

Related: #929, projectbluefin/common#966, projectbluefin/common#951.