### PR TITLE
ci: upload BATS coverage to Codecov

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -215,6 +215,15 @@ jobs:
           }
           echo "PASS: coverage ${PCT}% >= ${THRESHOLD}%"
 
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/kcov/cobertura.xml
+          flags: bats
+          fail_ci_if_error: false
+
       - name: Upload TAP results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: false
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: false
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

Closes #1062.

BATS coverage is generated via kcov on every PR (`pr-validation.yml`) but was never uploaded anywhere for trend tracking — only a step-summary snippet and a raw artifact. This adds Codecov integration:

- Added `codecov.yml` at repo root with an 80% target and 1% threshold (non-informational, so it enforces PR/patch coverage checks).
- Added a `codecov/codecov-action` step in `pr-validation.yml`, right after the existing coverage-threshold enforcement step, uploading the generated `coverage/kcov/cobertura.xml` Cobertura report. Uses `fail_ci_if_error: false` so a Codecov outage can't block merges, and reads `secrets.CODECOV_TOKEN` (needs to be configured as a repo secret for uploads to succeed on this public repo).

## Why

- Gives PR diff coverage comments from the Codecov bot.
- Enables historical coverage trend tracking instead of only a per-run floor check.
- The existing 30%/45%-style in-workflow threshold check is left untouched; Codecov's own project/patch thresholds are additive, not a replacement.

## Notes

- Requires a `CODECOV_TOKEN` secret to be added to the repo for the upload step to authenticate (standard for private orgs / to avoid rate limits on public repos).

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `ae03fa9`