### PR TITLE
fix(worktree): guard against deleting branches with unpushed commits

### DIFF
--- a/.github/scripts/worktree.sh
+++ b/.github/scripts/worktree.sh
@@ -84,14 +84,55 @@ cmd_list() {
 }
 
 remove_worktree() {
-  local path="$1" branch="$2"
+  local path="$1" branch="$2" force_branch_delete="${3:-false}"
   git worktree remove "$path" --force
-  git branch -D "$branch" 2>/dev/null || true
+  if [[ "$force_branch_delete" == "true" ]]; then
+    git branch -D "$branch" 2>/dev/null || true
+  else
+    git branch -d "$branch" 2>/dev/null || true
+  fi
   echo "Removed ${path} (branch ${branch})"
 }
 
+unpushed_count() {
+  local path="$1" branch="$2"
+  local target="" ahead=""
+
+  if git -C "$path" rev-parse --verify --quiet "refs/remotes/${REMOTE}/${branch}" >/dev/null 2>&1; then
+    target="${REMOTE}/${branch}"
+  elif git -C "$path" rev-parse --verify --quiet '@{upstream}' >/dev/null 2>&1; then
+    target='@{upstream}'
+  fi
+
+  if [[ -n "$target" ]]; then
+    ahead="$(git -C "$path" rev-list --count "${target}..HEAD" 2>/dev/null || echo unknown)"
+  else
+    ahead="unknown"
+  fi
+  printf '%s' "$ahead"
+}
+
 cmd_done() {
-  local target="${1:-}"
+  local force=false
+  local target=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force|-f)
+        force=true
+        shift
+        ;;
+      *)
+        if [[ -z "$target" ]]; then
+          target="$1"
+        else
+          die "unexpected argument: $1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
   [[ -n "$target" ]] || die "usage: worktree.sh done <branch-name>"
 
   local path
@@ -106,7 +147,19 @@ cmd_done() {
 Commit or discard them first, or run: git worktree remove ${path} --force"
   fi
 
-  remove_worktree "$path" "$branch"
+  if [[ "$force" != "true" && -z "${SKIP_UNPUSHED_GUARD:-}" ]]; then
+    local ahead
+    ahead="$(unpushed_count "$path" "$branch")"
+    if [[ "$ahead" == "unknown" ]]; then
+      die "branch '${branch}' has no remote tracking branch on '${REMOTE}'.
+Push your commits first, or override with: worktree.sh done --force ${target} (or SKIP_UNPUSHED_GUARD=1)"
+    elif [[ "$ahead" -gt 0 ]]; then
+      die "worktree has ${ahead} unpushed commit(s) on '${branch}'.
+Push your commits first, or override with: worktree.sh done --force ${target} (or SKIP_UNPUSHED_GUARD=1)"
+    fi
+  fi
+
+  remove_worktree "$path" "$branch" true
 }
 
 cmd_prune() {
@@ -119,12 +172,27 @@ cmd_prune() {
 
     state="$(pr_state "$branch" || true)"
     case "$state" in
-      MERGED | CLOSED)
+      MERGED)
         if [[ -n "$(git -C "$path" status --porcelain)" ]]; then
           echo "SKIP ${path}: PR ${state} but worktree is dirty"
           continue
         fi
-        remove_worktree "$path" "$branch"
+        remove_worktree "$path" "$branch" true
+        ;;
+      CLOSED)
+        if [[ -n "$(git -C "$path" status --porcelain)" ]]; then
+          echo "SKIP ${path}: PR ${state} but worktree is dirty"
+          continue
+        fi
+        if [[ -z "${SKIP_UNPUSHED_GUARD:-}" ]]; then
+          local ahead
+          ahead="$(unpushed_count "$path" "$branch")"
+          if [[ "$ahead" == "unknown" || "$ahead" -gt 0 ]]; then
+            echo "SKIP ${path}: PR CLOSED but branch has unpushed commits (override with SKIP_UNPUSHED_GUARD=1)"
+            continue
+          fi
+        fi
+        remove_worktree "$path" "$branch" false
         ;;
       *)
         echo "KEEP ${path} (branch ${branch}, PR: ${state:-none})"
@@ -142,10 +210,10 @@ case "${1:-}" in
     cat >&2 <<'USAGE'
 usage: worktree.sh <command>
 
-  new <branch>    Create a worktree in .worktrees/ based on projectbluefin/testing
-  list            List worktrees with their PR state
-  done <branch>   Remove a worktree and delete its local branch
-  prune           Remove every worktree whose PR is merged or closed
+  new <branch>        Create a worktree in .worktrees/ based on projectbluefin/testing
+  list                List worktrees with their PR state
+  done [--force] <b..> Remove a worktree and delete its local branch
+  prune               Remove every worktree whose PR is merged or closed
 USAGE
     exit 1
     ;;

--- a/docs/skills/worktrees/SKILL.md
+++ b/docs/skills/worktrees/SKILL.md
@@ -105,6 +105,7 @@ whether a branch is finished. `worktree.sh` asks the forge via `gh` instead.
 | `worktree already exists` | Stale directory from earlier work | `worktree.sh done <branch>`, or `git worktree prune` if the directory is already gone |
 | Untracked `.worktrees/` in `git status` | Hook and ignore rules predate this setup | Confirm `.worktrees/` is in `.gitignore` |
 | Uncommitted work blocks `done` | Real changes in the worktree | Commit them, or `git worktree remove <path> --force` to discard |
+| Unpushed commits block `done` / `prune` | Branch has commits not pushed to remote | Push them, use `worktree.sh done --force <branch>`, or override with `SKIP_UNPUSHED_GUARD=1` |
 | A repo script reports zero files | It filters `.worktrees` out by path and is running inside one | Run it from the main checkout, or fix the filter to be checkout-relative |
 | `gh pr merge --delete-branch` fails locally after merging | The branch is still checked out in a worktree | The remote merge succeeded; finish with `worktree.sh done <branch>` |
 

--- a/tests/unit/worktree_test.bats
+++ b/tests/unit/worktree_test.bats
@@ -259,6 +259,52 @@ set_pr_state() {
     [ -d "${REPO}/.worktrees/fix-thing" ]
 }
 
+@test "worktree done: refuses to remove a worktree with unpushed commits" {
+    wt new fix/unpushed
+    git -C "${REPO}/.worktrees/fix-unpushed" commit --quiet --no-verify --allow-empty -m "feat: unpushed"
+
+    wt done fix/unpushed
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unpushed commit(s)"* ]]
+    [ -d "${REPO}/.worktrees/fix-unpushed" ]
+    run git -C "${REPO}" rev-parse --verify --quiet "refs/heads/fix/unpushed"
+    [ "$status" -eq 0 ]
+}
+
+@test "worktree done: removes a worktree with unpushed commits when --force is used" {
+    wt new fix/unpushed-force
+    git -C "${REPO}/.worktrees/fix-unpushed-force" commit --quiet --no-verify --allow-empty -m "feat: unpushed"
+
+    wt done --force fix/unpushed-force
+    [ "$status" -eq 0 ]
+    [ ! -d "${REPO}/.worktrees/fix-unpushed-force" ]
+    run git -C "${REPO}" rev-parse --verify --quiet "refs/heads/fix/unpushed-force"
+    [ "$status" -ne 0 ]
+}
+
+@test "worktree done: removes a worktree with unpushed commits when SKIP_UNPUSHED_GUARD=1" {
+    wt new fix/unpushed-skip
+    git -C "${REPO}/.worktrees/fix-unpushed-skip" commit --quiet --no-verify --allow-empty -m "feat: unpushed"
+
+    run bash -c "cd '${REPO}' && SKIP_UNPUSHED_GUARD=1 bash '${WORKTREE_SH}' done fix/unpushed-skip 2>&1"
+    [ "$status" -eq 0 ]
+    [ ! -d "${REPO}/.worktrees/fix-unpushed-skip" ]
+    run git -C "${REPO}" rev-parse --verify --quiet "refs/heads/fix/unpushed-skip"
+    [ "$status" -ne 0 ]
+}
+
+@test "worktree done: succeeds when commits have been pushed" {
+    wt new fix/pushed
+    git -C "${REPO}/.worktrees/fix-pushed" commit --quiet --no-verify --allow-empty -m "feat: pushed"
+    git -C "${REPO}/.worktrees/fix-pushed" push --quiet projectbluefin fix/pushed
+
+    wt done fix/pushed
+    [ "$status" -eq 0 ]
+    [ ! -d "${REPO}/.worktrees/fix-pushed" ]
+    run git -C "${REPO}" rev-parse --verify --quiet "refs/heads/fix/pushed"
+    [ "$status" -ne 0 ]
+}
+
 @test "worktree done: accepts the un-slugified branch name" {
     wt new feat/deep/nested
 
@@ -337,6 +383,47 @@ set_pr_state() {
     wt prune
     [ "$status" -eq 0 ]
     [ -d "${TEST_ROOT}/outside" ]
+}
+
+@test "worktree prune: skips a closed worktree with unpushed commits" {
+    wt new fix/closed-unpushed
+    set_pr_state fix/closed-unpushed CLOSED
+    git -C "${REPO}/.worktrees/fix-closed-unpushed" commit --quiet --no-verify --allow-empty -m "feat: closed unpushed"
+
+    wt prune
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP"* ]]
+    [[ "$output" == *"unpushed commits"* ]]
+    [ -d "${REPO}/.worktrees/fix-closed-unpushed" ]
+    run git -C "${REPO}" rev-parse --verify --quiet "refs/heads/fix/closed-unpushed"
+    [ "$status" -eq 0 ]
+}
+
+@test "worktree prune: prunes a closed worktree with unpushed commits when SKIP_UNPUSHED_GUARD=1" {
+    wt new fix/closed-unpushed-skip
+    set_pr_state fix/closed-unpushed-skip CLOSED
+    git -C "${REPO}/.worktrees/fix-closed-unpushed-skip" commit --quiet --no-verify --allow-empty -m "feat: closed unpushed"
+
+    run bash -c "cd '${REPO}' && SKIP_UNPUSHED_GUARD=1 bash '${WORKTREE_SH}' prune 2>&1"
+    [ "$status" -eq 0 ]
+    [ ! -d "${REPO}/.worktrees/fix-closed-unpushed-skip" ]
+    # Because branch -d is used on CLOSED, the unmerged branch itself is preserved safely:
+    run git -C "${REPO}" rev-parse --verify --quiet "refs/heads/fix/closed-unpushed-skip"
+    [ "$status" -eq 0 ]
+}
+
+@test "worktree prune: removes a closed worktree and preserves unmerged branch via branch -d" {
+    wt new fix/closed-pushed
+    set_pr_state fix/closed-pushed CLOSED
+    git -C "${REPO}/.worktrees/fix-closed-pushed" commit --quiet --no-verify --allow-empty -m "feat: closed pushed"
+    git -C "${REPO}/.worktrees/fix-closed-pushed" push --quiet projectbluefin fix/closed-pushed
+
+    wt prune
+    [ "$status" -eq 0 ]
+    [ ! -d "${REPO}/.worktrees/fix-closed-pushed" ]
+    # The branch was unmerged into testing, so branch -d safely keeps it:
+    run git -C "${REPO}" rev-parse --verify --quiet "refs/heads/fix/closed-pushed"
+    [ "$status" -eq 0 ]
 }
 
 @test "worktree prune: processes several worktrees in one pass" {


### PR DESCRIPTION
## Summary

Worktrees with unpushed commits previously passed existing worktree removal guards because `git status --porcelain` only checks working-tree cleanliness. As a result, `worktree.sh done` and `worktree.sh prune` (for closed PRs) force-deleted local branches with unpushed commits, risking data loss.

- Implemented an unpushed commit guard in `worktree.sh done`, checking against the branch's remote tracking reference on `projectbluefin` or `@{upstream}`.
- Added bypass mechanisms: `worktree.sh done --force <branch>` and the `SKIP_UNPUSHED_GUARD=1` environment variable.
- In `worktree.sh prune`, protected closed PR worktrees: skips them if they contain unpushed commits (unless `SKIP_UNPUSHED_GUARD=1`), and uses `git branch -d` instead of `-D` on the closed arm so git's merge status acts as a safety backstop.
- Updated `docs/skills/worktrees/SKILL.md` to document the failure mode and bypass options.
- Added comprehensive unit tests in `tests/unit/worktree_test.bats` covering unpushed, forced, and closed prune scenarios.

Closes #1163

— hive: backend=goose model=gemini-3.8-flash