### PR TITLE
fix(ci): report lab checks with GITHUB_TOKEN instead of MergeRaptor token

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 # The lab sends several lifecycle events (queued -> in_progress -> completed)
 # for one head SHA, and the job below is a read-then-write: it looks up the
@@ -25,36 +26,15 @@ concurrency:
 
 jobs:
   report:
-    name: Update MergeRaptor check
+    name: Update lab check
     if: >-
       github.event.client_payload.repository == github.repository &&
       github.event.client_payload.sha != ''
     runs-on: ubuntu-24.04
     steps:
-      # continue-on-error: when the app installation lacks the requested
-      # permission, create-github-app-token fails with only the annotation
-      # "The permissions requested are not granted to this installation."
-      # Keep the run alive so the next step can surface an actionable message
-      # instead of a bare red X (bluefin#939). The job still fails either way.
-      - name: Get MergeRaptor token
-        id: app-token
-        continue-on-error: true
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
-          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-          permission-checks: write
-          permission-contents: read
-
-      - name: Fail with actionable message if token minting was denied
-        if: steps.app-token.outcome == 'failure' || steps.app-token.outputs.token == ''
-        run: |
-          echo "::error::MergeRaptor token mint failed — the app lacks the requested 'checks: write' permission. This cannot be fixed from the repository; an org owner must grant it in the GitHub UI, and it may take TWO steps. Step 1, only if 'checks' is absent from 'gh api /apps/mergeraptor --jq .permissions': Organization settings → Developer settings → GitHub Apps → MergeRaptor → Permissions & events → Repository permissions → Checks: Read and write → Save. Until that is done the installation page has nothing to approve. Step 2: approve the resulting request under Organization settings → GitHub Apps → MergeRaptor → Review request. Verify with: gh api orgs/projectbluefin/installations --jq '.installations[] | select(.app_slug == \"mergeraptor\") | .permissions' — see docs/skills/ci/references/mergeraptor-checks.md."
-          exit 1
-
       - name: Create or update lab check
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.client_payload.sha }}
           CHECK_JSON: ${{ toJSON(github.event.client_payload.check) }}
         run: |
@@ -62,7 +42,6 @@ jobs:
 
           PRODUCT="${GITHUB_REPOSITORY#*/}"
           CHECK_NAME="testing-lab / ${PRODUCT}"
-          APP_SLUG="mergeraptor"
 
           if [[ ! "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Invalid commit SHA: ${SHA}" >&2
@@ -102,14 +81,17 @@ jobs:
           # check runs of every name, newest first, so on a busy commit the
           # existing lab check falls off the page and this lookup returns
           # nothing -- which silently turns every update into a duplicate
-          # check run (bluefin#939).
+          # check run (bluefin#939). Matching is by name only: the run is
+          # created with the workflow token, so it is attributed to the
+          # github-actions app, and an app-slug filter would find nothing
+          # and duplicate every update (bluefin#1114).
           CHECK_ID=$(
             gh api --method GET \
               "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
               -f check_name="${CHECK_NAME}" \
               -f per_page=100 \
               --jq '.check_runs
-                | map(select(.name == "'"${CHECK_NAME}"'" and .app.slug == "'"${APP_SLUG}"'"))
+                | map(select(.name == "'"${CHECK_NAME}"'"))
                 | sort_by(.id)
                 | last
                 | .id // empty'

--- a/docs/skills/ci/SKILL.md
+++ b/docs/skills/ci/SKILL.md
@@ -89,12 +89,12 @@ context silently couples every stage to every input directory.
 Every open Bluefin PR is discovered by the lab's five-minute PR poller. The lab
 runs smoke QA against `bluefin:testing` and sends bounded
 `repository_dispatch` lifecycle events to `.github/workflows/lab-check.yml`.
-That workflow must exist on the default branch and uses a short-lived
-MergeRaptor installation token to update one `testing-lab / bluefin` Check Run
-for the exact PR head SHA. Do not duplicate the result in a PR comment or commit status.
-
-The MergeRaptor installation on `projectbluefin` also needs **Checks: write**
-for `lab-check.yml`; see [MergeRaptor checks](references/mergeraptor-checks.md).
+That workflow must exist on the default branch and uses the workflow's own
+`GITHUB_TOKEN` (workflow-level `checks: write`) to update one
+`testing-lab / bluefin` Check Run for the exact PR head SHA, matched by name
+only — it is attributed to the `github-actions` app, so an app-slug filter
+would duplicate every update (bluefin#1114). Do not duplicate the result in
+a PR comment or commit status; see [MergeRaptor checks](references/mergeraptor-checks.md).
 
 ## Workflow input and job constraints
 
@@ -174,7 +174,7 @@ Read the affected YAML, identify the owning reusable workflow, validate locally.
 ## Red Flags
 
 - Changing a caller when the behavior belongs in shared workflow logic.
-- Posting a lab result as a PR comment instead of updating the MergeRaptor Check Run.
+- Posting a lab result as a PR comment instead of updating the lab Check Run.
 - Reading a gate's log message as proof of what it did. A step can report that a
   tag was excluded and push it anyway; confirm against the pushed artifact.
 - Treating a fork PR with no checks as pending rather than unapproved.

--- a/docs/skills/ci/references/mergeraptor-checks.md
+++ b/docs/skills/ci/references/mergeraptor-checks.md
@@ -1,11 +1,30 @@
-# MergeRaptor Checks permission for lab-check.yml
+# MergeRaptor and lab-check.yml authentication
 
+`lab-check.yml` creates and updates the `testing-lab / <product>` Check Run
+with the workflow's own `GITHUB_TOKEN`, declaring `checks: write` in the
+workflow `permissions:` block. It no longer mints a MergeRaptor app token:
 `actions/create-github-app-token` can only request permissions the app
-installation already holds; anything else fails the run with `The permissions
-requested are not granted to this installation.` The MergeRaptor installation
-on `projectbluefin` therefore needs **Checks: write** for `lab-check.yml`, in
-addition to the contents/pull-requests/workflows grants `track-common.yml`
-uses.
+installation already holds, and the `projectbluefin` installation was never
+granted **Checks: write**, so every dispatch died with HTTP `422` `The
+permissions requested are not granted to this installation` (bluefin#939,
+bluefin#1114). Requesting only permissions the installation already holds —
+here, via the workflow token — is the fix that needs no org administration.
+
+The check-run lookup matches by name only, with a server-side `check_name`
+filter. A run created with `GITHUB_TOKEN` is attributed to the
+`github-actions` app, so filtering on the requesting app's slug would find
+nothing and every lifecycle event would POST a duplicate run (bluefin#1114).
+
+`track-common.yml` and `renovate-automerge.yml` still mint MergeRaptor
+installation tokens, but request only the contents and pull-requests
+permissions the installation already holds. If one of them starts failing
+with the `422` message above, a grant changed — confirm the current grants
+before debugging the workflow YAML:
+
+```bash
+gh api orgs/projectbluefin/installations \
+  --jq '.installations[] | select(.app_slug == "mergeraptor") | .permissions'
+```
 
 ## Diagnose before fixing: App definition vs. installation
 
@@ -31,44 +50,42 @@ Both commands need an org-owner token (`admin:org`); a contributor token returns
 
 Read the two together:
 
-| `checks` in App permissions | `checks` in installation permissions | What it means |
+| Permission in App permissions | Permission in installation permissions | What it means |
 |---|---|---|
 | absent | absent | The App cannot request it yet. **Both steps below are required.** Re-installing or re-approving does nothing — there is no pending request to approve. |
 | present | absent | Only step 2 — an org owner approves the pending permission request. |
-| present | `write` | Grant is in place; `lab-check.yml` should mint its token. Investigate elsewhere. |
+| present | `write` | Grant is in place; the workflow should mint its token. Investigate elsewhere. |
 
 ## The fix (UI only — there is no REST endpoint for this)
 
 **Step 1 — declare it on the App.** Organization settings → Developer settings →
 GitHub Apps → **MergeRaptor** → Permissions & events → Repository permissions →
-**Checks: Read and write** → Save. Skipping this is the common failure: it is a
-*different screen* from the installation page, and until it is done the
-installation page offers nothing to approve.
+the permission in question (for example **Checks: Read and write**) → Save.
+Skipping this is the common failure: it is a *different screen* from the
+installation page, and until it is done the installation page offers nothing to
+approve.
 
 **Step 2 — approve it on the installation.** Saving step 1 raises a permission
 request to org owners. Accept it under Organization settings → GitHub Apps →
 MergeRaptor → **Review request**.
 
-Then re-run the check with the step-2 command above; `checks` must read `write`.
-Dispatch a `lab-check` repository event (or wait for the next `track-common` QA
-run) and confirm `testing-lab / <product>` is created or updated.
+Then re-run the step-2 command above and dispatch the affected workflow to
+confirm the token mint succeeds.
 
 ## Rules
 
 Granting an app permission is org-admin administration in the GitHub UI, not a
-repository change. Never work around a missing grant with a PAT, and never add a
-fallback that lets `lab-check.yml` pass without reporting: a check that silently
-skips is worse than one that fails loudly, because the gap stops being visible.
-`lab-check.yml` requests exactly `permission-checks: write` and
-`permission-contents: read`, which is the minimum the check-run API needs.
+repository change. Never work around a missing grant with a PAT, and never add
+a fallback that lets a reporting workflow pass without reporting: a check that
+silently skips is worse than one that fails loudly, because the gap stops being
+visible.
 
 ## Reading a failed run
 
-The job summary shows **`Get MergeRaptor token: success`** directly above a
-failing diagnostic step. That is not a second bug and the mint did not
-half-succeed. `continue-on-error: true` makes a step report *conclusion*
-`success` while its *outcome* stays `failure`; the diagnostic keys off
-`outcome`, which is correct. Confirm the real result in the step log — a denied
-mint logs `##[error]The permissions requested are not granted to this
-installation` and an HTTP `422` from
-`POST /app/installations/{id}/access_tokens`.
+When `actions/create-github-app-token` requests a permission the installation
+lacks, the step fails with the annotation `The permissions requested are not
+granted to this installation` (an HTTP `422` from
+`POST /app/installations/{id}/access_tokens`) and nothing else. With
+`continue-on-error: true` the step reports *conclusion* `success` while its
+*outcome* stays `failure`; key any diagnosis off `outcome`, and confirm the
+denied mint in the step log.

--- a/tests/test_lab_check.py
+++ b/tests/test_lab_check.py
@@ -1,8 +1,8 @@
 """Tests for the check-run reporting script in lab-check.yml.
 
-The workflow has never run to completion in CI -- every dispatch so far dies at
-the MergeRaptor token mint (bluefin#939) -- so the script below is exercised
-here against a stub ``gh`` instead.
+The workflow reports with its own ``GITHUB_TOKEN`` (workflow-level
+``checks: write``, bluefin#1114), so the script below is exercised here
+against a stub ``gh`` instead.
 """
 
 from __future__ import annotations
@@ -180,7 +180,11 @@ class LabCheckReportTests(unittest.TestCase):
         self.assertNotIn("conclusion", body)
         self.assertEqual(body["details_url"], "https://lab.example/run/7")
 
-    def test_ignores_a_same_named_check_from_another_app(self) -> None:
+    def test_updates_a_same_named_check_from_any_app(self) -> None:
+        # Since bluefin#1114 the run is created with the workflow token, so it
+        # is attributed to the github-actions app, not the app that requested
+        # it: the lookup matches by name only and updates the existing run
+        # in place instead of filtering it out and POSTing a duplicate.
         requests = self.run_report(
             [check_run(4321, slug="some-other-app")],
             {"state": "completed", "conclusion": "failure",
@@ -188,7 +192,32 @@ class LabCheckReportTests(unittest.TestCase):
         )
 
         writes = [r for r in requests if r.get("method") in ("POST", "PATCH")]
-        self.assertEqual(writes[0]["method"], "POST")
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0]["method"], "PATCH")
+        self.assertTrue(writes[0]["endpoint"].endswith("/check-runs/4321"))
+
+
+class LabCheckAuthTests(unittest.TestCase):
+    """The report runs on the workflow's own token, not an app token.
+
+    Minting a MergeRaptor token with ``permission-checks:write`` failed with
+    422 because the org installation was never granted checks:write
+    (bluefin#1114). The workflow now declares ``checks: write`` in its
+    permissions block and uses ``GITHUB_TOKEN`` directly.
+    """
+
+    def workflow(self) -> str:
+        return WORKFLOW.read_text(encoding="utf-8")
+
+    def test_permissions_block_grants_checks_write(self) -> None:
+        permissions = self.workflow().split("\npermissions:\n", 1)[1]
+        permissions = permissions.split("\n\n", 1)[0]
+        self.assertIn("checks: write", permissions)
+
+    def test_no_app_token_mint(self) -> None:
+        workflow = self.workflow()
+        self.assertNotIn("create-github-app-token", workflow)
+        self.assertNotIn("MERGERAPTOR", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes projectbluefin/bluefin#1114.

## Problem

The Lab check fails before validation: `lab-check.yml` mints a MergeRaptor
installation token with `permission-checks: write`, but the `projectbluefin`
installation was never granted `checks: write`, so every dispatch dies with
HTTP 422 — `The permissions requested are not granted to this installation`
(first tracked in #939; reproduced on runs 32170118754 / 32170037172 /
32170032783 and again on 32617430091 / 32617437845 / 32617445870 /
32617481346 per the issue thread).

## Fix

Instead of requiring an org-side app-permission grant, align with the
bluefin-lts pattern: declare `checks: write` in the workflow `permissions:`
block and create/update the `testing-lab / <product>` check run with the
workflow's own `GITHUB_TOKEN`. This removes the
`actions/create-github-app-token` mint step and its deny-diagnostic step;
the workflow now requests only permissions the job can already hold.

The check-run lookup matches on the check name only (server-side
`check_name` filter). A run created with `GITHUB_TOKEN` is attributed to the
`github-actions` app, so keeping the old `.app.slug == "mergeraptor"` filter
would find nothing and every lifecycle event would POST a duplicate check
run.

## Changes

- `.github/workflows/lab-check.yml`: `checks: write` in the permissions
  block; drop the app-token mint and deny-diagnostic steps; use
  `${{ github.token }}`; name-only check-run matching; rename the job to
  "Update lab check".
- `tests/test_lab_check.py`: add `LabCheckAuthTests` pinning the workflow
  permissions and the absence of any app-token mint; update the same-name
  lookup test to the new name-based matching (PATCH, not POST).
- `docs/skills/ci/SKILL.md`,
  `docs/skills/ci/references/mergeraptor-checks.md`: document the new auth
  model; the reference now covers the remaining MergeRaptor token users
  (`track-common.yml`, `renovate-automerge.yml`) and the two-level
  permission diagnosis.

## Testing

- `python3 -m unittest tests.test_lab_check` — 7/7 pass (the reporting
  script is exercised against a stub `gh`, including the buried-check and
  same-name lookup cases).
- `python3 .github/scripts/validate-docs.py` — ok.
- `bash -n` on the extracted reporting script — ok.
- actionlint / pre-commit run in CI.

Note: `MERGERAPTOR_APP_ID` / `MERGERAPTOR_PRIVATE_KEY` are now consumed only
by `track-common.yml` and `renovate-automerge.yml`.

— hive: backend=goose