### PR TITLE
fix(sec): pin coreos generator and firewalld zone fetch to sha256

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -29,13 +29,21 @@ ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
 
 # use CoreOS' generator for emergency/rescue boot
 # see detail: https://github.com/ublue-os/main/issues/653
+# Pinned to commit SHA + SHA-256 digest to prevent unverified root-at-boot execution (CWE-829 / CWE-494)
+COREOS_SULOGIN_COMMIT="682c839aabbc01564f1605bb41687a7511180031"
+COREOS_SULOGIN_SHA256="eb9222214c4647f1ed430f379dca13c3ba945a6aa7950ce6b2d5be3e0a337da1"
 mkdir -p /usr/lib/systemd/system-generators
-ghcurl "https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator" --retry 3 -Lo /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
+ghcurl "https://raw.githubusercontent.com/coreos/fedora-coreos-config/${COREOS_SULOGIN_COMMIT}/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator" --retry 3 -Lo /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
+echo "${COREOS_SULOGIN_SHA256}  /usr/lib/systemd/system-generators/coreos-sulogin-force-generator" | sha256sum -c -
 chmod +x /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 
 # Configure firewalld with Fedora Workstation defaults
 # https://src.fedoraproject.org/rpms/firewalld/blob/rawhide/f/firewalld.spec
-ghcurl "https://src.fedoraproject.org/rpms/firewalld/raw/rawhide/f/FedoraWorkstation.xml" --retry 3 -Lo /usr/lib/firewalld/zones/FedoraWorkstation.xml
+# Pinned to commit SHA + SHA-256 digest for deterministic and tamper-resistant firewall configuration
+FIREWALLD_COMMIT="4c18519ae432381e9cb18e105f0f15c46537e81c"
+FIREWALLD_ZONE_SHA256="ceb2a036759ae52b623e2d50f2d6056e698ff6ce0763cfd76ef3f6a259b1a14e"
+ghcurl "https://src.fedoraproject.org/rpms/firewalld/raw/${FIREWALLD_COMMIT}/f/FedoraWorkstation.xml" --retry 3 -Lo /usr/lib/firewalld/zones/FedoraWorkstation.xml
+echo "${FIREWALLD_ZONE_SHA256}  /usr/lib/firewalld/zones/FedoraWorkstation.xml" | sha256sum -c -
 grep -F -e '<port protocol="udp" port="1025-65535"/>' /usr/lib/firewalld/zones/FedoraWorkstation.xml
 sed -i 's|^DefaultZone=.*|DefaultZone=FedoraWorkstation|g' /etc/firewalld/firewalld.conf
 sed -i 's|^IPv6_rpfilter=.*|IPv6_rpfilter=loose|g' /etc/firewalld/firewalld.conf

--- a/tests/unit/05-override-install_test.bats
+++ b/tests/unit/05-override-install_test.bats
@@ -45,13 +45,18 @@ DefaultZone=public
 IPv6_rpfilter=yes
 EOF
 
-    # FedoraWorkstation.xml with the content the script verifies via grep
+    # FedoraWorkstation.xml with the content matching the pinned SHA-256
     cat > "${TEST_ROOT}/usr/lib/firewalld/zones/FedoraWorkstation.xml" <<'EOF'
 <?xml version="1.0" encoding="utf-8"?>
 <zone>
   <short>Fedora Workstation</short>
+  <description>Unsolicited incoming network packets are rejected from port 1 to 1024, except for select network services. Incoming packets that are related to outgoing network connections are accepted. Outgoing network connections are allowed.</description>
+  <service name="dhcpv6-client"/>
+  <service name="ssh"/>
+  <service name="samba-client"/>
   <port protocol="udp" port="1025-65535"/>
   <port protocol="tcp" port="1025-65535"/>
+  <forward/>
 </zone>
 EOF
 
@@ -67,6 +72,76 @@ EOF
     (cd "${TEST_ROOT}/fixtures/tmp-content" && tar -czf "${TEST_ROOT}/fixtures/starship.tar.gz" starship)
     VALID_SHA=$(sha256sum "${TEST_ROOT}/fixtures/starship.tar.gz" | awk '{print $1}')
     echo "${VALID_SHA}" > "${TEST_ROOT}/fixtures/starship.tar.gz.sha256"
+
+    # coreos-sulogin-force-generator fixture matching pinned SHA-256
+    cat > "${TEST_ROOT}/fixtures/coreos-sulogin-force-generator" <<'EOF'
+#!/usr/bin/bash
+
+# This systemd.generator(7) detects if rescue or emergency targets were
+# requested from the kernel cmdline; if so, it overrides the respective
+# target to set force sulogin, allowing use of rescue/emergency targets
+# on systems with locked root password (as is Fedora default).
+#
+# This does NOT bypass locked root password on a fsck failure, but WILL
+# bypass when rescue/emergency targets are chosen from kernel cmdline.
+# Since this requires console/grub access, it is assumed to be at least
+# as secure as a user reset of the root password using grub to modify
+# the kernel cmdline with init=/bin/bash .
+#
+# NOTE: the SYSTEMD_SULOGIN_FORCE method used here does not bypass any
+# assigned password; root password is only bypassed when locked/unset.
+
+export PATH="/usr/bin:/usr/sbin:${PATH}"
+if [ -n "$1" ]; then
+    # If invoked with arguments (not testing) log to kmsg
+    # https://github.com/systemd/systemd/issues/15638
+    exec 1>/dev/kmsg; exec 2>&1
+fi
+
+# If invoked with no arguments (for testing) write to /tmp
+UNIT_DIR="${1:-/tmp}"
+
+set -euo pipefail
+
+have_some_karg() {
+    local args=("$@")
+    IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
+    local i
+    for i in "${cmdline[@]}"; do
+        for a in "${args[@]}"; do
+        if [[ "$i" == "$a" ]]; then
+            return 0
+        fi
+        done
+    done
+    return 1
+}
+
+write_dropin() {
+    local service="$1"
+
+    local out_dir="${UNIT_DIR}/${service}.service.d"
+    mkdir -p "${out_dir}"
+
+    # /tmp isn't r/w yet, and the shell needs to cache the here-document
+    TMPDIR=/run
+    cat > "${out_dir}/sulogin-force.conf" <<DROPIN
+# Automatically created by coreos-sulogin-force-generator
+[Service]
+Environment=SYSTEMD_SULOGIN_FORCE=1
+DROPIN
+    echo "$(basename ${0}): set SYSTEMD_SULOGIN_FORCE=1 for ${service}.service"
+}
+
+# Match kernel command line targets for systemd(1) rescue/emergency
+# Ignores 'rd.' prefixed targets since they enter the dracut ramdisk
+# environment which does not interact with installed system root user.
+if have_some_karg 'systemd.unit=rescue.target' rescue single s S 1; then
+    write_dropin rescue
+elif have_some_karg 'systemd.unit=emergency.target' emergency '-b' ; then
+    write_dropin emergency
+fi
+EOF
 
     # ── ghcurl stub ───────────────────────────────────────────────────────
     # Serves pre-created fixtures; supports a "corrupt" mode for sha256 tests.
@@ -102,7 +177,7 @@ case "\$URL" in
         cp "${TEST_ROOT}/usr/lib/firewalld/zones/FedoraWorkstation.xml" "\$DEST"
         ;;
     *coreos-sulogin-force-generator)
-        printf '#!/bin/bash\n' > "\$DEST"
+        cp "${TEST_ROOT}/fixtures/coreos-sulogin-force-generator" "$DEST"
         ;;
     *.pdf)
         printf 'dummy-pdf\n' > "\$DEST"
@@ -120,7 +195,8 @@ GHCURL_STUB
     # Protect the coreos generator URL before path replacements mangle it.
     # The URL contains /usr/lib/systemd/system-generators which would otherwise
     # be replaced with the TEST_ROOT path, producing a malformed URL.
-    local COREOS_URL="https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator"
+    local COREOS_COMMIT="682c839aabbc01564f1605bb41687a7511180031"
+    local COREOS_URL="https://raw.githubusercontent.com/coreos/fedora-coreos-config/${COREOS_COMMIT}/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator"
     local COREOS_URL_PLACEHOLDER="COREOS_SULOGIN_GENERATOR_URL_PLACEHOLDER"
     sed \
         -e "s|${COREOS_URL}|${COREOS_URL_PLACEHOLDER}|g" \

--- a/tests/unit/05-override-install_test.bats
+++ b/tests/unit/05-override-install_test.bats
@@ -142,6 +142,8 @@ elif have_some_karg 'systemd.unit=emergency.target' emergency '-b' ; then
     write_dropin emergency
 fi
 COREOS_FIXTURE
+    [ "$(sha256sum "${TEST_ROOT}/fixtures/coreos-sulogin-force-generator" | awk '{print $1}')" = \
+        "eb9222214c4647f1ed430f379dca13c3ba945a6aa7950ce6b2d5be3e0a337da1" ]
 
     # ── ghcurl stub ───────────────────────────────────────────────────────
     # Serves pre-created fixtures; supports a "corrupt" mode for sha256 tests.

--- a/tests/unit/05-override-install_test.bats
+++ b/tests/unit/05-override-install_test.bats
@@ -74,7 +74,7 @@ EOF
     echo "${VALID_SHA}" > "${TEST_ROOT}/fixtures/starship.tar.gz.sha256"
 
     # coreos-sulogin-force-generator fixture matching pinned SHA-256
-    cat > "${TEST_ROOT}/fixtures/coreos-sulogin-force-generator" <<'EOF'
+    cat > "${TEST_ROOT}/fixtures/coreos-sulogin-force-generator" <<'COREOS_FIXTURE'
 #!/usr/bin/bash
 
 # This systemd.generator(7) detects if rescue or emergency targets were
@@ -125,11 +125,11 @@ write_dropin() {
 
     # /tmp isn't r/w yet, and the shell needs to cache the here-document
     TMPDIR=/run
-    cat > "${out_dir}/sulogin-force.conf" <<DROPIN
+    cat > "${out_dir}/sulogin-force.conf" <<EOF
 # Automatically created by coreos-sulogin-force-generator
 [Service]
 Environment=SYSTEMD_SULOGIN_FORCE=1
-DROPIN
+EOF
     echo "$(basename ${0}): set SYSTEMD_SULOGIN_FORCE=1 for ${service}.service"
 }
 
@@ -141,7 +141,7 @@ if have_some_karg 'systemd.unit=rescue.target' rescue single s S 1; then
 elif have_some_karg 'systemd.unit=emergency.target' emergency '-b' ; then
     write_dropin emergency
 fi
-EOF
+COREOS_FIXTURE
 
     # ── ghcurl stub ───────────────────────────────────────────────────────
     # Serves pre-created fixtures; supports a "corrupt" mode for sha256 tests.
@@ -177,7 +177,7 @@ case "\$URL" in
         cp "${TEST_ROOT}/usr/lib/firewalld/zones/FedoraWorkstation.xml" "\$DEST"
         ;;
     *coreos-sulogin-force-generator)
-        cp "${TEST_ROOT}/fixtures/coreos-sulogin-force-generator" "$DEST"
+        cp "${TEST_ROOT}/fixtures/coreos-sulogin-force-generator" "\$DEST"
         ;;
     *.pdf)
         printf 'dummy-pdf\n' > "\$DEST"
@@ -195,8 +195,7 @@ GHCURL_STUB
     # Protect the coreos generator URL before path replacements mangle it.
     # The URL contains /usr/lib/systemd/system-generators which would otherwise
     # be replaced with the TEST_ROOT path, producing a malformed URL.
-    local COREOS_COMMIT="682c839aabbc01564f1605bb41687a7511180031"
-    local COREOS_URL="https://raw.githubusercontent.com/coreos/fedora-coreos-config/${COREOS_COMMIT}/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator"
+    local COREOS_URL='https://raw.githubusercontent.com/coreos/fedora-coreos-config/${COREOS_SULOGIN_COMMIT}/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator'
     local COREOS_URL_PLACEHOLDER="COREOS_SULOGIN_GENERATOR_URL_PLACEHOLDER"
     sed \
         -e "s|${COREOS_URL}|${COREOS_URL_PLACEHOLDER}|g" \


### PR DESCRIPTION
## Security Fix

`build_files/base/05-override-install.sh` downloaded two remote files at image-build time from floating upstream branch HEADs with no commit pinning and no integrity verification (CWE-829 / CWE-494):

1. **`coreos-sulogin-force-generator`** (runs as root at early boot via PID 1):
   - Previously tracked `refs/heads/stable` of `coreos/fedora-coreos-config`
   - Now pinned to commit `682c839aabbc01564f1605bb41687a7511180031`
   - Verified via SHA-256 digest `eb9222214c4647f1ed430f379dca13c3ba945a6aa7950ce6b2d5be3e0a337da1`
2. **`FedoraWorkstation.xml`** (firewalld zone configuration):
   - Previously tracked `rawhide`
   - Now pinned to commit `4c18519ae432381e9cb18e105f0f15c46537e81c`
   - Verified via SHA-256 digest `ceb2a036759ae52b623e2d50f2d6056e698ff6ce0763cfd76ef3f6a259b1a14e`

Unit tests in `tests/unit/05-override-install_test.bats` have been updated to reflect the pinned URLs and verify the assets against the expected digests.

Fixes #1145

— hive: backend=goose model=gemini-3.8-flash