### PR TITLE
feat: provision pinned gVisor runsc

### DIFF
--- a/docs/skills/security/SKILL.md
+++ b/docs/skills/security/SKILL.md
@@ -58,13 +58,15 @@ adjacent `gvisor-bin/` payload required by `runsc`.
 The install is exposed as `/usr/local/bin/runsc` for Podman's documented
 runtime name lookup, while versioned payloads live under the exact
 Bluefin-owned `/usr/local/libexec/bluefin-runsc/` directory. The recipe does
-not alter Podman's default runtime or configuration. Updates stage a complete
-payload before atomically switching the link; a failed update leaves the
-active link in place. A failure during staging cleans the temporary payload, and
-an interrupted publication can be recovered with the same idempotent install or
-the removal command. Repeating install/update is idempotent for the pinned
-release. `ujust runsc remove` removes only that owned directory and a link that
-resolves inside it, and refuses foreign paths.
+not alter Podman's default runtime or configuration. The helper writes its
+ownership marker only after a complete release is staged and refuses to adopt
+an unmarked or symlinked root or release path. Updates stage a complete payload
+before atomically switching the link; a failed update leaves the active link in
+place and cleans the newly staged release. An interrupted publication can be
+recovered with the same idempotent install or the removal command. Repeating
+install/update is idempotent for the pinned release. `ujust runsc remove`
+removes only that marked owned directory and a link that resolves inside it, and
+refuses foreign paths.
 
 The gVisor GitHub release currently publishes HTTPS assets and SHA-256/SHA-512
 checksum files but no detached signature for these archives; see the [official

--- a/docs/skills/security/SKILL.md
+++ b/docs/skills/security/SKILL.md
@@ -46,6 +46,34 @@ pre-commit run --all-files
 For container signatures, use the repository's existing verification recipe;
 do not invent a replacement key or trust path.
 
+## Bluefin host runsc provisioning
+
+The Bluefin-owned `ujust runsc install` and `ujust runsc update` recipes
+provision the pinned [gVisor `release-20260817.0` archive](https://github.com/google/gvisor/releases/tag/release-20260817.0) for the host's
+`x86_64` or `aarch64` architecture. They reject other architectures before
+network access, use the exact GitHub release asset and SHA-256 recorded in the
+recipe helper, verify the archive before reading it with `tar`, and retain the
+adjacent `gvisor-bin/` payload required by `runsc`.
+
+The install is exposed as `/usr/local/bin/runsc` for Podman's documented
+runtime name lookup, while versioned payloads live under the exact
+Bluefin-owned `/usr/local/libexec/bluefin-runsc/` directory. The recipe does
+not alter Podman's default runtime or configuration. Updates stage a complete
+payload before atomically switching the link; a failed update leaves the
+active link in place. A failure during staging cleans the temporary payload, and
+an interrupted publication can be recovered with the same idempotent install or
+the removal command. Repeating install/update is idempotent for the pinned
+release. `ujust runsc remove` removes only that owned directory and a link that
+resolves inside it, and refuses foreign paths.
+
+The gVisor GitHub release currently publishes HTTPS assets and SHA-256/SHA-512
+checksum files but no detached signature for these archives; see the [official
+installation guide](https://gvisor.dev/docs/user_guide/install/) for the
+multi-file payload requirement. This path therefore provides
+checksum-plus-HTTPS/GitHub asset-digest verification, not a detached-signature
+claim. Native rootless Podman execution, networking, cgroup
+behavior, and separate arm64 acceptance remain deployment-time gates.
+
 ## References
 
 - [COPR isolation invariant](references/copr-isolation.md)

--- a/system_files/shared/usr/libexec/bluefin-runsc
+++ b/system_files/shared/usr/libexec/bluefin-runsc
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RUNSC_VERSION="release-20260817.0"
+RUNSC_ROOT="/usr/local/libexec/bluefin-runsc"
+RUNSC_LINK="/usr/local/bin/runsc"
+RUNSC_WORK_DIR=""
+RUNSC_STAGE=""
+RUNSC_LINK_DIR=""
+RUNSC_INSTALL_STAGE=""
+
+die() {
+    echo "bluefin-runsc: $*" >&2
+    return 1
+}
+
+usage() {
+    echo "Usage: bluefin-runsc {install|update|remove}" >&2
+    return 2
+}
+
+cleanup() {
+    if [[ -n "${RUNSC_LINK_DIR}" && -d "${RUNSC_LINK_DIR}" ]]; then
+        rm -rf -- "${RUNSC_LINK_DIR}"
+    fi
+    if [[ -n "${RUNSC_STAGE}" && -d "${RUNSC_STAGE}" ]]; then
+        rm -rf -- "${RUNSC_STAGE}"
+    fi
+    if [[ -n "${RUNSC_INSTALL_STAGE}" && -d "${RUNSC_INSTALL_STAGE}" ]]; then
+        rm -rf -- "${RUNSC_INSTALL_STAGE}"
+    fi
+    if [[ -n "${RUNSC_WORK_DIR}" && -d "${RUNSC_WORK_DIR}" ]]; then
+        rm -rf -- "${RUNSC_WORK_DIR}"
+    fi
+}
+
+active_release() {
+    local link_target release_name release_dir expected_prefix
+
+    [[ -L "${RUNSC_LINK}" ]] || return 1
+    link_target="$(readlink -f -- "${RUNSC_LINK}")" || return 1
+    expected_prefix="${RUNSC_VERSION}-${EXPECTED_SHA256:0:12}-"
+    case "${link_target}" in
+        "${RUNSC_ROOT}"/releases/*/runsc) ;;
+        *) return 1 ;;
+    esac
+
+    release_dir="$(dirname "${link_target}")"
+    release_name="$(basename "${release_dir}")"
+    [[ "${release_name}" == "${expected_prefix}"* ]] || return 1
+    [[ -x "${link_target}" && -d "${release_dir}/gvisor-bin" ]]
+}
+
+remove_installation() {
+    local link_target
+
+    if [[ -e "${RUNSC_LINK}" || -L "${RUNSC_LINK}" ]]; then
+        [[ -L "${RUNSC_LINK}" ]] || die "refusing to remove non-symlink ${RUNSC_LINK}"
+        link_target="$(readlink -f -- "${RUNSC_LINK}")" || die "cannot resolve ${RUNSC_LINK}"
+        case "${link_target}" in
+            "${RUNSC_ROOT}"/releases/*/runsc) ;;
+            *) die "refusing to remove foreign runsc link ${RUNSC_LINK}" ;;
+        esac
+    fi
+
+    if [[ -e "${RUNSC_ROOT}" || -L "${RUNSC_ROOT}" ]]; then
+        [[ -d "${RUNSC_ROOT}" && ! -L "${RUNSC_ROOT}" ]] || die "refusing to remove non-directory ${RUNSC_ROOT}"
+        rm -rf -- "${RUNSC_ROOT}"
+    fi
+
+    if [[ -L "${RUNSC_LINK}" ]]; then
+        rm -f -- "${RUNSC_LINK}"
+    fi
+
+    echo "Bluefin runsc installation removed."
+}
+
+provision() {
+    local machine_arch asset_arch expected_sha256 archive_url
+    local archive members member release_dir release_name
+    local link_target expected_prefix
+
+    machine_arch="$(uname -m)"
+    case "${machine_arch}" in
+        x86_64)
+            asset_arch="x86_64"
+            expected_sha256="ae345a8c1466586b3a163fb534301913da663a97b8ed446bc711b2e1963a32c5"
+            ;;
+        aarch64|arm64)
+            asset_arch="aarch64"
+            expected_sha256="a3c2443e9564dbf500893e66fd2463be3b79fe42f66825971c44dc1624d454b2"
+            ;;
+        *)
+            die "unsupported host architecture: ${machine_arch}"
+            ;;
+    esac
+    EXPECTED_SHA256="${expected_sha256}"
+    export EXPECTED_SHA256
+
+    if active_release; then
+        echo "Bluefin runsc ${RUNSC_VERSION} is already installed."
+        return 0
+    fi
+
+    archive_url="https://github.com/google/gvisor/releases/download/${RUNSC_VERSION}/gvisor-${asset_arch}.tar.bz2"
+    RUNSC_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bluefin-runsc.XXXXXXXX")"
+    RUNSC_STAGE=""
+    RUNSC_LINK_DIR=""
+    RUNSC_INSTALL_STAGE=""
+    trap cleanup EXIT
+
+    archive="${RUNSC_WORK_DIR}/gvisor.tar.bz2"
+    curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+        --retry 3 --max-time 300 --output "${archive}" "${archive_url}"
+    printf '%s  %s\n' "${EXPECTED_SHA256}" "${archive}" | sha256sum --check --status -
+
+    members="$(tar -tjf "${archive}")"
+    grep -Eq '^runsc$' <<< "${members}" || die "verified archive has no runsc payload"
+    grep -Eq '^gvisor-bin/?$' <<< "${members}" || die "verified archive has no gvisor-bin payload"
+    while IFS= read -r member; do
+        case "${member}" in
+            runsc|gvisor-bin|gvisor-bin/*|containerd-shim-runsc-v1) ;;
+            *) die "verified archive contains unexpected member: ${member}" ;;
+        esac
+    done <<< "${members}"
+
+    RUNSC_STAGE="${RUNSC_WORK_DIR}/payload"
+    mkdir -p "${RUNSC_STAGE}"
+    tar -xjf "${archive}" --no-same-owner --no-same-permissions \
+        --directory "${RUNSC_STAGE}" runsc gvisor-bin
+    [[ -f "${RUNSC_STAGE}/runsc" && -d "${RUNSC_STAGE}/gvisor-bin" ]] || die "archive extraction omitted the runsc payload"
+    chmod a+rx "${RUNSC_STAGE}/runsc"
+    chmod -R a+rX "${RUNSC_STAGE}/gvisor-bin"
+
+    install -d -m 0755 "${RUNSC_ROOT}/releases"
+    release_name="${RUNSC_VERSION}-${EXPECTED_SHA256:0:12}-$(basename "${RUNSC_WORK_DIR}")"
+    release_dir="${RUNSC_ROOT}/releases/${release_name}"
+    RUNSC_INSTALL_STAGE="$(mktemp -d "${RUNSC_ROOT}/.staging.XXXXXXXX")"
+    cp -a "${RUNSC_STAGE}/." "${RUNSC_INSTALL_STAGE}/"
+    chmod a+rx "${RUNSC_INSTALL_STAGE}/runsc"
+    chmod -R a+rX "${RUNSC_INSTALL_STAGE}/gvisor-bin"
+    mv -T -- "${RUNSC_INSTALL_STAGE}" "${release_dir}"
+
+    expected_prefix="${RUNSC_ROOT}/releases/"
+    link_target="${release_dir}/runsc"
+    [[ "${link_target}" == "${expected_prefix}"* ]] || die "computed release escaped the owned root"
+    install -d -m 0755 "$(dirname "${RUNSC_LINK}")"
+    if [[ -e "${RUNSC_LINK}" || -L "${RUNSC_LINK}" ]]; then
+        [[ -L "${RUNSC_LINK}" ]] || die "refusing to replace non-symlink ${RUNSC_LINK}"
+        case "$(readlink -f -- "${RUNSC_LINK}")" in
+            "${RUNSC_ROOT}"/releases/*/runsc) ;;
+            *) die "refusing to replace foreign runsc link ${RUNSC_LINK}" ;;
+        esac
+    fi
+    RUNSC_LINK_DIR="$(mktemp -d "$(dirname "${RUNSC_LINK}")/.bluefin-runsc.XXXXXXXX")"
+    ln -s -- "${link_target}" "${RUNSC_LINK_DIR}/runsc"
+    mv -Tf -- "${RUNSC_LINK_DIR}/runsc" "${RUNSC_LINK}"
+    echo "Installed Bluefin runsc ${RUNSC_VERSION} for ${machine_arch}."
+}
+
+main() {
+    local action="${1:-}"
+    case "${action}" in
+        install|update)
+            provision
+            ;;
+        remove)
+            remove_installation
+            ;;
+        *)
+            usage
+            ;;
+    esac
+}
+
+main "$@"

--- a/system_files/shared/usr/libexec/bluefin-runsc
+++ b/system_files/shared/usr/libexec/bluefin-runsc
@@ -5,10 +5,15 @@ set -euo pipefail
 RUNSC_VERSION="release-20260817.0"
 RUNSC_ROOT="/usr/local/libexec/bluefin-runsc"
 RUNSC_LINK="/usr/local/bin/runsc"
+RUNSC_MARKER="${RUNSC_ROOT}/.bluefin-owned"
+RUNSC_MARKER_CONTENT="bluefin-runsc ownership marker v1"
 RUNSC_WORK_DIR=""
 RUNSC_STAGE=""
 RUNSC_LINK_DIR=""
 RUNSC_INSTALL_STAGE=""
+RUNSC_RELEASE_DIR=""
+RUNSC_RELEASE_PUBLISHED=0
+RUNSC_ROOT_CREATED=0
 
 die() {
     echo "bluefin-runsc: $*" >&2
@@ -30,15 +35,67 @@ cleanup() {
     if [[ -n "${RUNSC_INSTALL_STAGE}" && -d "${RUNSC_INSTALL_STAGE}" ]]; then
         rm -rf -- "${RUNSC_INSTALL_STAGE}"
     fi
+    if [[ "${RUNSC_RELEASE_PUBLISHED}" -eq 0 && -n "${RUNSC_RELEASE_DIR}" \
+        && -d "${RUNSC_RELEASE_DIR}" && ! -L "${RUNSC_RELEASE_DIR}" ]]; then
+        rm -rf -- "${RUNSC_RELEASE_DIR}"
+    fi
+    if [[ "${RUNSC_ROOT_CREATED}" -eq 1 && ! -e "${RUNSC_MARKER}" \
+        && ! -L "${RUNSC_MARKER}" && -d "${RUNSC_ROOT}" && ! -L "${RUNSC_ROOT}" ]]; then
+        rm -rf -- "${RUNSC_ROOT}"
+    fi
     if [[ -n "${RUNSC_WORK_DIR}" && -d "${RUNSC_WORK_DIR}" ]]; then
         rm -rf -- "${RUNSC_WORK_DIR}"
     fi
 }
 
+ownership_marker_valid() {
+    [[ -f "${RUNSC_MARKER}" && ! -L "${RUNSC_MARKER}" ]] || return 1
+    printf '%s\n' "${RUNSC_MARKER_CONTENT}" | cmp -s - "${RUNSC_MARKER}"
+}
+
+ensure_owned_root() {
+    if [[ -L "${RUNSC_ROOT}" ]]; then
+        die "refusing symlinked runsc root ${RUNSC_ROOT}"
+    elif [[ -e "${RUNSC_ROOT}" ]]; then
+        [[ -d "${RUNSC_ROOT}" ]] || die "refusing non-directory runsc root ${RUNSC_ROOT}"
+        ownership_marker_valid || die "refusing unowned runsc root ${RUNSC_ROOT}"
+    else
+        install -d -m 0755 "${RUNSC_ROOT}"
+        RUNSC_ROOT_CREATED=1
+    fi
+
+    if [[ -L "${RUNSC_ROOT}/releases" ]]; then
+        die "refusing symlinked runsc release directory ${RUNSC_ROOT}/releases"
+    elif [[ -e "${RUNSC_ROOT}/releases" ]]; then
+        [[ -d "${RUNSC_ROOT}/releases" ]] || die "refusing non-directory runsc release path"
+    else
+        install -d -m 0755 "${RUNSC_ROOT}/releases"
+    fi
+}
+
+link_points_to_owned_release() {
+    local raw_target resolved release_dir
+
+    [[ -L "${RUNSC_LINK}" ]] || return 1
+    raw_target="$(readlink -- "${RUNSC_LINK}")" || return 1
+    case "${raw_target}" in
+        "${RUNSC_ROOT}"/releases/*/runsc) ;;
+        *) return 1 ;;
+    esac
+
+    release_dir="${raw_target%/runsc}"
+    [[ "$(dirname "${release_dir}")" == "${RUNSC_ROOT}/releases" ]] || return 1
+    if [[ -e "${release_dir}" || -L "${release_dir}" ]]; then
+        [[ -d "${release_dir}" && ! -L "${release_dir}" ]] || return 1
+    fi
+    resolved="$(readlink -f -- "${RUNSC_LINK}")" || return 1
+    [[ "${resolved}" == "${release_dir}/runsc" ]]
+}
+
 active_release() {
     local link_target release_name release_dir expected_prefix
 
-    [[ -L "${RUNSC_LINK}" ]] || return 1
+    link_points_to_owned_release || return 1
     link_target="$(readlink -f -- "${RUNSC_LINK}")" || return 1
     expected_prefix="${RUNSC_VERSION}-${EXPECTED_SHA256:0:12}-"
     case "${link_target}" in
@@ -53,21 +110,29 @@ active_release() {
 }
 
 remove_installation() {
-    local link_target
+    if [[ -L "${RUNSC_ROOT}" ]]; then
+        die "refusing symlinked runsc root ${RUNSC_ROOT}"
+    fi
+    if [[ ! -e "${RUNSC_ROOT}" ]]; then
+        [[ ! -e "${RUNSC_LINK}" && ! -L "${RUNSC_LINK}" ]] || \
+            die "refusing to remove an unowned runsc installation"
+        echo "Bluefin runsc installation removed."
+        return 0
+    fi
+    [[ -d "${RUNSC_ROOT}" ]] || die "refusing non-directory runsc root ${RUNSC_ROOT}"
+    ownership_marker_valid || die "refusing to remove unowned runsc root ${RUNSC_ROOT}"
+    [[ ! -L "${RUNSC_ROOT}/releases" ]] || \
+        die "refusing symlinked runsc release directory ${RUNSC_ROOT}/releases"
+    if [[ -e "${RUNSC_ROOT}/releases" ]]; then
+        [[ -d "${RUNSC_ROOT}/releases" ]] || die "refusing non-directory runsc release path"
+    fi
 
     if [[ -e "${RUNSC_LINK}" || -L "${RUNSC_LINK}" ]]; then
         [[ -L "${RUNSC_LINK}" ]] || die "refusing to remove non-symlink ${RUNSC_LINK}"
-        link_target="$(readlink -f -- "${RUNSC_LINK}")" || die "cannot resolve ${RUNSC_LINK}"
-        case "${link_target}" in
-            "${RUNSC_ROOT}"/releases/*/runsc) ;;
-            *) die "refusing to remove foreign runsc link ${RUNSC_LINK}" ;;
-        esac
+        link_points_to_owned_release || die "refusing foreign runsc link ${RUNSC_LINK}"
     fi
 
-    if [[ -e "${RUNSC_ROOT}" || -L "${RUNSC_ROOT}" ]]; then
-        [[ -d "${RUNSC_ROOT}" && ! -L "${RUNSC_ROOT}" ]] || die "refusing to remove non-directory ${RUNSC_ROOT}"
-        rm -rf -- "${RUNSC_ROOT}"
-    fi
+    rm -rf -- "${RUNSC_ROOT}"
 
     if [[ -L "${RUNSC_LINK}" ]]; then
         rm -f -- "${RUNSC_LINK}"
@@ -79,7 +144,7 @@ remove_installation() {
 provision() {
     local machine_arch asset_arch expected_sha256 archive_url
     local archive members member release_dir release_name
-    local link_target expected_prefix
+    local link_target
 
     machine_arch="$(uname -m)"
     case "${machine_arch}" in
@@ -98,6 +163,9 @@ provision() {
     EXPECTED_SHA256="${expected_sha256}"
     export EXPECTED_SHA256
 
+    trap cleanup EXIT
+    ensure_owned_root
+
     if active_release; then
         echo "Bluefin runsc ${RUNSC_VERSION} is already installed."
         return 0
@@ -108,7 +176,8 @@ provision() {
     RUNSC_STAGE=""
     RUNSC_LINK_DIR=""
     RUNSC_INSTALL_STAGE=""
-    trap cleanup EXIT
+    RUNSC_RELEASE_DIR=""
+    RUNSC_RELEASE_PUBLISHED=0
 
     archive="${RUNSC_WORK_DIR}/gvisor.tar.bz2"
     curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
@@ -133,29 +202,36 @@ provision() {
     chmod a+rx "${RUNSC_STAGE}/runsc"
     chmod -R a+rX "${RUNSC_STAGE}/gvisor-bin"
 
-    install -d -m 0755 "${RUNSC_ROOT}/releases"
     release_name="${RUNSC_VERSION}-${EXPECTED_SHA256:0:12}-$(basename "${RUNSC_WORK_DIR}")"
     release_dir="${RUNSC_ROOT}/releases/${release_name}"
+    if [[ -e "${release_dir}" || -L "${release_dir}" ]]; then
+        [[ ! -L "${release_dir}" ]] || die "refusing symlinked runsc release path ${release_dir}"
+        die "refusing existing runsc release path ${release_dir}"
+    fi
     RUNSC_INSTALL_STAGE="$(mktemp -d "${RUNSC_ROOT}/.staging.XXXXXXXX")"
     cp -a "${RUNSC_STAGE}/." "${RUNSC_INSTALL_STAGE}/"
     chmod a+rx "${RUNSC_INSTALL_STAGE}/runsc"
     chmod -R a+rX "${RUNSC_INSTALL_STAGE}/gvisor-bin"
     mv -T -- "${RUNSC_INSTALL_STAGE}" "${release_dir}"
+    RUNSC_RELEASE_DIR="${release_dir}"
 
-    expected_prefix="${RUNSC_ROOT}/releases/"
+    if ! ownership_marker_valid; then
+        printf '%s\n' "${RUNSC_MARKER_CONTENT}" > "${RUNSC_WORK_DIR}/ownership-marker"
+        mv -T -- "${RUNSC_WORK_DIR}/ownership-marker" "${RUNSC_MARKER}"
+    fi
+
     link_target="${release_dir}/runsc"
-    [[ "${link_target}" == "${expected_prefix}"* ]] || die "computed release escaped the owned root"
+    [[ "$(dirname "${link_target}")" == "${RUNSC_ROOT}/releases/${release_name}" ]] || \
+        die "computed release escaped the owned root"
     install -d -m 0755 "$(dirname "${RUNSC_LINK}")"
     if [[ -e "${RUNSC_LINK}" || -L "${RUNSC_LINK}" ]]; then
         [[ -L "${RUNSC_LINK}" ]] || die "refusing to replace non-symlink ${RUNSC_LINK}"
-        case "$(readlink -f -- "${RUNSC_LINK}")" in
-            "${RUNSC_ROOT}"/releases/*/runsc) ;;
-            *) die "refusing to replace foreign runsc link ${RUNSC_LINK}" ;;
-        esac
+        link_points_to_owned_release || die "refusing to replace foreign runsc link ${RUNSC_LINK}"
     fi
     RUNSC_LINK_DIR="$(mktemp -d "$(dirname "${RUNSC_LINK}")/.bluefin-runsc.XXXXXXXX")"
     ln -s -- "${link_target}" "${RUNSC_LINK_DIR}/runsc"
     mv -Tf -- "${RUNSC_LINK_DIR}/runsc" "${RUNSC_LINK}"
+    RUNSC_RELEASE_PUBLISHED=1
     echo "Installed Bluefin runsc ${RUNSC_VERSION} for ${machine_arch}."
 }
 

--- a/system_files/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/shared/usr/share/ublue-os/just/60-custom.just
@@ -1,0 +1,5 @@
+# Bluefin-specific user recipes. Imported optionally by common's 00-entry.just.
+
+[group('System')]
+runsc action="install":
+    sudo /usr/libexec/bluefin-runsc "{{ action }}"

--- a/tests/unit/runsc-provisioning_test.bats
+++ b/tests/unit/runsc-provisioning_test.bats
@@ -84,6 +84,7 @@ EOF
     [ "${#release_dirs[@]}" -eq 1 ]
     [ -x "${release_dirs[0]}/runsc" ]
     [ -x "${release_dirs[0]}/gvisor-bin/runsc-sandbox" ]
+    [ -f "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/.bluefin-owned" ]
     [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = \
         "${release_dirs[0]}/runsc" ]
     grep -Fq 'gvisor-x86_64.tar.bz2' "${CURL_LOG}"
@@ -186,6 +187,87 @@ EOF
     [ "${status}" -ne 0 ]
     [ -L "${TEST_ROOT}/usr/local/bin/runsc" ]
     [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/keep" ]
+}
+
+@test "runsc helper refuses an unowned root and preserves foreign children" {
+
+    [[ -x "${HELPER}" ]]
+
+    patch_helper
+    mkdir -p "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    printf 'foreign data\n' > "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/foreign"
+
+    run "${PATCHED_HELPER}" remove
+
+    [ "${status}" -ne 0 ]
+    [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/foreign" ]
+
+    run "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ ! -s "${CURL_LOG}" ]
+    [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/foreign" ]
+}
+
+@test "runsc helper refuses a symlinked root or release directory" {
+
+    [[ -x "${HELPER}" ]]
+
+    patch_helper
+    mkdir -p "${TEST_ROOT}/usr/local/libexec"
+    mkdir -p "${TEST_ROOT}/foreign"
+    ln -s "${TEST_ROOT}/foreign" "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+
+    run "${PATCHED_HELPER}" remove
+
+    [ "${status}" -ne 0 ]
+    [ -d "${TEST_ROOT}/foreign" ]
+
+    rm -f "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    mkdir -p "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    printf 'bluefin-runsc ownership marker v1\n' > \
+        "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/.bluefin-owned"
+    ln -s "${TEST_ROOT}/foreign" \
+        "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases"
+
+    run "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ -d "${TEST_ROOT}/foreign" ]
+}
+
+@test "runsc helper cleans a staged release after publication failure" {
+
+    [[ -x "${HELPER}" ]]
+
+    patch_helper
+    run "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+    active_link="$(readlink "${TEST_ROOT}/usr/local/bin/runsc")"
+    release_dirs=("${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases/"*)
+
+    cat > "${STUB_BIN}/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${!#}" == "${FAIL_MV_TARGET}" ]]; then
+    exit 23
+fi
+exec /usr/bin/mv "$@"
+EOF
+    chmod +x "${STUB_BIN}/mv"
+    sed 's/release-20260817.0/release-20260818.0/g' \
+        "${PATCHED_HELPER}" > "${TEST_ROOT}/bluefin-runsc-update"
+    chmod +x "${TEST_ROOT}/bluefin-runsc-update"
+    export FAIL_MV_TARGET="${TEST_ROOT}/usr/local/bin/runsc"
+
+    run "${TEST_ROOT}/bluefin-runsc-update" update
+
+    [ "${status}" -ne 0 ]
+    [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = "${active_link}" ]
+    [ -x "${active_link}" ]
+    [ -d "$(dirname "${active_link}")/gvisor-bin" ]
+    after_release_dirs=("${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases/"*)
+    [ "${#after_release_dirs[@]}" -eq "${#release_dirs[@]}" ]
 }
 
 @test "runsc recipe and helper do not change defaults or weaken runtime isolation" {

--- a/tests/unit/runsc-provisioning_test.bats
+++ b/tests/unit/runsc-provisioning_test.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+# Deterministic contract tests for the Bluefin-owned runsc provisioning helper.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+HELPER="${SCRIPT_DIR}/../../system_files/shared/usr/libexec/bluefin-runsc"
+RUNSC_VERSION="release-20260817.0"
+
+setup() {
+    TEST_ROOT="$(mktemp -d)"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    mkdir -p "${STUB_BIN}" "${TEST_ROOT}/archive/gvisor-bin" "${TEST_ROOT}/bin"
+
+    printf '#!/usr/bin/env bash\n' > "${TEST_ROOT}/archive/runsc"
+    printf 'sandbox payload\n' > "${TEST_ROOT}/archive/gvisor-bin/runsc-sandbox"
+    printf 'shim payload\n' > "${TEST_ROOT}/archive/containerd-shim-runsc-v1"
+    chmod +x "${TEST_ROOT}/archive/runsc" "${TEST_ROOT}/archive/gvisor-bin/runsc-sandbox"
+    tar -cjf "${TEST_ROOT}/gvisor.tar.bz2" \
+        -C "${TEST_ROOT}/archive" runsc gvisor-bin containerd-shim-runsc-v1
+    VALID_SHA="$(sha256sum "${TEST_ROOT}/gvisor.tar.bz2" | awk '{print $1}')"
+
+    cat > "${STUB_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${CURL_LOG}"
+destination=""
+while (($#)); do
+    case "$1" in
+        -o) destination="$2"; shift 2 ;;
+        --output) destination="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [[ "$(cat "${CURL_MODE_FILE}" 2>/dev/null || true)" == corrupt ]]; then
+    printf 'corrupt archive\n' > "${destination}"
+else
+    cp "${FIXTURE_ARCHIVE}" "${destination}"
+fi
+EOF
+    chmod +x "${STUB_BIN}/curl"
+
+    export PATH="${STUB_BIN}:${PATH}"
+    export CURL_LOG="${TEST_ROOT}/curl.log"
+    export CURL_MODE_FILE="${TEST_ROOT}/curl-mode"
+    export FIXTURE_ARCHIVE="${TEST_ROOT}/gvisor.tar.bz2"
+    : > "${CURL_LOG}"
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+patch_helper() {
+    PATCHED_HELPER="${TEST_ROOT}/bluefin-runsc"
+    sed \
+        -e "s|/usr/local/libexec/bluefin-runsc|${TEST_ROOT}/usr/local/libexec/bluefin-runsc|g" \
+        -e "s|/usr/local/bin/runsc|${TEST_ROOT}/usr/local/bin/runsc|g" \
+        -e "s|ae345a8c1466586b3a163fb534301913da663a97b8ed446bc711b2e1963a32c5|${VALID_SHA}|g" \
+        -e "s|a3c2443e9564dbf500893e66fd2463be3b79fe42f66825971c44dc1624d454b2|${VALID_SHA}|g" \
+        "${HELPER}" > "${PATCHED_HELPER}"
+    chmod +x "${PATCHED_HELPER}"
+}
+
+stub_uname() {
+    local architecture="$1"
+    cat > "${STUB_BIN}/uname" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "-m" ]]; then
+    printf '%s\\n' "${architecture}"
+else
+    /usr/bin/uname "\$@"
+fi
+EOF
+    chmod +x "${STUB_BIN}/uname"
+}
+
+@test "runsc helper installs the pinned payload and discoverable link" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+
+    run "${PATCHED_HELPER}" install
+
+    [ "${status}" -eq 0 ]
+    release_dirs=("${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases/${RUNSC_VERSION}-"*)
+    [ "${#release_dirs[@]}" -eq 1 ]
+    [ -x "${release_dirs[0]}/runsc" ]
+    [ -x "${release_dirs[0]}/gvisor-bin/runsc-sandbox" ]
+    [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = \
+        "${release_dirs[0]}/runsc" ]
+    grep -Fq 'gvisor-x86_64.tar.bz2' "${CURL_LOG}"
+}
+
+@test "runsc helper rejects unsupported architecture before network access" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    stub_uname riscv64
+
+    run "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ ! -s "${CURL_LOG}" ]
+}
+
+@test "runsc helper maps arm64 hosts to the upstream aarch64 asset" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    stub_uname arm64
+
+    run "${PATCHED_HELPER}" install
+
+    [ "${status}" -eq 0 ]
+    grep -Fq 'gvisor-aarch64.tar.bz2' "${CURL_LOG}"
+}
+
+@test "runsc helper verifies the archive before its first tar read" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    printf 'corrupt\n' > "${CURL_MODE_FILE}"
+    cat > "${STUB_BIN}/tar" <<'EOF'
+#!/usr/bin/env bash
+printf 'tar was called\n' > "${TAR_LOG}"
+exit 99
+EOF
+    chmod +x "${STUB_BIN}/tar"
+    export TAR_LOG="${TEST_ROOT}/tar.log"
+
+    run "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ ! -e "${TAR_LOG}" ]
+}
+
+@test "runsc helper install is idempotent after the pinned release is active" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+
+    run "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+    first_curl_count="$(wc -l < "${CURL_LOG}")"
+
+    run "${PATCHED_HELPER}" install
+
+    [ "${status}" -eq 0 ]
+    [ "$(wc -l < "${CURL_LOG}")" -eq "${first_curl_count}" ]
+}
+
+@test "runsc helper leaves the active release unchanged after a failed update" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    run "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+    active_link="$(readlink "${TEST_ROOT}/usr/local/bin/runsc")"
+    rm -rf "$(dirname "${active_link}")/gvisor-bin"
+    printf 'corrupt\n' > "${CURL_MODE_FILE}"
+
+    run "${PATCHED_HELPER}" update
+
+    [ "${status}" -ne 0 ]
+    [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = "${active_link}" ]
+}
+
+@test "runsc helper removes only its owned installation" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    run "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+
+    run "${PATCHED_HELPER}" remove
+
+    [ "${status}" -eq 0 ]
+    [ ! -e "${TEST_ROOT}/usr/local/bin/runsc" ]
+    [ ! -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc" ]
+}
+
+@test "runsc helper refuses to remove a foreign runsc link" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    mkdir -p "${TEST_ROOT}/usr/local/bin"
+    printf '#!/usr/bin/env bash\n' > "${TEST_ROOT}/foreign-runsc"
+    chmod +x "${TEST_ROOT}/foreign-runsc"
+    ln -s "${TEST_ROOT}/foreign-runsc" "${TEST_ROOT}/usr/local/bin/runsc"
+    mkdir -p "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    printf 'owned data\n' > "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/keep"
+
+    run "${PATCHED_HELPER}" remove
+
+    [ "${status}" -ne 0 ]
+    [ -L "${TEST_ROOT}/usr/local/bin/runsc" ]
+    [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/keep" ]
+}
+
+@test "runsc recipe and helper do not change defaults or weaken runtime isolation" {
+    [[ -x "${HELPER}" ]]
+    RECIPE="${SCRIPT_DIR}/../../system_files/shared/usr/share/ublue-os/just/60-custom.just"
+    [[ -f "${RECIPE}" ]]
+    run grep -Eiq 'runsc action=' "${RECIPE}"
+    [ "${status}" -eq 0 ]
+    run grep -Eiq 'bluefin-runsc' "${RECIPE}"
+    [ "${status}" -eq 0 ]
+    run grep -Eiq 'runtime[[:space:]]*=' "${RECIPE}"
+    [ "${status}" -ne 0 ]
+    run grep -Eiq 'ignore-cgroups|network=host|curl[^\n]*PATH' "${HELPER}" "${RECIPE}"
+    [ "${status}" -ne 0 ]
+}

--- a/tests/unit/runsc-provisioning_test.bats
+++ b/tests/unit/runsc-provisioning_test.bats
@@ -78,7 +78,7 @@ EOF
     [[ -x "${HELPER}" ]]
     patch_helper
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
 
     [ "${status}" -eq 0 ]
     release_dirs=("${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases/${RUNSC_VERSION}-"*)
@@ -96,7 +96,7 @@ EOF
     patch_helper
     stub_uname riscv64
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
 
     [ "${status}" -ne 0 ]
     [ ! -s "${CURL_LOG}" ]
@@ -107,7 +107,7 @@ EOF
     patch_helper
     stub_uname arm64
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
 
     [ "${status}" -eq 0 ]
     grep -Fq 'gvisor-aarch64.tar.bz2' "${CURL_LOG}"
@@ -125,7 +125,7 @@ EOF
     chmod +x "${STUB_BIN}/tar"
     export TAR_LOG="${TEST_ROOT}/tar.log"
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
 
     [ "${status}" -ne 0 ]
     [ ! -e "${TAR_LOG}" ]
@@ -135,11 +135,11 @@ EOF
     [[ -x "${HELPER}" ]]
     patch_helper
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
     [ "${status}" -eq 0 ]
     first_curl_count="$(wc -l < "${CURL_LOG}")"
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
 
     [ "${status}" -eq 0 ]
     [ "$(wc -l < "${CURL_LOG}")" -eq "${first_curl_count}" ]
@@ -154,7 +154,7 @@ EOF
     rm -rf "$(dirname "${active_link}")/gvisor-bin"
     printf 'corrupt\n' > "${CURL_MODE_FILE}"
 
-    run "${PATCHED_HELPER}" update
+    run bash "${PATCHED_HELPER}" update
 
     [ "${status}" -ne 0 ]
     [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = "${active_link}" ]
@@ -163,10 +163,10 @@ EOF
 @test "runsc helper removes only its owned installation" {
     [[ -x "${HELPER}" ]]
     patch_helper
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
     [ "${status}" -eq 0 ]
 
-    run "${PATCHED_HELPER}" remove
+    run bash "${PATCHED_HELPER}" remove
 
     [ "${status}" -eq 0 ]
     [ ! -e "${TEST_ROOT}/usr/local/bin/runsc" ]
@@ -183,7 +183,7 @@ EOF
     mkdir -p "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
     printf 'owned data\n' > "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/keep"
 
-    run "${PATCHED_HELPER}" remove
+    run bash "${PATCHED_HELPER}" remove
 
     [ "${status}" -ne 0 ]
     [ -L "${TEST_ROOT}/usr/local/bin/runsc" ]
@@ -203,7 +203,7 @@ EOF
     [ "${status}" -ne 0 ]
     [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/foreign" ]
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
 
     [ "${status}" -ne 0 ]
     [ ! -s "${CURL_LOG}" ]
@@ -231,7 +231,7 @@ EOF
     ln -s "${TEST_ROOT}/foreign" \
         "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases"
 
-    run "${PATCHED_HELPER}" install
+    run bash "${PATCHED_HELPER}" install
 
     [ "${status}" -ne 0 ]
     [ -d "${TEST_ROOT}/foreign" ]
@@ -261,7 +261,7 @@ EOF
     chmod +x "${TEST_ROOT}/bluefin-runsc-update"
     export FAIL_MV_TARGET="${TEST_ROOT}/usr/local/bin/runsc"
 
-    run "${TEST_ROOT}/bluefin-runsc-update" update
+    run bash "${TEST_ROOT}/bluefin-runsc-update" update
 
     [ "${status}" -ne 0 ]
     [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = "${active_link}" ]

--- a/tests/unit/runsc-provisioning_test.bats
+++ b/tests/unit/runsc-provisioning_test.bats
@@ -6,7 +6,7 @@ HELPER="${SCRIPT_DIR}/../../system_files/shared/usr/libexec/bluefin-runsc"
 RUNSC_VERSION="release-20260817.0"
 
 setup() {
-    TEST_ROOT="$(mktemp -d)"
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/runsc-provisioning.${BATS_TEST_NUMBER:-0}.$$"
     STUB_BIN="${TEST_ROOT}/stub-bin"
     PATCHED_HELPER="${TEST_ROOT}/bluefin-runsc"
     mkdir -p "${STUB_BIN}" "${TEST_ROOT}/archive/gvisor-bin" "${TEST_ROOT}/bin"

--- a/tests/unit/runsc-provisioning_test.bats
+++ b/tests/unit/runsc-provisioning_test.bats
@@ -8,6 +8,7 @@ RUNSC_VERSION="release-20260817.0"
 setup() {
     TEST_ROOT="$(mktemp -d)"
     STUB_BIN="${TEST_ROOT}/stub-bin"
+    PATCHED_HELPER="${SCRIPT_DIR}/../../system_files/shared/usr/libexec/.bluefin-runsc-test"
     mkdir -p "${STUB_BIN}" "${TEST_ROOT}/archive/gvisor-bin" "${TEST_ROOT}/bin"
 
     printf '#!/usr/bin/env bash\n' > "${TEST_ROOT}/archive/runsc"
@@ -46,11 +47,11 @@ EOF
 }
 
 teardown() {
+    rm -f "${PATCHED_HELPER}"
     rm -rf "${TEST_ROOT}"
 }
 
 patch_helper() {
-    PATCHED_HELPER="${TEST_ROOT}/bluefin-runsc"
     sed \
         -e "s|/usr/local/libexec/bluefin-runsc|${TEST_ROOT}/usr/local/libexec/bluefin-runsc|g" \
         -e "s|/usr/local/bin/runsc|${TEST_ROOT}/usr/local/bin/runsc|g" \

--- a/tests/unit/runsc-provisioning_test.bats
+++ b/tests/unit/runsc-provisioning_test.bats
@@ -8,7 +8,7 @@ RUNSC_VERSION="release-20260817.0"
 setup() {
     TEST_ROOT="$(mktemp -d)"
     STUB_BIN="${TEST_ROOT}/stub-bin"
-    PATCHED_HELPER="${SCRIPT_DIR}/../../system_files/shared/usr/libexec/.bluefin-runsc-test"
+    PATCHED_HELPER="${TEST_ROOT}/bluefin-runsc"
     mkdir -p "${STUB_BIN}" "${TEST_ROOT}/archive/gvisor-bin" "${TEST_ROOT}/bin"
 
     printf '#!/usr/bin/env bash\n' > "${TEST_ROOT}/archive/runsc"


### PR DESCRIPTION
## What problem are you solving?

Issue #1139 needs a trusted Bluefin host path for installing gVisor's `runsc` OCI runtime so rootless Podman can select it explicitly for the Review prerequisite.

- [x] I am using an agent and I take responsibility for this PR

## Changes

- Add `ujust runsc install`, `update`, and `remove` recipes backed by a Bluefin-owned helper.
- Pin the current gVisor release and exact x86_64/aarch64 SHA-256 digests, reject unsupported architectures before network access, verify before archive inspection, retain `gvisor-bin`, and publish atomically without changing Podman's default runtime.
- Add deterministic lifecycle, architecture, archive, ownership, and isolation tests.
- Document the trust boundary and the still-unproved native acceptance gates.

## Testing

- [x] `just check` passes
- [ ] `pre-commit run --all-files` passes — not claimed as a host pass because the host lacks `pre-commit`; the disposable read-only run passed non-mutating hooks, but the EOF fixer attempted unrelated baseline rewrites.
- [x] Documentation was updated for the reusable security/lifecycle procedure
- [ ] Build tested locally (optional but appreciated) — local build was not run; hosted validate/build evidence is reported separately below and is not called a local build.

### Hosted evidence (separate from local build)

Hosted run [33093191493](https://github.com/projectbluefin/bluefin/actions/runs/33093191493) reported:

- Unit tests: pass; BATS 176/176
- BATS coverage: 61.3% >= 45% threshold
- Validate: pass
- Check PR base branch: pass
- E2E smoke: skipped by policy

## Checklist

- [x] Conventional commit message (`feat:`, `fix:`, `chore:`, etc.)
- [x] No hardcoded secrets or credentials
- [x] Package additions follow COPR isolation rules (`copr_install_isolated()`)

### Contributor-guide compliance

- Work was performed in the isolated issue-1139 worktree.
- The PR targets the `testing` base.
- Only explicit authorized paths were changed; no secrets or generated artifacts were added.
- No merge or self-approval was performed.

## Community verification (bug-fix PRs)

After the next testing image ships, run `ujust runsc install`, then verify `runsc --version` and a rootless Podman probe with `--runtime=runsc` using ordinary networking and no `ignore-cgroups=true`.

## Acceptance boundaries

Native runsc, rootless Podman, OCIRuntime, ordinary networking, cgroup/lifecycle, and arm64 acceptance remain unproved. This PR makes no closure claim; `Progresses #1139` remains the issue relationship. This body update does not alter the PR's current draft state.

The original public commit `a2d96f18a76cf0a3a593d74a4722e808a1126acb` retains its attribution-policy defect and remains immutable. This is not claimed as fixed and is not recorded as an exception; repair follow-up commits carry the exact required attribution trailer.

Progresses #1139