### PR TITLE
test(brew): assert the brew-preinstall payload, not just its trampoline

### DIFF
--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -35,6 +35,13 @@ test -f /usr/share/ublue-os/homebrew/fonts.Brewfile
 test -f /usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile
 test -f /usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile
 test -x /usr/bin/brew-preinstall
+# ExecStart names /usr/bin/brew-preinstall, but that is a two-line trampoline
+# (`exec /usr/libexec/brew-preinstall`). Asserting only the trampoline still
+# passes when the payload it exec's is renamed or dropped upstream -- the unit
+# then fails at first login with status 127 and bluefinctl silently never
+# installs, which is exactly the symptom reported in #965. Assert the file that
+# actually does the work, not just the one systemd calls.
+test -x /usr/libexec/brew-preinstall
 test -f /usr/lib/systemd/user/brew-preinstall.service
 grep -q '^enable brew-preinstall\.service$' /usr/lib/systemd/user-preset/01-brew-preinstall.preset
 

--- a/tests/unit/20-tests_test.bats
+++ b/tests/unit/20-tests_test.bats
@@ -11,6 +11,7 @@ setup() {
     mkdir -p "${STUB_BIN}"
     mkdir -p "${TEST_ROOT}/etc/containers" \
         "${TEST_ROOT}/usr/bin" \
+        "${TEST_ROOT}/usr/libexec" \
         "${TEST_ROOT}/usr/share/ublue-os/just" \
         "${TEST_ROOT}/usr/share/ublue-os/homebrew" \
         "${TEST_ROOT}/usr/share/flatpak/preinstall.d" \
@@ -36,8 +37,10 @@ setup() {
     touch "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile" \
         "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile" \
         "${TEST_ROOT}/usr/lib/systemd/user/brew-preinstall.service"
-    touch "${TEST_ROOT}/usr/bin/brew-preinstall"
-    chmod +x "${TEST_ROOT}/usr/bin/brew-preinstall"
+    touch "${TEST_ROOT}/usr/bin/brew-preinstall" \
+        "${TEST_ROOT}/usr/libexec/brew-preinstall"
+    chmod +x "${TEST_ROOT}/usr/bin/brew-preinstall" \
+        "${TEST_ROOT}/usr/libexec/brew-preinstall"
     echo 'enable brew-preinstall.service' \
         > "${TEST_ROOT}/usr/lib/systemd/user-preset/01-brew-preinstall.preset"
     cat > "${TEST_ROOT}/etc/containers/policy.json" <<'EOF'
@@ -170,6 +173,17 @@ EOF
 
 @test "20-tests: rejects an image missing the brew-preinstall ExecStart binary" {
     rm -f "${TEST_ROOT}/usr/bin/brew-preinstall"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+}
+
+@test "20-tests: rejects an image whose brew-preinstall trampoline has no payload" {
+    # /usr/bin/brew-preinstall is `exec /usr/libexec/brew-preinstall`. Dropping
+    # the payload leaves the trampoline, the unit and the preset all intact, so
+    # every other assertion here still passes -- the build ships and the service
+    # dies with 127 at first login. That silent shape is the one #965 reported.
+    rm -f "${TEST_ROOT}/usr/libexec/brew-preinstall"
 
     run bash "${PATCHED_SCRIPT}"
     [ "$status" -ne 0 ]


### PR DESCRIPTION
## What

`build_files/base/20-tests.sh` now asserts `/usr/libexec/brew-preinstall`, the file that actually performs the brew preinstall, in addition to `/usr/bin/brew-preinstall`, the trampoline `ExecStart` names. Adds a bats case covering the gap.

## Why

This is #965 item 2 — *"`bluefinctl` is not installed"*. Earlier triage concluded, correctly, that this is not a bluefin defect: the tool arrives from `common` via `preinstall.d/bluefinctl.Brewfile` + `brew-preinstall.service`, and #1081 added build-time assertions so a Renovate-bumped `common` digest could not silently break the path. Its comment states the goal:

> `# ... so a rename or drop upstream would silently stop shipping bluefinctl with no other signal. Assert the pieces the service actually needs: the Brewfiles it reads, the binary its ExecStart points at, the unit, and the preset that enables it.`

The ExecStart assertion is literally correct but stops one hop short. The unit has `ExecStart=/usr/bin/brew-preinstall`, and in `common` that file is a two-line trampoline:

```bash
#!/usr/bin/env bash
exec /usr/libexec/brew-preinstall "$@"
```

The implementation lives at `/usr/libexec/brew-preinstall`. Drop or rename it upstream and the trampoline, the unit, the preset and both Brewfiles all survive — **every existing assertion passes and the image ships**. The service then dies at first login with status 127, and `bluefinctl` silently never installs. That is precisely the reported symptom, and precisely the silent shape #1081 exists to prevent.

Both files exist in `common` today, so this is a latent gap, not a live break. It closes the hole rather than fixing an outage.

## Scope

Deliberately narrow. I re-verified the rest of #965 before touching anything:

- **Item 1 (`fzf` → `ujust --choose`)** — fixed and guarded. `fzf` is in `base.toml:50` and `IMPORTANT_PACKAGES` (`20-tests.sh:64`), with the #1090 regression test on `testing`.
- **Item 3 (`ujust dx-group`)** — still not in this repo. Zero `.just` files; `dx-group`, `/usr/lib/group` and `incus-admin` appear nowhere outside `.git`. Dakota-side.

I also checked the delivery path *resolves*, not just that it ships, since "wired but broken" was the shape of the last bug I found here: the `projectbluefin/bluefinctl` and `frostyard/tap` taps both exist, the tap provides `bluefinctl.rb` at its root (a valid tap layout), and all eleven `system-cli.Brewfile` formulae return 200 from the Homebrew API. Nothing broken there.

## Testing — and a caveat worth reading

**The new case is only meaningful where the suite's stubs actually run.**

Under `docker.io/bats/bats`, the stubs' `#!/usr/bin/bash` shebang does not resolve on Alpine, so `20-tests.sh` dies at its very first command with status 126. Every `"rejects ..."` test in this file then passes **vacuously** — including mine, and including the ones already on `testing`. I nearly shipped on that false green; the mutation test is what caught it.

Validated instead on `ubuntu:24.04` with `apt-get install bats jq`, matching the `unit-tests` job:

| | Result |
|---|---|
| Full file, with fix | 10/10 pass |
| Full file, **assertion removed** | `not ok 8 ... trampoline has no payload`; all others stay green |

So the new test fails for its own reason and nothing else moves. Also: `shellcheck` on `20-tests.sh` clean (exit 0), `just check` clean.

CI is unaffected by the Alpine issue — `pr-validation.yml` installs `bats` via apt on `ubuntu-24.04`, where the stubs work. I have not changed the stub shebangs; that would be unrelated scope. Flagging it because anyone reaching for the official bats image to check this file locally will get a green run that proves nothing.

Refs #965

— hive: backend=claude model=claude-opus-5
