### PR TITLE
fix(build): checkpoint the rpmdb out of WAL mode at every stage commit

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,6 +35,7 @@ COPY /build_files/shared/utils/ghcurl /build_files/shared/utils/ghcurl
 FROM scratch AS ctx
 COPY /system_files /system_files
 COPY /build_files/shared/build-gnome-extensions.sh /build_files/shared/build-gnome-extensions.sh
+COPY /build_files/shared/checkpoint-rpmdb.sh /build_files/shared/checkpoint-rpmdb.sh
 COPY /build_files/shared/clean-stage.sh /build_files/shared/clean-stage.sh
 COPY /build_files/shared/disable-repos.sh /build_files/shared/disable-repos.sh
 COPY /build_files/shared/finalize-gnome-extensions.sh /build_files/shared/finalize-gnome-extensions.sh
@@ -86,7 +87,8 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
         export PATH="/tmp/scripts/helpers:$PATH" && \
         /ctx/build_files/base/03-packages.sh && \
         /ctx/build_files/base/04-install-kernel-akmods.sh && \
-        /ctx/build_files/base/05-override-install.sh \
+        /ctx/build_files/base/05-override-install.sh && \
+        /ctx/build_files/shared/checkpoint-rpmdb.sh \
     '
 
 # hadolint ignore=DL3006
@@ -150,7 +152,8 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
         /ctx/build_files/base/19-initramfs.sh && \
         /ctx/build_files/shared/validate-repos.sh && \
         /ctx/build_files/shared/clean-stage.sh && \
-        /ctx/build_files/base/20-tests.sh \
+        /ctx/build_files/base/20-tests.sh && \
+        /ctx/build_files/shared/checkpoint-rpmdb.sh \
     '
 
 # Embed the Stable container-native ISO contract after Stage 2. This runs

--- a/build_files/shared/checkpoint-rpmdb.sh
+++ b/build_files/shared/checkpoint-rpmdb.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/bash
+
+echo "::group:: ===$(basename "$0")==="
+
+set -eoux pipefail
+
+# Leave the rpmdb as a single self-contained file in the committed layer.
+#
+# The Fedora bootc base images ship /usr/lib/sysimage/rpm/rpmdb.sqlite in
+# SQLite WAL journal mode together with stale rpmdb.sqlite-{shm,wal}
+# sidecars, and every dnf transaction in a build stage switches the database
+# back to WAL and leaves fresh sidecars behind. A layer committed in that
+# state is not self-contained: the next stage's first rpmdb read must
+# reconstruct WAL state through overlayfs, which is where CI's
+# "database disk image is malformed" failures come from (issue #995;
+# docs/skills/ci/references/failure-modes.md). Checkpointing the WAL and
+# switching to the default rollback-journal mode makes the database an
+# ordinary single file that any later stage — and the shipped image — can
+# read without WAL machinery. Run this as the last step of any RUN whose
+# rpmdb a later stage or the final image will read.
+
+# RPMDB_PATH: absolute path of the rpmdb SQLite database.
+# Defaults to the bootc sysimage location; overridden in unit tests.
+RPMDB_PATH="${RPMDB_PATH:-/usr/lib/sysimage/rpm/rpmdb.sqlite}"
+
+# sqlite3.connect() would silently create an empty database at a wrong path;
+# a build without an rpmdb here is broken and must fail now, not later.
+if [[ ! -f "${RPMDB_PATH}" ]]; then
+    echo "checkpoint-rpmdb: no rpmdb at ${RPMDB_PATH}" >&2
+    exit 1
+fi
+
+python3 - "${RPMDB_PATH}" <<'PYEOF'
+import sqlite3
+import sys
+
+db = sqlite3.connect(sys.argv[1])
+db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+db.execute("PRAGMA journal_mode=DELETE")
+db.close()
+PYEOF
+
+rm -f "${RPMDB_PATH}-shm" "${RPMDB_PATH}-wal"
+
+echo "::endgroup::"

--- a/docs/skills/ci/references/failure-modes.md
+++ b/docs/skills/ci/references/failure-modes.md
@@ -347,3 +347,53 @@ gh run list --repo projectbluefin/bluefin --workflow "Testing Images" -L 20 \
 gh run view RUN_ID --repo projectbluefin/bluefin --json jobs \
   --jq '.jobs[] | [.name, .status, .conclusion] | @tsv'
 ```
+
+### Update 2026-08-28 — registry-cache suspect disproven; failure is a WAL-mode rpmdb read across the stage-commit boundary
+
+Full-log forensics across the good/bad boundary correct two claims above and
+retire the prime suspect:
+
+- **The census conflates two failure modes.** Run `31607601482` (08-12) built
+  every stage successfully — including the `extension-builder` dnf install —
+  and failed only while *pushing* (GHCR secondary rate limit, HTTP 403, on
+  both the cache push and the image push). The rpmdb-malformed signature
+  starts with `31727537250` (08-13) and appears in every failing run from
+  then on. Last good *build* is therefore 08-12, not 08-10.
+- **The registry-cache-replay suspect is disproven.** The failing step's
+  parent (`base-common`) rebuilds fresh in the failing runs — its `FROM`
+  digest is re-resolved daily, so its cache key changes daily, and run
+  `32924887367` (08-26) demonstrably executed Stage 1 live (new
+  `BUILD_FILES_SHA`, full 251-package install in the log) and still failed.
+  Seven distinct daily base digests (08-13 → 08-26) all fail identically; no
+  stale cached layer is involved. Do not ask a maintainer for a cache-disabled
+  run; that experiment answers a question this evidence already settles.
+- **Environment is constant across the boundary.** Last-good (08-12) and
+  first-bad (08-13) runs used the identical runner image (`20260720.247.2`),
+  identical podman/buildah/crun from Ubuntu resolute
+  (5.7.0 / 1.42.1 / 1.21), a `projectbluefin/actions` delta touching only
+  sync-branches/renovate workflows, and a bluefin delta touching only
+  `20-tests.sh` (runs in Stage 2, after the failing step).
+- **The base composes are package-identical.** `44.20260812.0` (works) and
+  `44.20260813.0` (fails) have byte-identical `rpm -qa` sets and
+  byte-identical shipped `rpmdb.sqlite-shm`/`-wal` sidecars. Only the
+  `rpmdb.sqlite` bytes and layer packing differ.
+- **What is actually failing:** the Fedora bootc bases ship
+  `/usr/lib/sysimage/rpm/rpmdb.sqlite` in SQLite **WAL journal mode** with
+  stale `-shm`/`-wal` sidecars, and every dnf transaction in a build stage
+  leaves the database in WAL mode with fresh sidecars. The
+  `extension-builder` failure is the next stage's *first read* of that
+  committed WAL state (`SELECT hnum, blob FROM 'Packages'` is the rpmdb
+  Packages table): under CI's rootful buildah 1.42.1 overlay it reports
+  SQLITE_CORRUPT, while the same image and same read succeed under local
+  rootless podman 5.8.4 — the residual trigger is in the
+  buildah-version/overlay interaction with post-0812 rpmdb bytes, not in any
+  input this repo pins.
+- **Fix applied in this repo:** `build_files/shared/checkpoint-rpmdb.sh`
+  checkpoints the WAL, converts the rpmdb to the default rollback-journal
+  mode, and removes the sidecars; `Containerfile` runs it as the last step of
+  Stage 1 and Stage 2, so every committed layer (and the shipped image)
+  carries a single self-contained `rpmdb.sqlite`. Validated locally: with the
+  checkpoint in place, a two-stage build on the failing-era base commits a
+  sidecar-free `journal_mode=delete` database that the next stage reads and
+  installs against cleanly; without it, a stage's dnf write always re-enables
+  WAL, which is why the script must run per-stage, not once.

--- a/tests/unit/checkpoint-rpmdb_test.bats
+++ b/tests/unit/checkpoint-rpmdb_test.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/checkpoint-rpmdb.sh.
+# Run with: bats tests/unit/checkpoint-rpmdb_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+CHECKPOINT_RPMDB="${SCRIPT_DIR}/../../build_files/shared/checkpoint-rpmdb.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/checkpoint-rpmdb.${BATS_TEST_NUMBER:-0}.$$"
+    mkdir -p "${TEST_ROOT}"
+    RPMDB_PATH="${TEST_ROOT}/rpmdb.sqlite"
+    export RPMDB_PATH
+
+    # A real WAL-mode database with live sidecars, like the one a dnf
+    # transaction leaves behind at the end of a build stage.
+    python3 - "${RPMDB_PATH}" <<'PYEOF'
+import sqlite3
+import sys
+
+db = sqlite3.connect(sys.argv[1])
+db.execute("PRAGMA journal_mode=WAL")
+db.execute("CREATE TABLE Packages (hnum INTEGER PRIMARY KEY, blob BLOB)")
+db.execute("INSERT INTO Packages (hnum, blob) VALUES (1, x'c0ffee')")
+db.commit()
+# Leave the connection open state behind us without checkpointing so the
+# -wal file still holds the committed frames, then close.
+db.close()
+PYEOF
+}
+
+teardown() {
+    rm -rf "${TEST_ROOT}"
+}
+
+journal_mode() {
+    python3 -c '
+import sqlite3
+import sys
+
+db = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+print(db.execute("PRAGMA journal_mode").fetchone()[0])
+' "${RPMDB_PATH}"
+}
+
+@test "checkpoint-rpmdb: converts the database to rollback-journal mode" {
+    run "${CHECKPOINT_RPMDB}"
+    [ "$status" -eq 0 ]
+
+    run journal_mode
+    [ "$status" -eq 0 ]
+    [ "$output" = "delete" ]
+}
+
+@test "checkpoint-rpmdb: removes the -shm and -wal sidecar files" {
+    # Recreate the stale-sidecar state the base images ship with.
+    touch "${RPMDB_PATH}-shm" "${RPMDB_PATH}-wal"
+
+    run "${CHECKPOINT_RPMDB}"
+    [ "$status" -eq 0 ]
+
+    [ ! -e "${RPMDB_PATH}-shm" ]
+    [ ! -e "${RPMDB_PATH}-wal" ]
+}
+
+@test "checkpoint-rpmdb: preserves the database contents" {
+    run "${CHECKPOINT_RPMDB}"
+    [ "$status" -eq 0 ]
+
+    run python3 -c '
+import sqlite3
+import sys
+
+db = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+print(db.execute("SELECT hnum, hex(blob) FROM Packages").fetchone())
+' "${RPMDB_PATH}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "(1, 'C0FFEE')" ]
+}
+
+@test "checkpoint-rpmdb: fails loudly when the database is missing" {
+    rm -f "${RPMDB_PATH}"
+
+    run "${CHECKPOINT_RPMDB}"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no rpmdb at"* ]]
+    # The failed run must not have created a stray empty database.
+    [ ! -e "${RPMDB_PATH}" ]
+}

--- a/tests/unit/containerfile_contexts_test.bats
+++ b/tests/unit/containerfile_contexts_test.bats
@@ -58,6 +58,7 @@ expected = {
     "/build_files/base/19-initramfs.sh",
     "/build_files/base/20-tests.sh",
     "/build_files/shared/build-gnome-extensions.sh",
+    "/build_files/shared/checkpoint-rpmdb.sh",
     "/build_files/shared/clean-stage.sh",
     "/build_files/shared/disable-repos.sh",
     "/build_files/shared/finalize-gnome-extensions.sh",


### PR DESCRIPTION
## Summary

Every Testing Images build since 2026-08-13 has died at the same step: the first stage that tries to read the RPM package database written by the stage before it gets back "database disk image is malformed". No image means e2e never runs, which means `:testing` stays frozen — the promotion chain that issue #995 tracks. The cause class is that the RPM database is a SQLite file in write-ahead-log (WAL) mode: after each build stage it is left with companion `-shm`/`-wal` files that the next stage's reader has to reassemble through the container layer filesystem, and in CI that reassembly breaks. This PR makes each stage leave the database as one ordinary, self-contained file (checkpoint the WAL, switch to the default journal mode, delete the sidecars), so the next stage — and the shipped image — reads a plain file with no WAL machinery involved.

## Forensics (what was eliminated)

The earlier audit note (#1136) suspected the flavor-keyed registry layer cache replaying a corrupt layer, and suggested a maintainer trigger a cache-disabled build. Full-log comparison of the last-good and first-bad runs disproves that and everything else that is pinned:

| Input | Last good build ([31607601482](https://github.com/projectbluefin/bluefin/actions/runs/31607601482), 08-12) | First malformed ([31727537250](https://github.com/projectbluefin/bluefin/actions/runs/31727537250), 08-13) |
|---|---|---|
| Runner image | ubuntu-24.04 `20260720.247.2` | identical |
| podman / buildah / crun (resolute) | 5.7.0 / 1.42.1 / 1.21 | identical |
| `projectbluefin/actions` | `370431f`→`8906e13` delta touches only sync-branches/renovate workflows | same `8906e13` |
| bluefin delta between the runs | — | only `20-tests.sh` (+9 lines, runs in Stage 2, after the failing step) |
| Base compose packages | `44.20260812.0` | `44.20260813.0` — **byte-identical `rpm -qa` set**, byte-identical shipped `-shm`/`-wal` sidecars |

Notes that correct the earlier census:

- The 08-12 run **built every stage successfully** (including extension-builder) and failed only on GHCR pushes — secondary rate limit 403s. The malformed-rpmdb signature starts 08-13.
- The registry-cache-replay theory cannot hold: the base digest is re-resolved from `silverblue:44` daily, so Stage 1's cache key changes daily and it rebuilds fresh in every failing run — seven distinct daily base digests (08-13 → 08-26) all fail identically, and run [32924887367](https://github.com/projectbluefin/bluefin/actions/runs/32924887367) (08-26) demonstrably executed Stage 1 live (new `BUILD_FILES_SHA`, full 251-package install in the log) before the child stage's read failed.

What remains after elimination: the Fedora bootc bases ship `/usr/lib/sysimage/rpm/rpmdb.sqlite` in WAL mode with stale sidecars, every dnf transaction re-enables WAL, and the failing read (`SELECT hnum, blob FROM 'Packages'` is the rpmdb Packages table) is the next stage's first open of that committed WAL state under CI's rootful buildah 1.42.1 overlay. The same image and same read succeed under rootless podman 5.8.4 locally, so the residual trigger sits in the buildah/overlay interaction with the post-0812 database bytes — not in any input this repo pins, which is why removing the WAL state at the commit boundary is the right repo-side fix regardless of which side of that interaction is ultimately at fault. (ublue-os/main builds the same bases green today; its Containerfile has no dnf-stage → dnf-stage boundary and it uses the runner's stock podman.)

## Change

- `build_files/shared/checkpoint-rpmdb.sh` — `PRAGMA wal_checkpoint(TRUNCATE)` + `PRAGMA journal_mode=DELETE`, then remove `-shm`/`-wal`; fails loudly if the rpmdb is missing (`sqlite3.connect` would otherwise silently create an empty one).
- `Containerfile` — run it as the last step of Stage 1 (`base-common`) and Stage 2, and add it to the `ctx` COPY list. Per-stage is required, not optional: a stage's own dnf write always flips the database back to WAL (observed directly).
- `tests/unit/checkpoint-rpmdb_test.bats` — real-SQLite tests: converts to rollback-journal mode, removes sidecars, preserves rows, fails without creating a stray db.
- `tests/unit/containerfile_contexts_test.bats` — expected `ctx` input set gains the new script.
- `docs/skills/ci/references/failure-modes.md` — records the corrected census and retires the cache-disabled-run experiment so nobody re-runs a settled question.

## Validation

- Two-stage build on the failing-era base (`44.20260824`, digest `c43ca97f`) with the checkpoint in place: the committed layer carries a single `rpmdb.sqlite`, the next stage reads `journal_mode=delete` with no sidecars present, and `rpm -qa` + a dnf install succeed. The corrupting condition itself only manifests under CI's builder, so the merge-queue / push build of this PR is the end-to-end test — if the fix is wrong, Testing Images stays red and nothing regresses.
- `bats tests/unit/`: 168 tests, the only failures are the two pre-existing non-hermetic framework-hook tests that #1144 fixes (they fail on any host with a real `rpm-ostree`).
- `shellcheck` clean; `python3 .github/scripts/validate-docs.py` passes.

Refs #995 (unfreezes the promotion chain; the audit's re-pointing decisions remain human-gated). Once a Testing Images run goes green, post-testing-e2e will run again and #989's AT-SPI failure becomes the next blocker in line.

— hive: backend=claude model=claude-fable-5
