### PR TITLE
fix(iso): keep /boot empty so derived images pass bootc container lint

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -156,11 +156,15 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
         /ctx/build_files/shared/checkpoint-rpmdb.sh \
     '
 
-# Embed the Stable container-native ISO contract after Stage 2. This runs
-# without the /boot tmpfs so Titanoboa can consume the committed EFI payload.
+# Embed the Stable container-native ISO contract after Stage 2. The /boot tmpfs
+# is mounted here like in every other stage: /boot must stay empty in the
+# published image or `bootc container lint` fails in every derived build.
+# The ISO builder stages the EFI payload from /usr/lib/efi itself.
+# See build_files/base/21-container-native-iso.sh.
 RUN --mount=type=bind,from=ctx-iso,source=/build_files/base/21-container-native-iso.sh,target=/ctx/build_files/base/21-container-native-iso.sh \
     --mount=type=bind,from=ctx-iso,source=/build_files/shared/utils/ghcurl,target=/ctx/build_files/shared/utils/ghcurl \
     --mount=type=secret,id=GITHUB_TOKEN \
+    --mount=type=tmpfs,dst=/boot \
     bash -euo pipefail -c ' \
         mkdir -p /var/cache/bluefin-iso/helpers && \
         install -Dm0755 /ctx/build_files/shared/utils/ghcurl /var/cache/bluefin-iso/helpers/ghcurl && \
@@ -176,4 +180,4 @@ RUN rm -rf /opt && ln -s /var/opt /opt
 
 CMD ["/sbin/init"]
 
-RUN bootc container lint --fatal-warnings --skip nonempty-boot
+RUN bootc container lint --fatal-warnings

--- a/build_files/base/21-container-native-iso.sh
+++ b/build_files/base/21-container-native-iso.sh
@@ -44,7 +44,6 @@ else
 fi
 
 mkdir -p \
-    "${ROOT}/boot/efi/EFI" \
     "${ROOT}/etc/anaconda/profile.d" \
     "${ROOT}/etc/sysconfig" \
     "${ROOT}/usr/lib/bluefin" \
@@ -231,15 +230,26 @@ EOF
 echo 'livesys_session=gnome' >"${ROOT}/etc/sysconfig/livesys"
 systemctl enable livesys.service livesys-late.service
 
+# The container-native ISO contract wants shim and grub2 in /boot/efi/EFI/$VENDOR,
+# but /boot must be empty in a bootc container image: anything left there is
+# masked at runtime and makes `bootc container lint` fail with `nonempty-boot`
+# in every image built FROM this one.
+# See https://github.com/projectbluefin/bluefin/issues/1208.
+#
+# So only assert the payload is present. Staging it into /boot/efi belongs to
+# the ISO builder, which does it in its own throwaway layer — the same split the
+# reference implementations use:
+# https://github.com/ondrejbudai/bootc-isos/blob/main/bluefin-lts/src/build.sh
+#
+#     mkdir -p /boot/efi && cp -a /usr/lib/efi/*/*/EFI /boot/efi/
+#
 shopt -s nullglob
 efi_dirs=("${ROOT}"/usr/lib/efi/*/*/EFI)
 if ((${#efi_dirs[@]} == 0)); then
     echo "No EFI payload found under /usr/lib/efi" >&2
     exit 1
 fi
-for efi_dir in "${efi_dirs[@]}"; do
-    cp -a "${efi_dir}/." "${ROOT}/boot/efi/EFI/"
-done
+printf 'EFI payload for the ISO builder: %s\n' "${efi_dirs[@]}"
 
 cat >"${ISO_CONFIG}" <<'EOF'
 label: "titanoboa_boot"

--- a/docs/skills/build/SKILL.md
+++ b/docs/skills/build/SKILL.md
@@ -66,6 +66,11 @@ just clean
 - Keep `build_files/base/04-install-kernel-akmods.sh` as an entrypoint wrapper;
   the orchestration logic lives in `04-install-kernel-akmods.py`.
 - `/tmp` does not persist between container `RUN` instructions.
+- `/boot` must be empty in the published image. Every `RUN` that could write
+  there mounts `--mount=type=tmpfs,dst=/boot`, and the final
+  `bootc container lint --fatal-warnings` carries no `--skip`. Content under
+  `/boot` is masked at runtime and fails that same lint in every image built
+  `FROM` ours. See [#1208](https://github.com/projectbluefin/bluefin/issues/1208).
 - Preserve Containerfile cache boundaries.
 - Report expensive builds accurately.
 

--- a/docs/skills/installation-artifacts/SKILL.md
+++ b/docs/skills/installation-artifacts/SKILL.md
@@ -34,6 +34,27 @@ metadata:
 
 Never overwrite a known-good artifact to force a broken rebuild through.
 
+## Container-native ISO contract
+
+`build_files/base/21-container-native-iso.sh` embeds the contract the ISO
+builder consumes, but only the parts that belong in a bootc image: the Anaconda
+profile and post-scripts, the livesys hooks, and
+`/usr/lib/bootc-image-builder/iso.yaml`.
+
+The shim and grub2 EFI payload stays where its RPMs put it,
+`/usr/lib/efi/*/*/EFI`. The contract asks for it in `/boot/efi/EFI/$VENDOR`, and
+the ISO builder stages it there in its own throwaway layer, exactly as the
+[reference implementations](https://github.com/ondrejbudai/bootc-isos/blob/main/bluefin-lts/src/build.sh)
+do:
+
+```bash
+mkdir -p /boot/efi && cp -a /usr/lib/efi/*/*/EFI /boot/efi/
+```
+
+Do not move that copy back into the image. `/boot` must ship empty or every
+derived image fails `bootc container lint --fatal-warnings`. See
+[#1208](https://github.com/projectbluefin/bluefin/issues/1208).
+
 ## When to Use
 
 Use for Installation media or downstream image artifacts.

--- a/tests/unit/21-container-native-iso_test.bats
+++ b/tests/unit/21-container-native-iso_test.bats
@@ -162,8 +162,10 @@ teardown() {
     [ "$status" -eq 0 ]
     [ ! -e "${TEST_ROOT}/var/lib/rpm-state" ]
 
-    [ -f "${TEST_ROOT}/boot/efi/EFI/fedora/gcdx64.efi" ]
-    [ -f "${TEST_ROOT}/boot/efi/EFI/fedora/shimx64.efi" ]
+    # /boot must stay empty: content here is masked at runtime and trips
+    # `bootc container lint`'s nonempty-boot check in every derived image.
+    # See https://github.com/projectbluefin/bluefin/issues/1208.
+    [ ! -e "${TEST_ROOT}/boot" ]
     [ ! -f "${DRACUT_LOG}" ]
     [ -f "${TEST_ROOT}/usr/lib/modules/6.0.0-test/.bluefin-initramfs-done" ]
     run grep -F 'enable livesys.service livesys-late.service' \
@@ -225,7 +227,15 @@ teardown() {
     [[ "$output" != *$'\nfirefox\n'* ]]
 }
 
-@test "Containerfile runs the ISO contract script after Stage 2 without a boot tmpfs" {
+@test "Fails when the ISO builder would have no EFI payload to stage" {
+    rm -rf "${TEST_ROOT}/usr/lib/efi"
+
+    run bash "${ISO_SCRIPT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'No EFI payload found under /usr/lib/efi'* ]]
+}
+
+@test "Containerfile runs the ISO contract script after Stage 2 under a boot tmpfs" {
     run python3 -c '
 from pathlib import Path
 import sys
@@ -243,11 +253,15 @@ print("\n".join(lines[start:end + 1]))
 ' "${CONTAINERFILE}"
     [ "$status" -eq 0 ]
     [[ "$output" == *'/ctx/build_files/base/21-container-native-iso.sh'* ]]
-    [[ "$output" != *'tmpfs,dst=/boot'* ]]
+    [[ "$output" == *'tmpfs,dst=/boot'* ]]
 
+    # No --skip: derived images run the default lint, so this one must too.
     run grep -Fx \
-        'RUN bootc container lint --fatal-warnings --skip nonempty-boot' \
+        'RUN bootc container lint --fatal-warnings' \
         "${CONTAINERFILE}"
     [ "$status" -eq 0 ]
     [[ "$output" != *'var-tmpfiles'* ]]
+
+    run grep -F 'nonempty-boot' "${CONTAINERFILE}"
+    [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Problem

Building any image `FROM ghcr.io/projectbluefin/bluefin*` fails the standard bootc lint:

```
[4/4] STEP 14/15: RUN bootc container lint --fatal-warnings
Lint warning: nonempty-boot: Found non-empty /boot:
  efi

Checks passed: 12
Checks skipped: 1
Warnings: 1
error: Linting: Checks failed: 1
```

That `efi` entry is ours. `build_files/base/21-container-native-iso.sh` copied the
shim/grub2 EFI payload out of `/usr/lib/efi/*/*/EFI` into `/boot/efi/EFI`, and the
Containerfile deliberately ran that step **without** the `/boot` tmpfs so the copy
would be committed. Our own gate hid it with `--skip nonempty-boot`; downstream
builds run the plain `--fatal-warnings` form and break.

Confirmed in the published artifact — layer
`sha256:01306633be4295cc16e0feedb0b31a5d2e70e0be16fcd6d83c175a20f7c020a8` of
`ghcr.io/projectbluefin/bluefin-nvidia:stable` carries ~8 MB of
`boot/efi/EFI/{BOOT,fedora}/*.efi`, and it is the only layer that writes to `/boot`
(every other `RUN` already mounts the tmpfs). Reported in #1208; the reporter's
workaround was `RUN rm -rf /boot/*` in their own Containerfile.

## Why the copy can go

- **It is a duplicate.** The bytes are already in the image at `/usr/lib/efi/*/*/EFI`,
  which is where the contract discovers the UEFI vendor in the first place.
- **It is masked at runtime.** bootc mounts the real ESP over `/boot`; nothing ever
  reads the committed copy on a booted system.
- **The production ISO pipeline never reads it.** `projectbluefin/iso` pins Titanoboa
  to `840217d` and invokes its Justfile `build` recipe, which assembles the ESP from
  the *builder* container's own `shim`/`grub2-efi-x64` RPMs — it never touches the
  Bluefin rootfs's `/boot`.
- **Staging belongs to the ISO builder.** The container-native ISO contract's own
  reference implementations put this copy in a throwaway layer on top of the shipped
  image, not in the image —
  [`bootc-isos/bluefin-lts/src/build.sh`](https://github.com/ondrejbudai/bootc-isos/blob/main/bluefin-lts/src/build.sh):

  ```bash
  # image-builder expects the EFI directory to be in /boot/efi
  mkdir -p /boot/efi
  cp -av /usr/lib/efi/*/*/EFI /boot/efi/
  ```

## Change

- `21-container-native-iso.sh`: drop the `cp` into `/boot/efi/EFI` and the `mkdir` for
  it. The `/usr/lib/efi` payload check stays and still fails the build when it is
  missing, so `grub2-efi-x64-cdboot`/`shim` silently dropping out is still caught. The
  resolved paths are logged for the ISO builder.
- `Containerfile`: mount `--mount=type=tmpfs,dst=/boot` on the ISO step like every
  other stage, and drop `--skip nonempty-boot` so our gate now catches a regression
  instead of hiding it.
- Everything else in the contract is untouched — Anaconda profile and post-scripts,
  secure-boot key enrollment, livesys hooks, `/usr/lib/bootc-image-builder/iso.yaml`.
  Those live under `/usr` and `/etc` and are legitimate image content.
- Docs: recorded the `/boot`-must-be-empty rule in the `build` skill and the
  EFI-staging split in the `installation-artifacts` skill, per AGENTS.md.

## Follow-up for whoever moves the ISO pipeline to the container-native path

When `projectbluefin/iso` moves off the pinned Titanoboa to the `main` action /
`image-builder`, that builder needs the two-line stage above in its own layer before
handing the image to the ISO tool. Both skills now say so.

## Validation

```
$ bats tests/unit/21-container-native-iso_test.bats
1..6
ok 1 Stable image embeds the Titanoboa ISO contract and installer configuration
ok 2 Falls back to the mutable :stable tag when the registry manifest lookup fails
ok 3 Falls back to the mutable :stable tag when the manifest response has no digest header
ok 4 Stable package manifest contains the container-native ISO dependencies
ok 5 Fails when the ISO builder would have no EFI payload to stage
ok 6 Containerfile runs the ISO contract script after Stage 2 under a boot tmpfs
```

Test updates: assert `/boot` is never created, assert the Containerfile mounts the
`/boot` tmpfs on the ISO step and lints with no `--skip`, plus a new test covering the
"no EFI payload" failure path.

Also run: `just check`, `bats tests/unit/` (the 16 pre-existing
`04-install-kernel-akmods` failures reproduce unchanged on `testing` without this
patch), `shellcheck build_files/base/21-container-native-iso.sh`,
`hadolint --config .hadolint.yaml Containerfile`,
`python3 .github/scripts/validate-docs.py`.

**Not run:** a full image build. The `/boot`-empty claim rests on the layer inspection
above plus the reporter's lint output, which names `efi` as the only entry — so with
this layer's `/boot` writes gone, `/boot` is empty. Worth a CI build before merge.

Fixes #1208
