### PR TITLE
ci: gate bluefin :stable promotion to a weekly Tuesday release window

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -29,7 +29,81 @@ jobs:
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(bluefin|actions)/\.github/workflows/
       run_e2e: false
-      # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked.
-      # use_merge_queue: true calls enqueuePullRequest GraphQL instead.
-      use_merge_queue: true
+      # main uses a merge queue ruleset (17070404): gh pr merge --auto is blocked,
+      # and enqueuePullRequest requires this bit set on the reusable workflow's own
+      # call. We gate the *actual* enqueue to the weekly release window below
+      # (release-window-enqueue), so this stays false here: the reusable workflow
+      # still refreshes the squash PR and re-runs gate checks on every trigger,
+      # it just never enqueues/merges on its own.
+      use_merge_queue: false
     secrets: inherit
+
+  # bluefin:stable's weekly release day is Tuesday (UTC), part of a
+  # factory-wide 3x/week promotion schedule (bluefin-lts=Thursday,
+  # dakota=Sunday; see projectbluefin/common issue "Weekly stable release
+  # cadence"). The `promote` job above still runs daily (and on every push to
+  # testing) to keep the promotion PR fresh and re-run release-gate checks
+  # (release/ready status, cosign verify) — this job only decides *when* the
+  # already-validated PR is allowed to enter the merge queue and actually
+  # release.
+  release-window-enqueue:
+    name: Enqueue promotion PR (Tuesday release window)
+    needs: [promote]
+    if: needs.promote.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check release window
+        id: window
+        run: |
+          set -euo pipefail
+          # workflow_dispatch is the documented hotfix escape hatch: it bypasses
+          # the Tuesday check so a maintainer can force a release any day.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "in_window=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::workflow_dispatch hotfix escape hatch — bypassing the Tuesday release window"
+          elif [ "$(date -u +%u)" = "2" ]; then
+            echo "in_window=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "in_window=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Not Tuesday (UTC) — promotion PR #${{ needs.promote.outputs.pr_number }} stays fresh and gated, but merge queue enqueue is deferred until the weekly release window."
+          fi
+
+      - name: Check do-not-merge label
+        if: steps.window.outputs.in_window == 'true'
+        id: check-dnm
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.promote.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          LABELS=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json labels \
+            --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          if echo "$LABELS" | grep -q "do-not-merge"; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR #${PR_NUMBER} has the do-not-merge label; merge queue enqueue skipped."
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enqueue promotion PR in merge queue
+        if: steps.window.outputs.in_window == 'true' && steps.check-dnm.outputs.blocked == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.promote.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          NODE_ID=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json id --jq '.id')
+          # shellcheck disable=SC2016  # $id is a GraphQL variable, not a shell variable
+          gh api graphql \
+            -f query='mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id}){mergeQueueEntry{id}}}' \
+            -f id="$NODE_ID" \
+            && echo "✅ PR #${PR_NUMBER} enqueued in merge queue" \
+            || echo "⚠️  Could not enqueue PR #${PR_NUMBER} (may already be queued, or approvals not yet met)"


### PR DESCRIPTION
## What does this change?

Gate `bluefin:stable` / `bluefin-nvidia:stable` promotion to a weekly
**Tuesday (UTC)** release window, per #1066.

## Why?

`promote-testing-to-main.yml` runs daily and on every push to `testing`, and
unconditionally enqueues the squash promotion PR into the merge queue via
`use_merge_queue: true`. In practice `:stable` promotes as soon as the queue
accepts it — there's no enforced weekly cadence.

## Approach

- `promote` job: keep calling `reusable-promote-squash.yml` on every trigger
  (daily heartbeat + push to `testing`) so the squash PR stays fresh and
  `release-gate` checks (release/ready status, cosign verify) keep re-running.
  Flip `use_merge_queue` to `false` so this job never enqueues/merges on its
  own — it only builds/validates the PR.
- New `release-window-enqueue` job: runs after `promote`, and only performs
  the actual `enqueuePullRequest` GraphQL call when it is Tuesday (UTC), using
  the already-validated PR's number from `promote`'s outputs. Re-checks the
  `do-not-merge` label immediately before enqueueing (same guard the reusable
  workflow already has).
- `workflow_dispatch` bypasses the day check as the documented hotfix escape
  hatch, matching the issue's proposed change.

`release-reminder.yml`'s `days_warn: 7` / `days_escalate: 14` already match a
7-day cadence, so no change was needed there.

## Note on duplicate PRs

While preparing this I found #1076 and #1102 already open against the same
issue with similar approaches. Opening this for comparison/completeness per
my task instructions — maintainers may prefer to close the redundant ones
once one lands. Happy to close this one if another is preferred.

Closes #1066
