### PR TITLE
test(framework): stop the hook tests from driving the host's real rpm-ostree

### DIFF
--- a/tests/unit/11-framework-ucsi-workaround_test.bats
+++ b/tests/unit/11-framework-ucsi-workaround_test.bats
@@ -79,11 +79,18 @@ EOF
 
 @test "11-framework-ucsi-workaround: missing rpm-ostree exits with warning" {
     rm -f "${STUB_BIN}/rpm-ostree"
-    export PATH="${STUB_BIN}:/usr/bin:/bin"
+    # Drop the stub so the hook's `command -v rpm-ostree` guard is exercised for
+    # real. PATH is narrowed for the hook process ONLY — it must not re-admit
+    # the host's /usr/bin. On any rpm-ostree host (Bluefin and every other
+    # ostree desktop this project is developed on) the real binary would be
+    # found there, the warning branch would never run, and the hook would go on
+    # to drive rpm-ostree against the developer's own deployment. Setting PATH
+    # via `env` rather than `export` keeps the change off the test's own shell,
+    # so teardown still has its normal PATH.
     echo "Framework" > "${TEST_ROOT}/chassis_vendor"
     echo "Laptop 13 (Intel Core Ultra Series 1)" > "${TEST_ROOT}/product_name"
 
-    run bash "${PATCHED_SCRIPT}"
+    run env PATH="${STUB_BIN}" "${BASH}" "${PATCHED_SCRIPT}"
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning: rpm-ostree not found"* ]]

--- a/tests/unit/12-framework-amd-kargs-cleanup_test.bats
+++ b/tests/unit/12-framework-amd-kargs-cleanup_test.bats
@@ -126,12 +126,19 @@ EOF
 
 @test "12-framework-amd-kargs-cleanup: missing rpm-ostree exits with warning" {
     rm -f "${STUB_BIN}/rpm-ostree"
-    export PATH="${STUB_BIN}:/usr/bin:/bin"
+    # Drop the stub so the hook's `command -v rpm-ostree` guard is exercised for
+    # real. PATH is narrowed for the hook process ONLY — it must not re-admit
+    # the host's /usr/bin. On any rpm-ostree host (Bluefin and every other
+    # ostree desktop this project is developed on) the real binary would be
+    # found there, the warning branch would never run, and the hook would go on
+    # to drive rpm-ostree against the developer's own deployment. Setting PATH
+    # via `env` rather than `export` keeps the change off the test's own shell,
+    # so teardown still has its normal PATH.
 
     echo "Framework" > "${TEST_ROOT}/chassis_vendor"
     echo "Laptop 13 (AMD Ryzen 7040 Series)" > "${TEST_ROOT}/product_name"
 
-    run bash "${PATCHED_SCRIPT}"
+    run env PATH="${STUB_BIN}" "${BASH}" "${PATCHED_SCRIPT}"
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning: rpm-ostree not found"* ]]


### PR DESCRIPTION
## What's wrong

Both Framework setup-hook tests have a `missing rpm-ostree exits with warning` case that removes the stub and then resets PATH:

```bash
rm -f "${STUB_BIN}/rpm-ostree"
export PATH="${STUB_BIN}:/usr/bin:/bin"
```

Re-admitting `/usr/bin` defeats the case. On any rpm-ostree host the hook's `command -v rpm-ostree` guard finds the **real** binary, the warning branch is never exercised, and the hook goes on to drive rpm-ostree against the developer's own deployment.

That host is not hypothetical — it is Bluefin, which is what this project is developed and dogfooded on. `bats tests/unit/` on a Bluefin machine, on current `testing`:

```
not ok 54 11-framework-ucsi-workaround: missing rpm-ostree exits with warning
# (in test file tests/unit/11-framework-ucsi-workaround_test.bats, line 88)
#   `[ "$status" -eq 0 ]' failed
# error: rpmostreed OS operation KernelArgs not allowed for user

not ok 61 12-framework-amd-kargs-cleanup: missing rpm-ostree exits with warning
```

The `rpmostreed OS operation KernelArgs not allowed for user` line is the part worth pausing on. That is polkit refusing a real `rpm-ostree kargs --append-if-missing=usbcore.autosuspend=-1` — **the unit test tried to append a kernel argument to the live deployment**, and was stopped only because the run happened to be unprivileged. A contributor who runs the suite with the privilege to complete that call gets their boot configuration edited by a test. The `12-` case is the same shape: it ran a real `rpm-ostree kargs` and only avoided the `--delete` because that particular host did not carry the stale karg.

CI never sees any of this. The build container has no rpm-ostree, so the `/usr/bin` entry finds nothing, the guard fires, and both tests pass. Green on the one machine where the bug is invisible; red — and destructive — on the machines contributors actually use.

This is also the repo's own documented red flag for these tests: *"A real `/usr` helper or absolute binary is still called"* and *"The test writes outside its sandbox"* (`docs/skills/setup-hook-tests/SKILL.md`).

## The fix

Narrow PATH to the stub directory alone, and set it with `env` for the hook process rather than `export`ing it into the test's shell — teardown then keeps a working PATH for its `rm -rf`. The script is invoked through `${BASH}` because `env` resolves the program name against the PATH it just set, so a bare `bash` would no longer be findable.

```bash
run env PATH="${STUB_BIN}" "${BASH}" "${PATCHED_SCRIPT}"
```

Both tests now exercise the branch they name, and do so identically whether or not rpm-ostree is installed.

## Verification

`bats tests/unit/` on a Bluefin host:

| | before | after |
|---|---:|---:|
| passed | 162 | **164** |
| failed | **2** | 0 |

I confirmed both cases were executing the host binary before the change (the polkit error above is the direct evidence for `11-`), and that both reach the warning branch after it. Nothing else in the suite is touched. `shellcheck` in `.pre-commit-config.yaml` is scoped to `build_files|system_files/**.sh`, so `.bats` files are unaffected either way.

## Scope

Test-only; no image or hook behaviour changes.

`12-framework-amd-kargs-cleanup` is the AMD karg-cleanup half of the #879 fix (landed in #1103 three days ago) — it is the hook that removes the stale `module_blacklist=hid_sensor_hub` karg the reporter was originally told to delete by hand. `11-framework-ucsi-workaround` is the test it was patterned on, and carries the identical defect, so both are fixed together rather than leaving a known-bad template in place for the next hook to copy.

I did re-verify the rest of #879 while I was here, and found nothing else outstanding in this repo: `fw-charge-control.conf` is present with the right option and is covered three ways (source unit test, `build_files/base/20-tests.sh` image assertion, and the unit test of that assertion), and the dead `fw-ectool` user hook is gone (#1132). The fix still has not reached `:stable` or `:testing` — both tags currently resolve to images built before #1019 merged — but that is the promotion freeze tracked in #989/#995, not anything left to change here.

Refs: #879

— hive: backend=claude model=claude-opus-5
