### PR TITLE
docs(security): track CVE-2026-56854 across container-tools and tailscale

### DIFF
--- a/docs/skills/security/SKILL.md
+++ b/docs/skills/security/SKILL.md
@@ -51,6 +51,7 @@ do not invent a replacement key or trust path.
 - [COPR isolation invariant](references/copr-isolation.md)
 - [signing and verification](references/signing.md)
 - [CVE-2026-33186 grpc in buildah and podman](references/cve-2026-33186-grpc-buildah.md)
+- [CVE-2026-56854 crypto in container-tools and tailscale](references/cve-2026-56854-crypto.md)
 
 ## When to Use
 

--- a/docs/skills/security/references/cve-2026-56854-crypto.md
+++ b/docs/skills/security/references/cve-2026-56854-crypto.md
@@ -1,0 +1,122 @@
+# CVE-2026-56854 (golang.org/x/crypto) across container-tools, containerd, and tailscale
+
+Severity: **Critical** (CVSS ≥ 9.0, per the vulnerability scan gate).
+
+## Finding
+
+CVE-2026-56854 affects `golang.org/x/crypto/ssh` before `v0.55.0`, which is
+statically bundled into Go binaries installed on the image. In
+`golang.org/x/crypto/ssh`, source-address restrictions in `Permissions`
+returned by authentication callbacks were only enforced for `PublicKeyCallback`
+and `VerifiedPublicKeyCallback`. Other authentication callbacks
+(`PasswordCallback`, `KeyboardInteractiveCallback`, `NoClientAuthCallback`, and
+`GSSAPIWithMICConfig.AllowLogin`) silently ignored these restrictions, allowing
+remote attackers to bypass source-address restrictions.
+
+Trivy flagged four distinct installed versions of `golang.org/x/crypto`
+(`v0.43.0`, `v0.46.0`, `v0.53.0`, `v0.54.0`) during the `testing` build scan
+(scan date `2026-09-04T22:54:59Z`, run `33924757139`). Fixed version is
+`0.55.0`. There is **no self-contained fix** that this repository can apply on
+the Fedora 44 target.
+
+## Root cause
+
+The vulnerable module is bundled within upstream binaries rather than declared
+as standalone RPM dependencies in `build_files/packages/base.toml`.
+
+**Four distinct versions across five carriers ship the vulnerable module:**
+
+| Carrier package | Source / origin | Crypto pinned | Status |
+|---|---|---|---|
+| `buildah-2:1.43.2-1.fc44` | Fedora Silverblue container-tools | `v0.43.0` | vulnerable |
+| `skopeo-1.22.2-2.fc44` | Fedora Silverblue container-tools | `v0.46.0` | vulnerable |
+| `podman-5.8.4-1.fc44` | Fedora Silverblue container-tools | `v0.53.0` | vulnerable |
+| `containerd-2.3.4-1.fc44` | Fedora base packages (`base.toml`) | `v0.53.0` | vulnerable |
+| `tailscale-1.98.10-1` | Tailscale stable repository (`03-packages.sh`) | `v0.54.0` | vulnerable |
+
+All four versions reported by Trivy map directly to these image components:
+- `v0.43.0` from `buildah`
+- `v0.46.0` from `skopeo`
+- `v0.53.0` from `podman` and `containerd`
+- `v0.54.0` from `tailscale`
+
+## Why an in-repo pin/override does not resolve it
+
+The `Pins and Overrides` section in `build_files/base/03-packages.sh` documents
+the mechanism for `rpm-ostree override replace`, but it requires fixed RPMs to
+exist in Fedora or third-party repositories. No fixed package exists on Fedora 44
+(or even Rawhide `fc46`) for `buildah`, `skopeo`, `podman`, or `containerd`.
+Downgrading does not help because older versions are also vulnerable.
+
+## Where upstream fixes land
+
+| Project | Current F44 / Image pin | Upstream status (as of Sep 2026) | Crypto version |
+|---|---|---|---|
+| `buildah` | `v1.43.2` | Latest release `v1.45.0` | `v0.54.0` (unfixed) |
+| `skopeo` | `v1.22.2` | Latest release `v1.24.0` | `v0.54.0` (unfixed) |
+| `podman` | `v5.8.4` | Latest release `v6.1.1` | `v0.54.0` (unfixed) |
+| `containerd` | `v2.3.4` | Latest release `v2.3.5` | `v0.53.0` (unfixed) |
+| `tailscale` | `v1.98.10` | Fixed in `main`; latest release `v1.102.3` | `v0.54.0` (unfixed) |
+
+None of the upstream container projects have cut a release tagging
+`golang.org/x/crypto >= 0.55.0` yet. Tailscale has updated `main` to `0.55.0`
+but has not yet packaged an RPM release carrying it.
+
+## Action
+
+Track upstream package updates across the carriers and downstream Fedora /
+Tailscale repository builds. When updated packages reach the repositories,
+subsequent `testing` builds will automatically ingest them. Do not suppress or
+weaken the vulnerability scan gate or add `.trivyignore` exceptions; this
+finding is a tracking note, not an approval to bypass scan gates.
+
+## A new issue number is not a new problem
+
+`bootc-build/scan-image` files a fresh `fix(security): critical CVE detected …`
+issue on scheduled or push builds when Trivy detects a novel CVE not already
+tracked by an open issue. Duplicate check keys on open issues for that specific
+CVE. Issue #1186 is the canonical open issue for `CVE-2026-56854`.
+
+## Re-checking this (do not re-derive by hand)
+
+This finding can be re-checked with the following commands.
+
+Current F44 versions of the carriers:
+
+```bash
+for p in buildah podman skopeo containerd; do
+  printf '%-12s ' "$p"
+  curl -s "https://mdapi.fedoraproject.org/f44/pkg/$p" | jq -r '"\(.version)-\(.release)"'
+done
+```
+
+The crypto version any given upstream release bundles:
+
+```bash
+curl -s https://raw.githubusercontent.com/containers/buildah/v1.43.2/go.mod | grep 'golang.org/x/crypto'
+curl -s https://raw.githubusercontent.com/containers/skopeo/v1.22.2/go.mod | grep 'golang.org/x/crypto'
+curl -s https://raw.githubusercontent.com/containers/podman/v5.8.4/go.mod | grep 'golang.org/x/crypto'
+curl -s https://raw.githubusercontent.com/containerd/containerd/v2.3.4/go.mod | grep 'golang.org/x/crypto'
+curl -s https://raw.githubusercontent.com/tailscale/tailscale/v1.98.10/go.mod | grep 'golang.org/x/crypto'
+```
+
+Check Tailscale stable RPM repository:
+
+```bash
+curl -s https://pkgs.tailscale.com/stable/fedora/x86_64/repodata/repomd.xml
+```
+
+The finding clears when **every** carrier above resolves to a version whose
+`go.mod` pins `golang.org/x/crypto >= v0.55.0`.
+
+## Verification
+
+Verified `2026-09-07`:
+
+- `f44/buildah` → `1.43.2-1.fc44`; `containers/buildah@v1.43.2` → `crypto v0.43.0`.
+- `f44/skopeo` → `1.22.2-2.fc44`; `containers/skopeo@v1.22.2` → `crypto v0.46.0`.
+- `f44/podman` → `5.8.4-1.fc44`; `containers/podman@v5.8.4` → `crypto v0.53.0`.
+- `f44/containerd` → `2.3.4-1.fc44` → `crypto v0.53.0`.
+- `tailscale` → `1.98.10-1` → `crypto v0.54.0`.
+- Upstream releases inspected: `buildah@v1.45.0` (`v0.54.0`), `skopeo@v1.24.0` (`v0.54.0`), `podman@v6.1.1` (`v0.54.0`), `containerd@v2.3.5` (`v0.53.0`), `tailscale@v1.102.3` (`v0.54.0`).
+- None of the carriers currently ship `0.55.0` on Fedora 44 or stable repos.


### PR DESCRIPTION
## Summary

Refs #1186.

Documents finding, root cause, carrier inventory, and resolution path for `CVE-2026-56854` (`golang.org/x/crypto/ssh` < `0.55.0`), detected as a critical vulnerability in the `testing` build scan.

### Root Cause & Carriers

Trivy flagged four distinct versions of `golang.org/x/crypto` installed across the image:
- `v0.43.0`: bundled in `buildah-2:1.43.2-1.fc44` (Fedora Silverblue container-tools)
- `v0.46.0`: bundled in `skopeo-1.22.2-2.fc44` (Fedora Silverblue container-tools)
- `v0.53.0`: bundled in `podman-5.8.4-1.fc44` (Fedora Silverblue container-tools) and `containerd-2.3.4-1.fc44` (`base.toml`)
- `v0.54.0`: bundled in `tailscale-1.98.10-1` (`tailscale-stable` repo, `03-packages.sh`)

### In-Repo Disposition

- There is **no self-contained fix** that this repository can apply on Fedora 44 without suppressing or weakening the security scanning gates.
- No fixed RPM packages exist on Fedora 44, Fedora 44 updates, or even Rawhide (`fc46`) for `buildah`, `skopeo`, `podman`, or `containerd`.
- Upstream container projects (`containers/buildah`, `containers/skopeo`, `containers/podman`, `containerd/containerd`) have not yet tagged releases with `golang.org/x/crypto >= 0.55.0`.
- Tailscale bumped to `0.55.0` on `main`, but has not yet packaged an RPM release carrying it.
- Per security policy, scan gates must not be weakened and `.trivyignore` exceptions are prohibited.

### Changes

- Add `docs/skills/security/references/cve-2026-56854-crypto.md` detailing the finding, carriers, upstream status, verification data, and reproducible re-check commands.
- Update `docs/skills/security/SKILL.md` to link the new reference document.

## Validation

- `python3 .github/scripts/validate-docs.py`
- `just check`
- `python3 tests/test_pr_validation.py`
- `python3 tests/test_renovate_config.py`
- `git diff projectbluefin/testing...HEAD --check`