### PR TITLE
fix(ci): preserve builds after Renovate merges

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,1 +1,2 @@
 pre-commit==4.6.2
+PyYAML==6.0.2

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Check testsuite workflow contract
         run: python3 scripts/check-testsuite-workflow-ref.py
 
+      - name: Check Renovate auto-merge authentication contract
+        run: python3 scripts/check-renovate-automerge-auth.py
+
       - name: Check for undeclared gitlinks
         shell: bash
         env:

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -15,3 +15,6 @@ jobs:
     uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@v1
     with:
       head_sha: ${{ github.event.workflow_run.head_sha }}
+    secrets:
+      app_id: ${{ secrets.MERGERAPTOR_APP_ID }}
+      private_key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}

--- a/docs/skills/dependency-automation/SKILL.md
+++ b/docs/skills/dependency-automation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dependency-automation
-version: "1.1"
-last_updated: 2026-08-07
+version: "1.2"
+last_updated: 2026-08-16
 id: dependency-automation
 one_line_purpose: Review Renovate configuration and automated dependency updates.
 entry_point: docs/skills/dependency-automation/SKILL.md
@@ -30,8 +30,10 @@ metadata:
    workflow. Do not add another supported Renovate config filename: Renovate
    stops at the first match and would silently shadow the canonical file.
 2. Validate configuration changes with the repository's configured validator.
-3. Preserve the configured authentication model; never add personal access
-   tokens or credentials.
+3. Preserve the configured authentication model: pass the MergeRaptor App
+   credentials to the reusable auto-merge workflow. A merge performed with
+   `GITHUB_TOKEN` suppresses the resulting `push` workflow, so testing images
+   would not build. Never add personal access tokens or user credentials.
 4. Confirm the pull request targets the development branch.
 5. Run the default gate.
 

--- a/scripts/check-renovate-automerge-auth.py
+++ b/scripts/check-renovate-automerge-auth.py
@@ -5,6 +5,10 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/renovate-automerge.yml")
+REUSABLE_WORKFLOW = (
+    "    uses: "
+    "projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@v1"
+)
 REQUIRED_BLOCK = """\
     secrets:
       app_id: ${{ secrets.MERGERAPTOR_APP_ID }}
@@ -12,9 +16,28 @@ REQUIRED_BLOCK = """\
 """
 
 
+def _automerge_job(workflow: str) -> str:
+    """Return the uncommented YAML text belonging to ``jobs.automerge``."""
+    lines = workflow.splitlines(keepends=True)
+    try:
+        start = lines.index("  automerge:\n")
+    except ValueError:
+        return ""
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.startswith("  ") and not line.startswith("    ") and line.strip():
+            end = index
+            break
+    return "".join(
+        line for line in lines[start:end] if not line.lstrip().startswith("#")
+    )
+
+
 def main() -> int:
-    workflow = WORKFLOW.read_text()
-    if REQUIRED_BLOCK not in workflow:
+    job = _automerge_job(WORKFLOW.read_text())
+    if REUSABLE_WORKFLOW not in job or REQUIRED_BLOCK not in job:
         print("Renovate auto-merge authentication contract failed:")
         print(
             "The automerge job must pass the adjacent app_id and private_key "

--- a/scripts/check-renovate-automerge-auth.py
+++ b/scripts/check-renovate-automerge-auth.py
@@ -5,23 +5,21 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/renovate-automerge.yml")
-REQUIRED_LINES = (
-    "    secrets:\n",
-    "      app_id: ${{ secrets.MERGERAPTOR_APP_ID }}\n",
-    "      private_key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}\n",
-)
+REQUIRED_BLOCK = """\
+    secrets:
+      app_id: ${{ secrets.MERGERAPTOR_APP_ID }}
+      private_key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+"""
 
 
 def main() -> int:
     workflow = WORKFLOW.read_text()
-    missing = [line.strip() for line in REQUIRED_LINES if line not in workflow]
-    if missing:
+    if REQUIRED_BLOCK not in workflow:
         print("Renovate auto-merge authentication contract failed:")
-        for line in missing:
-            print(f" - missing: {line}")
         print(
-            "Use the MergeRaptor App token so the resulting testing-branch push "
-            "can trigger image builds."
+            "The automerge job must pass the adjacent app_id and private_key "
+            "MergeRaptor secrets so the resulting testing-branch push can "
+            "trigger image builds."
         )
         return 1
 

--- a/scripts/check-renovate-automerge-auth.py
+++ b/scripts/check-renovate-automerge-auth.py
@@ -3,41 +3,36 @@
 
 from pathlib import Path
 
+import yaml
+
 
 WORKFLOW = Path(".github/workflows/renovate-automerge.yml")
+
 REUSABLE_WORKFLOW = (
-    "    uses: "
     "projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@v1"
 )
-REQUIRED_BLOCK = """\
-    secrets:
-      app_id: ${{ secrets.MERGERAPTOR_APP_ID }}
-      private_key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-"""
-
-
-def _automerge_job(workflow: str) -> str:
-    """Return the uncommented YAML text belonging to ``jobs.automerge``."""
-    lines = workflow.splitlines(keepends=True)
-    try:
-        start = lines.index("  automerge:\n")
-    except ValueError:
-        return ""
-
-    end = len(lines)
-    for index in range(start + 1, len(lines)):
-        line = lines[index]
-        if line.startswith("  ") and not line.startswith("    ") and line.strip():
-            end = index
-            break
-    return "".join(
-        line for line in lines[start:end] if not line.lstrip().startswith("#")
-    )
+REQUIRED_SECRETS = {
+    "app_id": "${{ secrets.MERGERAPTOR_APP_ID }}",
+    "private_key": "${{ secrets.MERGERAPTOR_PRIVATE_KEY }}",
+}
 
 
 def main() -> int:
-    job = _automerge_job(WORKFLOW.read_text())
-    if REUSABLE_WORKFLOW not in job or REQUIRED_BLOCK not in job:
+    try:
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        workflow = None
+
+    job = (
+        workflow.get("jobs", {}).get("automerge", {})
+        if isinstance(workflow, dict)
+        else {}
+    )
+    if (
+        not isinstance(job, dict)
+        or job.get("uses") != REUSABLE_WORKFLOW
+        or job.get("secrets") != REQUIRED_SECRETS
+    ):
         print("Renovate auto-merge authentication contract failed:")
         print(
             "The automerge job must pass the adjacent app_id and private_key "

--- a/scripts/check-renovate-automerge-auth.py
+++ b/scripts/check-renovate-automerge-auth.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Require Renovate merges to use MergeRaptor instead of GITHUB_TOKEN."""
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/renovate-automerge.yml")
+REQUIRED_LINES = (
+    "    secrets:\n",
+    "      app_id: ${{ secrets.MERGERAPTOR_APP_ID }}\n",
+    "      private_key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}\n",
+)
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text()
+    missing = [line.strip() for line in REQUIRED_LINES if line not in workflow]
+    if missing:
+        print("Renovate auto-merge authentication contract failed:")
+        for line in missing:
+            print(f" - missing: {line}")
+        print(
+            "Use the MergeRaptor App token so the resulting testing-branch push "
+            "can trigger image builds."
+        )
+        return 1
+
+    print("Renovate auto-merge authentication contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_renovate_automerge_auth.py
+++ b/tests/test_renovate_automerge_auth.py
@@ -1,0 +1,36 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts" / "check-renovate-automerge-auth.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location("renovate_auth", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RenovateAutomergeAuthTests(unittest.TestCase):
+    def test_accepts_semantically_correct_flow_style_secrets(self) -> None:
+        checker = load_checker()
+        workflow = """\
+name: Renovate Auto-merge
+jobs:
+  automerge:
+    uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@v1
+    secrets: {app_id: "${{ secrets.MERGERAPTOR_APP_ID }}", private_key: "${{ secrets.MERGERAPTOR_PRIVATE_KEY }}"}
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            checker.WORKFLOW = Path(directory) / "renovate-automerge.yml"
+            checker.WORKFLOW.write_text(workflow, encoding="utf-8")
+            self.assertEqual(checker.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Pass the existing MergeRaptor GitHub App credentials to the reusable Renovate auto-merge workflow, and lock that authentication contract in PR validation.

## Why

The reusable workflow falls back to `github.token` when callers do not pass App credentials. GitHub suppresses downstream workflow events created by `GITHUB_TOKEN`, so a Renovate merge can advance `testing` without starting the push-triggered Testing Images workflow.

This occurred on PR #1110: merge commit `345ce401baba4c1ae6511cdb11bb82f1caf20669` has zero workflow runs. Comparable human merges #1080 and #1081 started Testing Images immediately.

The shared Actions workflow already supports App credentials, and this repository already uses the same MergeRaptor secrets in `track-common.yml` and `lab-check.yml`.

Refs projectbluefin/actions#403.

## Validation

- Regression contract observed failing before the caller fix and passing afterward
- `yq` parsed both modified workflows
- `just check`
- Documentation validation
- Python byte compilation
- `git diff --check`

## Post-merge verification

After this PR merges, observe the next qualified Renovate merge and confirm its resulting `testing` commit starts Testing Images. Renovate runs autonomously, so this is operational verification after merge, not a PR readiness gate.
