### PR TITLE
test(build): guard just and gum, the rest of the ujust chain (#965)

### DIFF
--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -61,6 +61,16 @@ test -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service && false
 test -f /usr/lib/modprobe.d/fw-charge-control.conf
 grep -q '^options cros_charge_control probe_with_fwk_charge_control=1$' /usr/lib/modprobe.d/fw-charge-control.conf
 
+# `ujust` is the entry point for every user-facing recipe, and it is only a
+# wrapper: its last line is `exec just --justfile
+# /usr/share/ublue-os/just/00-entry.just`, and the recipes it hands off to
+# render their prompts with `gum`. Both the wrapper and the .just files come
+# from `common`, so the stat checks above still pass if these two RPMs are
+# dropped from base.toml -- `ujust` then exits 127 on every invocation, or every
+# interactive recipe fills with "gum: command not found", and nothing here
+# fails the build. That is #965 item 1 (`ujust --choose` broken by a missing
+# fzf) one level up the same chain, so guard the chain and not just its leaf.
+# See: https://github.com/projectbluefin/bluefin/issues/965
 IMPORTANT_PACKAGES=(
     anaconda-live
     distrobox
@@ -70,7 +80,9 @@ IMPORTANT_PACKAGES=(
     flatpak
     fzf
     grub2-efi-x64-cdboot
+    gum
     isomd5sum
+    just
     libblockdev-btrfs
     libblockdev-dm
     libblockdev-lvm

--- a/tests/unit/20-tests_test.bats
+++ b/tests/unit/20-tests_test.bats
@@ -127,6 +127,57 @@ EOF
     [[ "$output" == *"Missing package: fzf"* ]]
 }
 
+@test "20-tests: rejects an image missing just, the binary ujust exec's" {
+    # /usr/bin/ujust is a wrapper that ends in `exec just --justfile ...`, and
+    # it ships from `common`, so the `stat /usr/bin/ujust` check above passes
+    # whether or not the just RPM is on the image. Drop just from base.toml and
+    # every ujust invocation exits 127 -- a strictly worse version of the #965
+    # item 1 symptom -- with nothing failing the build. This case fails if just
+    # is ever removed from IMPORTANT_PACKAGES.
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+if [[ "$*" == *"%{VENDOR}"* ]]; then
+    echo "negativo17.org"
+    exit 0
+fi
+case "$*" in
+    *fedora-flathub-remote*|*fedora-logos*|*fedora-third-party*|*gnome-software*|*podman-docker*) exit 1 ;;
+    *" just"*) exit 1 ;;
+esac
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing package: just"* ]]
+}
+
+@test "20-tests: rejects an image missing gum, which the just recipes render with" {
+    # The .just files come from `common` and call gum for every prompt, spinner
+    # and styled block, so a missing gum RPM leaves the recipes present and the
+    # stat checks green while every interactive recipe degrades into a stream of
+    # "gum: command not found". This case fails if gum is ever removed from
+    # IMPORTANT_PACKAGES.
+    cat > "${STUB_BIN}/rpm" <<'EOF'
+#!/usr/bin/bash
+if [[ "$*" == *"%{VENDOR}"* ]]; then
+    echo "negativo17.org"
+    exit 0
+fi
+case "$*" in
+    *fedora-flathub-remote*|*fedora-logos*|*fedora-third-party*|*gnome-software*|*podman-docker*) exit 1 ;;
+    *" gum"*) exit 1 ;;
+esac
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing package: gum"* ]]
+}
+
 @test "20-tests: rejects an unwanted package" {
     cat > "${STUB_BIN}/rpm" <<'EOF'
 #!/usr/bin/bash


### PR DESCRIPTION
## Problem

#965 item 1 was `ujust --choose` failing on a fresh install because `fzf` was not on the image. #1057 fixed it by adding `fzf` to `build_files/packages/base.toml` and to `IMPORTANT_PACKAGES` in `build_files/base/20-tests.sh`; #1090 then proved the missing-package path actually fails the build.

That guards the **leaf** of the chain, not the chain.

`/usr/bin/ujust` is a wrapper. Its last line, in `common`:

```bash
exec just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"
```

The wrapper and the `.just` files it loads both ship from `common`, so the existing assertions

```bash
for i in bin/ujust share/ublue-os/just/{00-entry.just,apps.just,default.just,system.just,update.just,}; do
   stat /usr/"$i"
done
```

keep passing regardless of what `base.toml` installs. Drop `just` from `base.toml` and every one of those stats is still green, the image ships, and *every* `ujust` invocation exits 127 — not only `--choose`, and strictly worse than the symptom this issue reported. Nothing in the build fails.

`gum` has the same shape one step further in: the shipped recipes call it for every prompt, spinner and styled block (17 times in `common`'s `system_files/bluefin/.../system.just` alone, plus `default.just`, `update.just`, `apps.just`), so losing it leaves the recipes present and turns each one into a stream of `gum: command not found`.

Confirmed there is no existing guard: `grep -rn "command -v just\|/usr/bin/just\|rpm -q just\|command -v gum\|/usr/bin/gum" build_files/ tests/ .github/` returns nothing.

## Change

- Add `gum` and `just` to `IMPORTANT_PACKAGES`. Both are **already** in `base.toml`'s `[fedora]` list, so this changes no image content — it only extends to them the same regression guard #1057 gave `fzf`, which that guard is worthless without.
- Add one bats case each. These are not duplicates of the existing missing-`IMPORTANT_PACKAGES`-entry test: that one proves the *mechanism* works, these two assert *list membership* — removing `just` or `gum` from the array makes the corresponding case fail.

## Testing

- `bats tests/unit/20-tests_test.bats` → 12/12 pass.
- `shellcheck build_files/base/20-tests.sh` → clean.
- `just check` → clean.
- **Negative control**, per the vacuous-pass trap recorded in #1135: with the two new entries stashed back out of `IMPORTANT_PACKAGES`, exactly the two new cases fail on `[ "$status" -ne 0 ]` and the other ten stay green — so neither case passes for a reason other than the one it names.
- Run on a Fedora host, where the suite's `#!/usr/bin/bash` stub shebangs resolve (they do not under `docker.io/bats/bats` on Alpine, which silently vacuums every `rejects …` case in this file).
- Package names verified real and current in Fedora (`mdapi`: `just` 1.57.0, `gum` 0.16.2), and both already install cleanly today — the rest of the `[fedora]` list is asserted by `rpm -q` in this same script and passes in CI.
- No image build; this is a build-test change only.

## Scope

`Refs: #965` rather than `Closes` — item 1 is now fully guarded and item 2 was closed by #1081/#1135, but item 3 (`ujust dx-group` adding no groups) has no surface in this repo and is tracked at projectbluefin/dakota#622.

— hive: backend=claude model=claude-opus-5