### PR TITLE
fix(lab-check): serialise lifecycle events that share a head SHA

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -7,6 +7,22 @@ on:
 permissions:
   contents: read
 
+# The lab sends several lifecycle events (queued -> in_progress -> completed)
+# for one head SHA, and the job below is a read-then-write: it looks up the
+# existing check run, then POSTs a new one or PATCHes that one. Two runs for the
+# same SHA overlapping means both look up before either writes, both find
+# nothing, and both POST -- leaving duplicate `testing-lab / <product>` checks,
+# all but one stranded in a non-terminal state. Serialise per SHA so the lookup
+# cannot race its own write; distinct SHAs still report in parallel, which the
+# lab's five-minute poller across every open PR depends on (bluefin#939).
+#
+# cancel-in-progress stays false on purpose. Cancelling an in-flight run can
+# kill the one applying the terminal `completed` event and strand the check as
+# in_progress -- the same always-unresolved check this serialisation prevents.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.client_payload.sha }}
+  cancel-in-progress: false
+
 jobs:
   report:
     name: Update MergeRaptor check

--- a/tests/test_lab_check.py
+++ b/tests/test_lab_check.py
@@ -193,3 +193,40 @@ class LabCheckReportTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class LabCheckConcurrencyTests(unittest.TestCase):
+    """The workflow must serialise lifecycle events that share a head SHA.
+
+    Reporting is a read-then-write -- look up the existing check run, then POST
+    or PATCH -- so two runs for one SHA that overlap both find nothing and both
+    POST, duplicating `testing-lab / <product>` and stranding all but one in a
+    non-terminal state (bluefin#939).
+    """
+
+    def concurrency_block(self) -> str:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        # A leading newline with no indent pins this to the workflow level; a
+        # job-level `concurrency:` would not serialise across runs.
+        marker = "\nconcurrency:\n"
+        self.assertIn(marker, workflow, "lab-check.yml declares no concurrency group")
+        self.assertLess(
+            workflow.index(marker),
+            workflow.index("\njobs:"),
+            "concurrency must be declared before jobs, at the workflow level",
+        )
+        return workflow.split(marker, 1)[1].split("\njobs:", 1)[0]
+
+    def test_group_is_keyed_on_the_dispatched_head_sha(self) -> None:
+        block = self.concurrency_block()
+        group = [line for line in block.splitlines() if line.strip().startswith("group:")]
+        self.assertEqual(len(group), 1, block)
+        # Keying on the payload SHA is what makes this safe: it serialises the
+        # events for one commit while leaving different PRs to report in
+        # parallel, which the lab's five-minute poller relies on.
+        self.assertIn("github.event.client_payload.sha", group[0])
+
+    def test_in_flight_runs_are_not_cancelled(self) -> None:
+        # Cancelling can kill the run applying the terminal `completed` event
+        # and leave the check stuck in_progress for good.
+        self.assertIn("cancel-in-progress: false", self.concurrency_block())


### PR DESCRIPTION
## What

Adds a workflow-level `concurrency` group to `.github/workflows/lab-check.yml`, keyed on the dispatched head SHA, plus two tests.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.client_payload.sha }}
  cancel-in-progress: false
```

## Why

**This does not fix #939** — the `checks: write` grant is still org-owner UI work, and I have not touched the gate, added a fallback, or proposed a PAT. This is the same kind of find as #1100: a defect in what happens *after* the grant lands, which is invisible today because every dispatch dies at the token mint.

Reporting is a read-then-write — look up the existing `testing-lab / <product>` check run, then POST a new one or PATCH the one it found — and nothing serialises it. Per `docs/skills/ci/SKILL.md`, the lab sends **several lifecycle events per head SHA** from a five-minute PR poller, and must update **one** check run for the exact PR head SHA:

> Every open Bluefin PR is discovered by the lab's five-minute PR poller. […] sends bounded `repository_dispatch` lifecycle events to `.github/workflows/lab-check.yml`. That workflow […] uses a short-lived MergeRaptor installation token to update one `testing-lab / bluefin` Check Run for the exact PR head SHA.

Two events for one SHA that overlap both run the lookup before either writes, both find nothing, and both POST. That leaves duplicate check runs on one commit, all but the last stranded in whatever non-terminal state they were created with — no later PATCH ever targets them.

That is the same end state #1100 fixed for a different cause. There the lookup missed an existing check because an unfiltered listing paged past it; here it misses one because it hasn't been created yet. Both turn every update into a duplicate, and a permanently unresolved check is precisely the failure mode @castrojo called out on this issue — a check people learn to scroll past, still wrong on the day it matters.

Dispatch bursts are not hypothetical. Nine Lab check runs fired in 71 seconds today, several 3 seconds apart:

```console
$ gh run list --repo projectbluefin/bluefin --workflow "Lab check" --limit 10 \
    --json conclusion,createdAt --jq '.[] | "\(.conclusion) \(.createdAt)"'
failure 2026-08-24T16:47:12Z
failure 2026-08-24T16:47:02Z
failure 2026-08-24T16:46:55Z
failure 2026-08-24T16:46:22Z
failure 2026-08-24T16:46:19Z
...
```

(`repository_dispatch` runs report the default-branch SHA in `head_sha`, so a run listing can't show which payload SHA each carried — the same-SHA overlap is established by the documented per-SHA lifecycle sequence, not by these timestamps. The timestamps establish that runs do overlap.)

## Design notes

**Keyed on the payload SHA, not the workflow alone.** The poller sweeps every open PR, so a workflow-wide group would queue unrelated PRs behind each other. Per-SHA serialises the events that actually race while leaving distinct SHAs parallel.

**`cancel-in-progress: false` is deliberate.** Cancelling can kill the run applying the terminal `completed` event and leave the check `in_progress` for good — the same stranded check this change prevents.

**One accepted trade-off:** GitHub keeps only one *pending* run per concurrency group, so if three events land at once an intermediate `in_progress` render can be dropped. The terminal event is the newest and always survives, so the check still settles on the correct final state. Dropping a transient render is strictly better than three duplicates, two of which never resolve.

## Testing

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 11 tests, all pass.
- Both new assertions **fail without the concurrency block** (verified by stashing the workflow change: `AssertionError: lab-check.yml declares no concurrency group`), so they are not vacuous.
- `actionlint` (via `rhysd/actionlint`) on the workflow — clean, exit 0.
- `just check` — clean.
- YAML parses; `concurrency` resolves to `{'group': '${{ github.workflow }}-${{ github.event.client_payload.sha }}', 'cancel-in-progress': False}` at the workflow level.

The new tests assert the workflow YAML rather than the script, because serialisation is a workflow-level property the step's shell cannot express. They use text parsing, consistent with `tests/test_pr_validation.py`, so no new test dependency is introduced.

## Still needed from an org owner (unchanged)

1. Org settings → Developer settings → GitHub Apps → **MergeRaptor** → Permissions & events → Repository permissions → **Checks: Read and write** → Save
2. Org settings → GitHub Apps → **MergeRaptor** → approve the resulting request

I re-checked today and still can't read either level myself — `gh api /apps/mergeraptor` returns `404` without `admin:org`, so I'm relying on @castrojo's readings for the App-vs-installation detail.

Refs #939

— hive: backend=claude model=claude-opus-5
