### PR TITLE
test(unit): add image-variant matrix drift gate against Justfile (#1164)

### DIFF
--- a/docs/skills/variants/SKILL.md
+++ b/docs/skills/variants/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: variants
 version: "1.0"
-last_updated: 2026-08-06
+last_updated: 2026-08-30
 id: variants
 one_line_purpose: Determine the correct image, stream, flavor, branch, and target.
 entry_point: docs/skills/variants/SKILL.md
@@ -19,26 +19,47 @@ metadata:
   type: reference
   source-of-truth:
     - Justfile
-    - image-versions.yml
-    - .github/workflows/
 ---
 
 # Variants
 
+`Justfile` is the single source of the variant matrix. The `images` and
+`flavors` maps declare the axes; the `image_name` recipe derives a published
+image name from an (image, flavor) pair — the bare image name for the `main`
+flavor, `<image>-<flavor>` otherwise. `image-versions.yml` pins the *upstream*
+images the build consumes; it does not declare what this repo publishes.
+
+Every workflow that names a published variant is a restatement of that
+derivation, not an independent source:
+
+| Site | Restates |
+|---|---|
+| `.github/workflows/build-image-testing.yml` | default `image_flavors` list |
+| `.github/workflows/execute-release.yml` | `variants` matrix, digest loop, release-notes table |
+| `.github/workflows/promote-testing-to-main.yml` | `variants` matrix |
+| `.github/workflows/vulnerability-scan.yml` | `image_matrix` |
+
+`tests/unit/image_variant_matrix_test.bats` holds all of them to the Justfile
+derivation, so a variant that is built but not scanned, or promoted but not
+released, fails the unit-test gate instead of shipping.
+
 ## Procedure
 
-1. Read the image mapping in `Justfile`.
-2. Read the relevant build workflow matrix.
+1. Read the `images` and `flavors` maps in `Justfile`.
+2. Derive the published name with the `image_name` rule above.
 3. Confirm the published tag from the workflow, not memory.
 4. Use the exact image reference in commands and reports.
 
 Do not infer that a branch, stream, or flavor is published merely because a
-name appears in documentation. Update this skill when the matrix changes.
+name appears in documentation. Adding or removing a variant means editing the
+`Justfile` maps *and* every restatement site above; the gate lists whichever
+ones you missed.
 
 ## Verify
 
 ```bash
-git grep -n 'image_name\|stream\|flavor' Justfile image-versions.yml .github/workflows
+bats tests/unit/image_variant_matrix_test.bats
+git grep -n 'image_name\|stream\|flavor' Justfile .github/workflows
 just check
 ```
 

--- a/tests/unit/helpers/variant_matrix.py
+++ b/tests/unit/helpers/variant_matrix.py
@@ -1,0 +1,128 @@
+"""Derive the published image-variant set from the Justfile.
+
+The `Justfile` declares the variant axes (`images`, `flavors`, `tags`) and the
+`image_name` recipe turns an (image, flavor) pair into a published image name.
+Everything else in the repo that names a published image — the release matrix,
+the promotion matrix, the vulnerability-scan matrix, the testing-build flavor
+list — is a restatement of that derivation. This module performs the
+derivation once so `image_variant_matrix_test.bats` can hold the restatements
+to it.
+
+Nothing in the build path imports this module; it exists only for the gate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+JUSTFILE = REPO_ROOT / "Justfile"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _assoc_array(name: str, text: str) -> list[str]:
+    """Return the keys of a bash associative-array literal in the Justfile.
+
+    Matches `name := '(\\n    [key]=value\\n)'`.
+    """
+    match = re.search(rf"^{name} := '\((.*?)\)'", text, re.MULTILINE | re.DOTALL)
+    if match is None:
+        raise AssertionError(f"Justfile no longer declares a `{name}` map")
+    keys = re.findall(r"\[([^\]]+)\]=", match.group(1))
+    if not keys:
+        raise AssertionError(f"Justfile `{name}` map is empty")
+    return keys
+
+
+def images() -> list[str]:
+    return _assoc_array("images", JUSTFILE.read_text())
+
+
+def flavors() -> list[str]:
+    return _assoc_array("flavors", JUSTFILE.read_text())
+
+
+def image_name(image: str, flavor: str) -> str:
+    """Mirror of the Justfile `image_name` recipe.
+
+    `image_name` publishes the bare image name for the `main` flavor and
+    `<image>-<flavor>` for every other flavor. `assert_image_name_rule()`
+    guards this mirror against the recipe drifting away from it.
+    """
+    return image if flavor == "main" else f"{image}-{flavor}"
+
+
+def variants() -> set[str]:
+    """Every image name this repo publishes, derived from the Justfile axes."""
+    return {
+        image_name(image, flavor) for image in images() for flavor in flavors()
+    }
+
+
+def assert_image_name_rule() -> None:
+    """Fail if the Justfile `image_name` recipe stops matching `image_name()`.
+
+    The recipe is shell inside a `just` recipe body, so it cannot be executed
+    here without `just`. Instead, pin its two branches textually: any edit to
+    the naming rule must also update this module and the expectations that
+    depend on it.
+    """
+    text = JUSTFILE.read_text()
+    match = re.search(
+        r"^image_name image=.*?\n(.*?)(?=\n# )", text, re.MULTILINE | re.DOTALL
+    )
+    if match is None:
+        raise AssertionError("Justfile no longer declares an `image_name` recipe")
+    body = match.group(1)
+    expected = [
+        r'if \[\[ "\{\{ flavor \}\}" =~ main \]\]; then',
+        r"image_name=\{\{ image \}\}",
+        r'image_name="\{\{ image \}\}-\{\{ flavor \}\}"',
+    ]
+    missing = [pattern for pattern in expected if not re.search(pattern, body)]
+    if missing:
+        raise AssertionError(
+            "Justfile `image_name` recipe no longer matches "
+            f"helpers/variant_matrix.py:image_name(); missing {missing}"
+        )
+
+
+def workflow(name: str) -> str:
+    path = WORKFLOWS / name
+    if not path.is_file():
+        raise AssertionError(f"missing workflow {name}")
+    return path.read_text()
+
+
+def json_field_values(text: str, field: str) -> set[str]:
+    """Collect every `"<field>":"<value>"` occurrence in a workflow body."""
+    return set(re.findall(rf'"{field}"\s*:\s*"([^"]+)"', text))
+
+
+def json_literal_after(text: str, marker: str) -> object:
+    """Parse the first JSON array literal appearing after `marker`."""
+    index = text.find(marker)
+    if index < 0:
+        raise AssertionError(f"marker not found: {marker!r}")
+    start = text.find("[", index)
+    if start < 0:
+        raise AssertionError(f"no JSON array after marker: {marker!r}")
+    depth = 0
+    for offset in range(start, len(text)):
+        if text[offset] == "[":
+            depth += 1
+        elif text[offset] == "]":
+            depth -= 1
+            if depth == 0:
+                return json.loads(text[start : offset + 1])
+    raise AssertionError(f"unterminated JSON array after marker: {marker!r}")
+
+
+def compare(actual: set[str], expected: set[str], site: str) -> None:
+    if actual != expected:
+        raise AssertionError(
+            f"{site} disagrees with the Justfile variant matrix; "
+            f"missing={sorted(expected - actual)} extra={sorted(actual - expected)}"
+        )

--- a/tests/unit/image_variant_matrix_test.bats
+++ b/tests/unit/image_variant_matrix_test.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+#
+# Gate: the published image-variant set is derived once, in the Justfile.
+#
+# `Justfile` declares the variant axes (`images`, `flavors`) and the
+# `image_name` recipe turns a pair into a published image name. Five other
+# sites restate the resulting set as literals. Nothing built the two together,
+# so a new flavor could ship built-but-unscanned, or promoted-but-unreleased.
+# These tests hold every restatement to the Justfile derivation.
+#
+# Sites covered:
+#   .github/workflows/build-image-testing.yml   default image_flavors list
+#   .github/workflows/execute-release.yml       variants matrix
+#   .github/workflows/execute-release.yml       `for image in ...` digest loop
+#   .github/workflows/execute-release.yml       release-notes variants table
+#   .github/workflows/promote-testing-to-main.yml   variants matrix
+#   .github/workflows/vulnerability-scan.yml    image_matrix
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+HELPERS="${SCRIPT_DIR}/helpers"
+
+@test "Justfile image_name recipe still matches the derivation helper" {
+    run python3 -c '
+import sys
+sys.path.insert(0, sys.argv[1])
+import variant_matrix as vm
+
+vm.assert_image_name_rule()
+if not vm.images() or not vm.flavors():
+    raise SystemExit("Justfile variant axes are empty")
+' "${HELPERS}"
+
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "build-image-testing.yml default flavor list matches Justfile flavors" {
+    run python3 -c '
+import sys
+sys.path.insert(0, sys.argv[1])
+import variant_matrix as vm
+
+text = vm.workflow("build-image-testing.yml")
+declared = vm.json_literal_after(text, "|| ")
+vm.compare(set(declared), set(vm.flavors()), "build-image-testing.yml image_flavors default")
+' "${HELPERS}"
+
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "execute-release.yml variants matrix matches the Justfile variant set" {
+    run python3 -c '
+import sys
+sys.path.insert(0, sys.argv[1])
+import variant_matrix as vm
+
+text = vm.workflow("execute-release.yml")
+vm.compare(vm.json_field_values(text, "image"), vm.variants(),
+           "execute-release.yml variants matrix")
+' "${HELPERS}"
+
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "execute-release.yml digest loop iterates the Justfile variant set" {
+    run python3 -c '
+import re
+import sys
+sys.path.insert(0, sys.argv[1])
+import variant_matrix as vm
+
+text = vm.workflow("execute-release.yml")
+match = re.search(r"for image in ([^;]+); do", text)
+if match is None:
+    raise SystemExit("execute-release.yml no longer has a `for image in ...` digest loop")
+vm.compare(set(match.group(1).split()), vm.variants(),
+           "execute-release.yml digest loop")
+' "${HELPERS}"
+
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "execute-release.yml release-notes table names every variant" {
+    run python3 -c '
+import re
+import sys
+sys.path.insert(0, sys.argv[1])
+import variant_matrix as vm
+
+text = vm.workflow("execute-release.yml")
+start = text.find("## Variants promoted")
+if start < 0:
+    raise SystemExit("execute-release.yml no longer prepends a variants table")
+end = text.find("printf", start)
+table = text[start:end if end > start else len(text)]
+rows = set(re.findall(r"\| \\`([a-z0-9.-]+)\\` \| \\`:", table))
+vm.compare(rows, vm.variants(), "execute-release.yml release-notes variants table")
+' "${HELPERS}"
+
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "promote-testing-to-main.yml variants matrix matches the Justfile variant set" {
+    run python3 -c '
+import sys
+sys.path.insert(0, sys.argv[1])
+import variant_matrix as vm
+
+text = vm.workflow("promote-testing-to-main.yml")
+vm.compare(vm.json_field_values(text, "image"), vm.variants(),
+           "promote-testing-to-main.yml variants matrix")
+' "${HELPERS}"
+
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "vulnerability-scan.yml image_matrix matches the Justfile variant set" {
+    run python3 -c '
+import sys
+sys.path.insert(0, sys.argv[1])
+import variant_matrix as vm
+
+text = vm.workflow("vulnerability-scan.yml")
+vm.compare(vm.json_field_values(text, "image_name"), vm.variants(),
+           "vulnerability-scan.yml image_matrix")
+' "${HELPERS}"
+
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}


### PR DESCRIPTION
## Summary

The published image-variant set is derivable from the `Justfile` `images` and `flavors` maps via the `image_name` recipe, but is restated as literals across six workflow sites without drift validation. A missed site could silently build an image without scanning it, or promote without releasing it.

This PR adds a drift gate against the single source of truth:
- Adds `tests/unit/helpers/variant_matrix.py`: derives the variant set from `Justfile`, mirrors the `image_name` recipe, and verifies the recipe contract.
- Adds `tests/unit/image_variant_matrix_test.bats`: checks all six workflow restatements against the derived matrix:
  - `.github/workflows/build-image-testing.yml` (default `image_flavors` list)
  - `.github/workflows/execute-release.yml` (`variants` matrix, `for image in ...` digest loop, and release-notes variants table)
  - `.github/workflows/promote-testing-to-main.yml` (`variants` matrix)
  - `.github/workflows/vulnerability-scan.yml` (`image_matrix`)
- Updates `docs/skills/variants/SKILL.md` to establish `Justfile` as the single source of truth and document the test gate.

Fixes #1164

— hive: backend=goose model=gemini-3.8-flash
