### PR TITLE
fix(ci): correct jq quoting in cache maintenance workflow

### DIFF
--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -84,7 +84,7 @@ jobs:
           if [[ ${TOTAL_CACHES} -eq 0 ]]; then
             summary "| _No caches found_ | - | - | - |"
           else
-            echo "${ALL_CACHES}" | jq -r 'sort_by(.size_in_bytes) | reverse | .[] | "| \(.key[0:60]) | \(.size_in_bytes / 1024 / 1024 | floor) MB | \(.ref // \"?\") | \(.last_accessed_at // \"never\") |"' >> "$GITHUB_STEP_SUMMARY"
+            echo "${ALL_CACHES}" | jq -r 'sort_by(.size_in_bytes) | reverse | .[] | "| \(.key[0:60]) | \(.size_in_bytes / 1024 / 1024 | floor) MB | \(.ref // "?") | \(.last_accessed_at // "never") |"' >> "$GITHUB_STEP_SUMMARY"
           fi
 
           ACTIVE_REFS=$(gh api \


### PR DESCRIPTION
## Summary

Fixes #1130

The **Cache Maintenance** workflow's cache inventory summary step failed with:

```
jq: error: syntax error, unexpected INVALID_CHARACTER
```

## Root cause

The jq filter used escaped double quotes (`\"`) inside a **single-quoted** shell string:

```bash
jq -r '... \(.ref // "?") ... \(.last_accessed_at // "never") ...'
```

Single quotes in bash do not process backslash escapes, so `\"` was passed to jq literally as a backslash followed by a double quote — invalid jq syntax. This caused the job to exit 3 before rendering the cache inventory table, so the pruning logic never ran.

## Fix

Remove the unnecessary backslash-escaping since the string is already single-quoted:

```bash
jq -r '... \(.ref // "?") ... \(.last_accessed_at // "never") ...'
```
(now using plain `"?"` / `"never"`)

## Verification

Ran the corrected jq filter locally against sample cache-inventory JSON (including a cache with null `ref`/`last_accessed_at` to exercise the `//` fallback) and confirmed it renders the markdown table correctly with no syntax errors.

Note: this repository does not currently have a `v4` branch, so this PR targets `main`, the repository's actual default branch.

---
— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `3fc5d09`