### PR TITLE
test(unit): add BATS coverage for build.sh and profile.d scripts (#1176)

### DIFF
--- a/tests/unit/build_test.bats
+++ b/tests/unit/build_test.bats
@@ -65,7 +65,7 @@ EOF
         cat > "${stage_path}" << EOF
 #!/usr/bin/bash
 echo "${stage}" >> "${STAGE_LOG}"
-if [[ -n "${FAIL_STAGE:-}" && "${FAIL_STAGE}" == "${stage}" ]]; then
+if [[ -n "\${FAIL_STAGE:-}" && "\${FAIL_STAGE}" == "${stage}" ]]; then
     exit 1
 fi
 exit 0
@@ -113,7 +113,7 @@ teardown() {
     run cat "${STAGE_LOG}"
     [ "$status" -eq 0 ]
     [ "${lines[-1]}" = "base/05-override-install.sh" ]
-    refute_line --output "${output}" "base/17-cleanup.sh"
+    [[ "${output}" != *"base/17-cleanup.sh"* ]]
 }
 
 @test "build.sh: fails immediately if dnf5 config-manager fails" {

--- a/tests/unit/build_test.bats
+++ b/tests/unit/build_test.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# Unit tests for build_files/shared/build.sh
+# Run with: bats tests/unit/build_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_SCRIPT="${REPO_ROOT}/build_files/shared/build.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/build.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    STAGE_LOG="${TEST_ROOT}/stage.log"
+    mkdir -p "${STUB_BIN}"
+    mkdir -p "${TEST_ROOT}/ctx/system_files/shared"
+    mkdir -p "${TEST_ROOT}/ctx/build_files/shared/utils"
+    touch "${TEST_ROOT}/ctx/build_files/shared/utils/ghcurl"
+
+    ORIG_PATH="${PATH}"
+    export PATH="${STUB_BIN}:${PATH}"
+    export STAGE_LOG
+
+    # Stub commands used in build.sh
+    cat > "${STUB_BIN}/dnf5" << 'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/dnf5"
+
+    cat > "${STUB_BIN}/rpm" << 'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm"
+
+    cat > "${STUB_BIN}/rsync" << 'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rsync"
+
+    cat > "${STUB_BIN}/install" << 'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/install"
+
+    # Create mock stage scripts that log their invocation
+    MOCK_STAGES=(
+        "base/00-image-info.sh"
+        "base/03-packages.sh"
+        "base/04-install-kernel-akmods.sh"
+        "base/05-override-install.sh"
+        "shared/build-gnome-extensions.sh"
+        "base/17-cleanup.sh"
+        "base/18-workarounds.sh"
+        "base/19-initramfs.sh"
+        "shared/validate-repos.sh"
+        "shared/clean-stage.sh"
+        "base/20-tests.sh"
+    )
+
+    for stage in "${MOCK_STAGES[@]}"; do
+        stage_path="${TEST_ROOT}/ctx/build_files/${stage}"
+        mkdir -p "$(dirname "${stage_path}")"
+        cat > "${stage_path}" << EOF
+#!/usr/bin/bash
+echo "${stage}" >> "${STAGE_LOG}"
+if [[ -n "${FAIL_STAGE:-}" && "${FAIL_STAGE}" == "${stage}" ]]; then
+    exit 1
+fi
+exit 0
+EOF
+        chmod +x "${stage_path}"
+    done
+
+    # Prepare patched build.sh pointing /ctx to TEST_ROOT/ctx and /tmp to TEST_ROOT/tmp
+    PATCHED_SCRIPT="${TEST_ROOT}/build-patched.sh"
+    sed -e "s|/ctx|${TEST_ROOT}/ctx|g"         -e "s|/tmp|${TEST_ROOT}/tmp|g"         "${BUILD_SCRIPT}" > "${PATCHED_SCRIPT}"
+    chmod +x "${PATCHED_SCRIPT}"
+}
+
+teardown() {
+    export PATH="${ORIG_PATH}"
+    rm -rf "${TEST_ROOT}"
+}
+
+@test "build.sh: executes build stages in exact expected sequence" {
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -eq 0 ]
+
+    # Verify every stage ran in exact order
+    run cat "${STAGE_LOG}"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "base/00-image-info.sh" ]
+    [ "${lines[1]}" = "base/03-packages.sh" ]
+    [ "${lines[2]}" = "base/04-install-kernel-akmods.sh" ]
+    [ "${lines[3]}" = "base/05-override-install.sh" ]
+    [ "${lines[4]}" = "shared/build-gnome-extensions.sh" ]
+    [ "${lines[5]}" = "base/17-cleanup.sh" ]
+    [ "${lines[6]}" = "base/18-workarounds.sh" ]
+    [ "${lines[7]}" = "base/19-initramfs.sh" ]
+    [ "${lines[8]}" = "shared/validate-repos.sh" ]
+    [ "${lines[9]}" = "shared/clean-stage.sh" ]
+    [ "${lines[10]}" = "base/20-tests.sh" ]
+}
+
+@test "build.sh: fails immediately if a stage fails" {
+    export FAIL_STAGE="base/05-override-install.sh"
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+
+    # Subsequent stages should not have run
+    run cat "${STAGE_LOG}"
+    [ "$status" -eq 0 ]
+    [ "${lines[-1]}" = "base/05-override-install.sh" ]
+    refute_line --output "${output}" "base/17-cleanup.sh"
+}
+
+@test "build.sh: fails immediately if dnf5 config-manager fails" {
+    cat > "${STUB_BIN}/dnf5" << 'EOF'
+#!/usr/bin/bash
+exit 2
+EOF
+    chmod +x "${STUB_BIN}/dnf5"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "$status" -ne 0 ]
+    [ ! -f "${STAGE_LOG}" ]
+}

--- a/tests/unit/profile_d_test.bats
+++ b/tests/unit/profile_d_test.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# Unit tests for system_files/shared/etc/profile.d/ scripts:
+#   - 90-bluefin-starship.sh
+#   - 91-bluefin-aliases.sh
+# Run with: bats tests/unit/profile_d_test.bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STARSHIP_SCRIPT="${REPO_ROOT}/system_files/shared/etc/profile.d/90-bluefin-starship.sh"
+ALIASES_SCRIPT="${REPO_ROOT}/system_files/shared/etc/profile.d/91-bluefin-aliases.sh"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/profile_d.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/bin"
+    mkdir -p "${STUB_BIN}"
+    ORIG_PATH="${PATH}"
+    export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+    export PATH="${ORIG_PATH}"
+    rm -rf "${TEST_ROOT}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 90-bluefin-starship.sh tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "90-bluefin-starship: no-op when starship is absent from PATH and brew" {
+    run bash -c "source '${STARSHIP_SCRIPT}'; echo 'SOURCE_EXIT_OK'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "SOURCE_EXIT_OK" ]]
+}
+
+@test "90-bluefin-starship: initializes starship when starship is on PATH in bash" {
+    cat > "${STUB_BIN}/starship" << 'EOF'
+#!/usr/bin/bash
+if [ "$1" = "init" ] && [ "$2" = "bash" ]; then
+    echo "export STARSHIP_INIT_CALLED=1"
+fi
+EOF
+    chmod +x "${STUB_BIN}/starship"
+
+    run bash -c "source '${STARSHIP_SCRIPT}'; echo "VAL=\$STARSHIP_INIT_CALLED""
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "VAL=1" ]]
+}
+
+@test "90-bluefin-starship: initializes starship from linuxbrew when not on PATH" {
+    BREW_BIN="${TEST_ROOT}/var/home/linuxbrew/.linuxbrew/bin"
+    mkdir -p "${BREW_BIN}"
+    cat > "${BREW_BIN}/starship" << 'EOF'
+#!/usr/bin/bash
+if [ "$1" = "init" ] && [ "$2" = "bash" ]; then
+    echo "export STARSHIP_BREW_INIT_CALLED=1"
+fi
+EOF
+    chmod +x "${BREW_BIN}/starship"
+
+    PATCHED_STARSHIP="${TEST_ROOT}/90-bluefin-starship.sh"
+    sed "s|/var/home/linuxbrew/.linuxbrew/bin/starship|${BREW_BIN}/starship|g"         "${STARSHIP_SCRIPT}" > "${PATCHED_STARSHIP}"
+
+    run bash -c "source '${PATCHED_STARSHIP}'; echo "VAL=\$STARSHIP_BREW_INIT_CALLED""
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "VAL=1" ]]
+}
+
+@test "90-bluefin-starship: does not call starship init if shell is not bash" {
+    cat > "${STUB_BIN}/starship" << 'EOF'
+#!/usr/bin/bash
+echo "export STARSHIP_INIT_CALLED=1"
+EOF
+    chmod +x "${STUB_BIN}/starship"
+
+    PATCHED_STARSHIP="${TEST_ROOT}/90-bluefin-starship-nonbash.sh"
+    sed 's/"bash"/"zsh"/g' "${STARSHIP_SCRIPT}" > "${PATCHED_STARSHIP}"
+
+    run bash -c "source '${PATCHED_STARSHIP}'; echo "VAL=\${STARSHIP_INIT_CALLED:-0}""
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "VAL=0" ]]
+}
+
+@test "90-bluefin-starship: unsets _starship_bin after sourcing" {
+    cat > "${STUB_BIN}/starship" << 'EOF'
+#!/usr/bin/bash
+echo ""
+EOF
+    chmod +x "${STUB_BIN}/starship"
+
+    run bash -c "source '${STARSHIP_SCRIPT}'; echo "BIN=\${_starship_bin:-UNSET}""
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "BIN=UNSET" ]]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 91-bluefin-aliases.sh tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@test "91-bluefin-aliases: rl alias is set when ramalama exists" {
+    cat > "${STUB_BIN}/ramalama" << 'EOF'
+#!/usr/bin/bash
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/ramalama"
+
+    run bash -c "shopt -s expand_aliases; source '${ALIASES_SCRIPT}'; alias rl"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "alias rl='ramalama'" ]]
+}
+
+@test "91-bluefin-aliases: rl alias is not set when ramalama is absent" {
+    run bash -c "shopt -s expand_aliases; source '${ALIASES_SCRIPT}'; alias rl 2>&1"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "not found" ]]
+}


### PR DESCRIPTION
## Summary
Adds BATS unit tests in `tests/unit/` for scripts highlighted in #1176 that had zero test coverage:
- `build_files/shared/build.sh` -> `tests/unit/build_test.bats`
- `system_files/shared/etc/profile.d/90-bluefin-starship.sh` and `91-bluefin-aliases.sh` -> `tests/unit/profile_d_test.bats`

## Coverage
- **`tests/unit/build_test.bats`**:
  - Sandboxes `build.sh` and stubs `dnf5`, `rpm`, `rsync`, `install`.
  - Mocks stage scripts and asserts exact execution order.
  - Verifies immediate failure propagation when any stage exits non-zero.
  - Verifies failure propagation when initial configuration commands fail.
- **`tests/unit/profile_d_test.bats`**:
  - Verifies `90-bluefin-starship.sh` no-op when starship is absent.
  - Verifies PATH-based starship initialization in bash.
  - Verifies fallback to Linuxbrew bin location when not in PATH.
  - Verifies starship init is skipped if shell is not bash.
  - Verifies cleanup of intermediate environment variables (`_starship_bin`).
  - Verifies `91-bluefin-aliases.sh` configures `rl` alias only when `ramalama` binary is present.

## Validation
- Ran tests via test harness: 10/10 test assertions pass.
- `python3 -m unittest discover -s tests -p 'test_*.py'`: 60 tests passed.
- `just check`: syntax clean.

Closes #1176

— hive: backend=goose model=gemini-3.8-flash