### PR TITLE
fix(sec): pin Anaconda install payload to a digest, not :stable

### DIFF
--- a/build_files/base/21-container-native-iso.sh
+++ b/build_files/base/21-container-native-iso.sh
@@ -13,6 +13,36 @@ IMAGE_REF="$(jq -r '."image-ref"' "${IMAGE_INFO}")"
 IMAGE_REF="${IMAGE_REF##*://}"
 INSTALL_IMAGE="${IMAGE_REF}:stable"
 
+# Resolve the mutable `:stable` tag to an immutable digest at ISO build time,
+# so the initial Anaconda ostreecontainer payload pull is content-addressed
+# and cannot be swapped for different content by a compromised registry or a
+# network attacker, independent of --no-signature-verification below. This is
+# a best-effort resolution: if it fails (e.g. registry hiccup, first-ever
+# build with no published `:stable` tag yet), fall back to the mutable tag —
+# the subsequent `bootc switch --enforce-container-sigpolicy` %post script
+# still enforces signature policy on the final deployment.
+resolve_stable_digest() {
+    local repo="$1" tag="$2" token digest
+    token="$(ghcurl "https://ghcr.io/token?scope=repository:${repo}:pull" |
+        jq -r '.token // empty')" || return 1
+    [[ -n "${token}" ]] || return 1
+    digest="$(curl -sSL --fail \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+        -D - -o /dev/null \
+        "https://ghcr.io/v2/${repo}/manifests/${tag}" |
+        tr -d '\r' | awk -F': ' 'tolower($1) == "docker-content-digest" {print $2}')" || return 1
+    [[ "${digest}" == sha256:* ]] || return 1
+    echo "${digest}"
+}
+
+if STABLE_DIGEST="$(resolve_stable_digest "${IMAGE_REF#ghcr.io/}" "stable")"; then
+    INSTALL_IMAGE="${IMAGE_REF}@${STABLE_DIGEST}"
+    echo "Pinned Anaconda install payload to ${INSTALL_IMAGE}"
+else
+    echo "::warning::Could not resolve a digest for ${INSTALL_IMAGE}; the initial Anaconda payload pull will use the mutable :stable tag." >&2
+fi
+
 mkdir -p \
     "${ROOT}/boot/efi/EFI" \
     "${ROOT}/etc/anaconda/profile.d" \

--- a/tests/unit/21-container-native-iso_test.bats
+++ b/tests/unit/21-container-native-iso_test.bats
@@ -74,6 +74,7 @@ EOF
     cat >"${STUB_BIN}/ghcurl" <<'EOF'
 #!/usr/bin/bash
 destination=""
+url="$1"
 while (($#)); do
     case "$1" in
         -o|-Lo)
@@ -85,8 +86,33 @@ while (($#)); do
             ;;
     esac
 done
-mkdir -p "$(dirname "$destination")"
-printf 'test-key' >"$destination"
+case "$url" in
+    https://ghcr.io/token*)
+        echo '{"token":"test-registry-token"}'
+        ;;
+    *)
+        mkdir -p "$(dirname "$destination")"
+        printf 'test-key' >"$destination"
+        ;;
+esac
+EOF
+    cat >"${STUB_BIN}/curl" <<'EOF'
+#!/usr/bin/bash
+# Emulates the GHCR manifest HEAD/GET response consumed by
+# resolve_stable_digest() in 21-container-native-iso.sh. Tests control the
+# behavior via STUB_DIGEST_STATUS (ok|no-digest|fail).
+case "${STUB_DIGEST_STATUS:-ok}" in
+    ok)
+        printf 'HTTP/1.1 200 OK\r\nDocker-Content-Digest: %s\r\n\r\n' \
+            "${STUB_MANIFEST_DIGEST:-sha256:deadbeef00000000000000000000000000000000000000000000000000feed}"
+        ;;
+    no-digest)
+        printf 'HTTP/1.1 200 OK\r\n\r\n'
+        ;;
+    fail)
+        exit 22
+        ;;
+esac
 EOF
     chmod +x "${STUB_BIN}"/*
 
@@ -94,6 +120,8 @@ EOF
     export FAKE_ROOT="${TEST_ROOT}"
     export BRANDING_DIR
     export DRACUT_LOG SYSTEMCTL_LOG
+    export STUB_DIGEST_STATUS="ok"
+    export STUB_MANIFEST_DIGEST="sha256:deadbeef00000000000000000000000000000000000000000000000000feed"
 }
 
 teardown() {
@@ -118,11 +146,11 @@ teardown() {
         "${TEST_ROOT}/etc/anaconda/profile.d/bluefin.conf"
     [ "$status" -eq 0 ]
     run grep -F \
-        'ostreecontainer --url=ghcr.io/projectbluefin/bluefin:stable --transport=registry' \
+        "ostreecontainer --url=ghcr.io/projectbluefin/bluefin@${STUB_MANIFEST_DIGEST} --transport=registry" \
         "${TEST_ROOT}/usr/share/anaconda/interactive-defaults.ks"
     [ "$status" -eq 0 ]
     run grep -F \
-        'bootc switch --mutate-in-place --enforce-container-sigpolicy --transport registry ghcr.io/projectbluefin/bluefin:stable' \
+        "bootc switch --mutate-in-place --enforce-container-sigpolicy --transport registry ghcr.io/projectbluefin/bluefin@${STUB_MANIFEST_DIGEST}" \
         "${TEST_ROOT}/usr/share/anaconda/post-scripts/install-configure-upgrade.ks"
     [ "$status" -eq 0 ]
     run grep -F 'favorite-apps' \
@@ -140,6 +168,34 @@ teardown() {
     [ -f "${TEST_ROOT}/usr/lib/modules/6.0.0-test/.bluefin-initramfs-done" ]
     run grep -F 'enable livesys.service livesys-late.service' \
         "${SYSTEMCTL_LOG}"
+    [ "$status" -eq 0 ]
+}
+
+@test "Falls back to the mutable :stable tag when the registry manifest lookup fails" {
+    export STUB_DIGEST_STATUS="fail"
+    run bash "${ISO_SCRIPT}"
+    [ "$status" -eq 0 ]
+
+    [[ "$output" == *"::warning::Could not resolve a digest"* ]]
+    run grep -F \
+        'ostreecontainer --url=ghcr.io/projectbluefin/bluefin:stable --transport=registry' \
+        "${TEST_ROOT}/usr/share/anaconda/interactive-defaults.ks"
+    [ "$status" -eq 0 ]
+    run grep -F \
+        'bootc switch --mutate-in-place --enforce-container-sigpolicy --transport registry ghcr.io/projectbluefin/bluefin:stable' \
+        "${TEST_ROOT}/usr/share/anaconda/post-scripts/install-configure-upgrade.ks"
+    [ "$status" -eq 0 ]
+}
+
+@test "Falls back to the mutable :stable tag when the manifest response has no digest header" {
+    export STUB_DIGEST_STATUS="no-digest"
+    run bash "${ISO_SCRIPT}"
+    [ "$status" -eq 0 ]
+
+    [[ "$output" == *"::warning::Could not resolve a digest"* ]]
+    run grep -F \
+        'ostreecontainer --url=ghcr.io/projectbluefin/bluefin:stable --transport=registry' \
+        "${TEST_ROOT}/usr/share/anaconda/interactive-defaults.ks"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

Fixes #1159.

`build_files/base/21-container-native-iso.sh` writes the Anaconda kickstart for the live ISO with:

```
ostreecontainer --url=${INSTALL_IMAGE} --transport=registry --no-signature-verification
```

`INSTALL_IMAGE` was the mutable `ghcr.io/.../bluefin:stable` tag. The initial payload pull that lands unverified content on disk had no cryptographic tie to a specific, known-good image — a compromised registry or an attacker able to swap what the tag resolves to could serve different content for that first, unverified pull. The later `bootc switch --enforce-container-sigpolicy` %post step re-verifies signatures and bounds the exposure, but only after the fact, and only if that step succeeds.

## Fix

Resolve the `:stable` tag to its immutable manifest digest against the GHCR registry API at ISO build time — using the existing `ghcurl` helper to get an anonymous pull-scoped token, then a direct manifest request for the `Docker-Content-Digest` response header — and pin both the `ostreecontainer` payload URL and the subsequent `bootc switch` to that digest instead of the mutable tag.

A digest-addressed pull is content-addressed: it cannot be satisfied with different content without failing content verification, closing the install-time window regardless of `--no-signature-verification` (which only governs container *signature* policy, not content integrity).

Digest resolution is best-effort: if it fails (registry hiccup, or no `:stable` tag published yet for a brand-new image), the script falls back to the previous mutable-tag behavior and emits a build warning, so the ISO build never breaks due to a transient network/registry issue.

## Testing

- `bash -n build_files/base/21-container-native-iso.sh`
- `shellcheck build_files/base/21-container-native-iso.sh` (clean)
- `bats tests/unit/21-container-native-iso_test.bats` — added coverage for the digest-pinned success path and both fallback paths (failed lookup, response missing the digest header); all 5 tests pass
- Full `bats tests/unit/*.bats` suite (161 tests) — all pass

Note: this repository's `v4` branch does not currently exist upstream, so this PR targets `main` (the repo's actual default branch).

— hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6f4ec51`