### PR TITLE
ci: add top-level least-privilege permissions to moderator.yml

### DIFF
--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -7,6 +7,9 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   spam-detection:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Closes #1050

`.github/workflows/moderator.yml` had no top-level `permissions:` block. While the `spam-detection` job already declares its own explicit permissions, adding a restrictive top-level default (`contents: read`) ensures any future job added to this workflow starts from least-privilege rather than inheriting the repository default `GITHUB_TOKEN` scope (which may be broader, including write access).

## Change
Added:
```yaml
permissions:
  contents: read
```
at the workflow level, above the existing job-level permissions block (which is left untouched since it already follows least-privilege for its specific needs).

## Note on base branch
This task's instructions referenced a `v4` branch, but no such branch exists in the upstream repository (only `main` and various topic branches). This PR is opened against `main`, the repository's actual default branch.

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `218ab9c`