### PR TITLE
fix(scanner): make framework AMD kargs cleanup retry-safe on failure

### DIFF
--- a/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh
+++ b/system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh
@@ -8,17 +8,35 @@
 # This is a one-time migration cleanup. The kernel driver fix for battery
 # charge threshold control on AMD Framework is in fw-charge-control.conf
 # (bluefin#879); this script only removes a stale karg side-effect.
+#
+# NOTE (bluefin#1126): version-script records a migration as "complete" the
+# moment it is called, before this script's body runs. A naive
+# `version-script ... || exit 0` guard at the top would mark the migration
+# done even if rpm-ostree is unavailable or the karg deletion fails, so a
+# failed attempt would never be retried on a later boot. To stay
+# retry-safe, completion is tracked with our own on-disk marker that is
+# only written after the migration has actually succeeded (or has been
+# determined not to apply), and version-script is invoked afterwards purely
+# to keep the shared setup-versioning ledger in sync.
 
 # shellcheck source=/dev/null
 source /usr/lib/ublue/setup-services/libsetup.sh
 
-version-script framework-amd-kargs-cleanup privileged 1 || exit 0
+STATE_FILE="/var/lib/ublue-os/.framework-amd-kargs-cleanup-v1"
+
+[[ -e "${STATE_FILE}" ]] && exit 0
 
 set -euo pipefail
 
 VENDOR_PATH="/sys/devices/virtual/dmi/id/chassis_vendor"
 PRODUCT_PATH="/sys/devices/virtual/dmi/id/product_name"
 STALE_KARG="module_blacklist=hid_sensor_hub"
+
+mark_done() {
+    mkdir -p "$(dirname "${STATE_FILE}")"
+    touch "${STATE_FILE}"
+    version-script framework-amd-kargs-cleanup privileged 1 || true
+}
 
 if [[ ! -r "${VENDOR_PATH}" || ! -r "${PRODUCT_PATH}" ]]; then
     echo "Framework AMD kargs cleanup: DMI information not available, skipping."
@@ -28,13 +46,20 @@ fi
 vendor="$(<"${VENDOR_PATH}")"
 product_name="$(<"${PRODUCT_PATH}")"
 
-# Only run on Framework hardware
-[[ "${vendor}" == "Framework" ]] || exit 0
+# Only run on Framework hardware. Non-Framework vendor is a permanent
+# condition, so it's safe to record completion.
+if [[ "${vendor}" != "Framework" ]]; then
+    mark_done
+    exit 0
+fi
 
 # Positive AMD match: only act on Framework laptops that name AMD in the product
 # string.  This avoids mutating boot config on Intel or future unknown Framework
-# hardware.
-[[ "${product_name}" =~ AMD ]] || exit 0
+# hardware. Also a permanent condition, safe to record completion.
+if [[ ! "${product_name}" =~ AMD ]]; then
+    mark_done
+    exit 0
+fi
 
 if ! command -v rpm-ostree >/dev/null 2>&1; then
     echo "Warning: rpm-ostree not found; unable to clean up stale AMD Framework kargs."
@@ -43,8 +68,14 @@ fi
 
 if ! rpm-ostree kargs | grep -Fq "${STALE_KARG}"; then
     echo "AMD Framework: ${STALE_KARG} not present — nothing to do."
+    mark_done
     exit 0
 fi
 
-rpm-ostree kargs --delete="${STALE_KARG}"
-echo "Removed stale AMD Framework karg: ${STALE_KARG}. Reboot to activate."
+if rpm-ostree kargs --delete="${STALE_KARG}"; then
+    echo "Removed stale AMD Framework karg: ${STALE_KARG}. Reboot to activate."
+    mark_done
+else
+    echo "Failed to remove stale AMD Framework karg; will retry on next boot." >&2
+    exit 1
+fi

--- a/tests/unit/12-framework-amd-kargs-cleanup_test.bats
+++ b/tests/unit/12-framework-amd-kargs-cleanup_test.bats
@@ -28,6 +28,7 @@ EOF
         -e "s|source /usr/lib/ublue/setup-services/libsetup.sh|version-script() { return 0; }|g" \
         -e "s|/sys/devices/virtual/dmi/id/chassis_vendor|${TEST_ROOT}/chassis_vendor|g" \
         -e "s|/sys/devices/virtual/dmi/id/product_name|${TEST_ROOT}/product_name|g" \
+        -e "s|/var/lib/ublue-os/.framework-amd-kargs-cleanup-v1|${TEST_ROOT}/framework-amd-kargs-cleanup-v1|g" \
         "${HOOK_SCRIPT}" > "${PATCHED_SCRIPT}"
     chmod +x "${PATCHED_SCRIPT}"
     export PATCHED_SCRIPT TEST_ROOT STUB_BIN
@@ -151,4 +152,64 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"DMI information not available"* ]]
+}
+
+@test "12-framework-amd-kargs-cleanup: failed deletion is not marked complete and retries" {
+    # Stub: kargs reports the stale entry, but --delete fails (e.g. rpm-ostree
+    # temporarily unavailable). bluefin#1126: a failed migration must not be
+    # recorded as done, so a subsequent boot retries it.
+    cat > "${STUB_BIN}/rpm-ostree" <<'EOF'
+#!/usr/bin/bash
+echo "rpm-ostree $*" >> "${STUB_BIN}/rpm-ostree.log"
+if [[ "$1" == "kargs" && "$#" -eq 1 ]]; then
+    echo "quiet rhgb module_blacklist=hid_sensor_hub"
+    exit 0
+fi
+if [[ "$1" == "kargs" && "$2" == --delete=* ]]; then
+    exit 1
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm-ostree"
+
+    echo "Framework" > "${TEST_ROOT}/chassis_vendor"
+    echo "Laptop 13 (AMD Ryzen 7040 Series)" > "${TEST_ROOT}/product_name"
+
+    # First (failing) invocation
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"will retry on next boot"* ]]
+    [ ! -f "${TEST_ROOT}/framework-amd-kargs-cleanup-v1" ]
+
+    # Second invocation with a working rpm-ostree simulates a later boot retry
+    cat > "${STUB_BIN}/rpm-ostree" <<'EOF'
+#!/usr/bin/bash
+echo "rpm-ostree $*" >> "${STUB_BIN}/rpm-ostree.log"
+if [[ "$1" == "kargs" && "$#" -eq 1 ]]; then
+    echo "quiet rhgb module_blacklist=hid_sensor_hub"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/rpm-ostree"
+
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Removed stale AMD Framework karg"* ]]
+    [ -f "${TEST_ROOT}/framework-amd-kargs-cleanup-v1" ]
+    grep -q "kargs --delete=module_blacklist=hid_sensor_hub" "${STUB_BIN}/rpm-ostree.log"
+}
+
+@test "12-framework-amd-kargs-cleanup: already-marked complete skips without checking hardware" {
+    mkdir -p "$(dirname "${TEST_ROOT}/framework-amd-kargs-cleanup-v1")"
+    touch "${TEST_ROOT}/framework-amd-kargs-cleanup-v1"
+
+    # No DMI files present at all; if the marker guard works, the script
+    # returns before ever reading them.
+    run bash "${PATCHED_SCRIPT}"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "${STUB_BIN}/rpm-ostree.log" ]
 }


### PR DESCRIPTION
## Problem

Fixes #1126.

PR #1103 added a one-time privileged hook that removes the stale
`module_blacklist=hid_sensor_hub` karg from AMD Framework laptops. The
hook called `version-script` *before* attempting the
`rpm-ostree kargs --delete`. Looking at `version-script`'s
implementation (`ublue-setup-services`'s `libsetup.sh`), it records the
target version as complete on the *call itself*, not on the success of
the code that follows. So if `rpm-ostree` is temporarily unavailable or
the deletion otherwise fails, the hook exits non-zero, but the
migration is already marked complete — subsequent boots see the
version as done and skip the hook forever, leaving the stale karg in
the boot configuration.

## Fix

`system_files/shared/usr/share/ublue-os/privileged-setup.hooks.d/12-framework-amd-kargs-cleanup.sh`
now tracks completion with its own on-disk marker
(`/var/lib/ublue-os/.framework-amd-kargs-cleanup-v1`) that is only
written after the migration has actually succeeded, or after
determining it doesn't apply (non-Framework/non-AMD hardware, or the
karg is already absent). `version-script` is still called, but only
after that marker is written, so the shared setup-versioning ledger
stays in sync without ever recording a failed attempt as done.

If the karg deletion itself fails, the hook now exits non-zero without
writing the marker, so it will be retried on the next boot.

## Tests

`tests/unit/12-framework-amd-kargs-cleanup_test.bats` adds:
- A test that simulates a failing `rpm-ostree kargs --delete`, confirms
  the marker is not written and the hook reports it will retry, then
  simulates a subsequent successful boot and confirms the karg is
  removed and the marker is written.
- A test confirming that once the marker exists, the hook skips
  without re-checking hardware.

All 10 tests in the file pass locally with `bats`, and the script is
clean under `shellcheck`.

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `f938ab6`