### PR TITLE
fix(build): validate supported brew preinstall contract

### DIFF
--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -24,22 +24,21 @@ done
 
 test -f /usr/share/ublue-os/homebrew/fonts.Brewfile
 
-# bluefinctl and the default CLI set (fzf, starship, htop, ...) are not baked
-# into the image — they are installed per-user at first graphical login by the
-# brew-preinstall user service. The whole delivery path is inherited from the
-# pinned `common` image, whose digest Renovate bumps automatically, so a rename
-# or drop upstream would silently stop shipping bluefinctl with no other signal.
+# The default CLI set (fzf, starship, htop, ...) is not baked into the image —
+# it is installed per-user at first graphical login by the brew-preinstall user
+# service. The whole delivery path is inherited from the pinned `common` image,
+# whose digest Renovate bumps automatically, so a rename or drop upstream
+# would silently stop shipping default CLI tools with no other signal.
 # Assert the pieces the service actually needs: the Brewfiles it reads, the
 # binary its ExecStart points at, the unit, and the preset that enables it.
 # See: https://github.com/projectbluefin/bluefin/issues/965
-test -f /usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile
 test -f /usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile
 test -x /usr/bin/brew-preinstall
 # ExecStart names /usr/bin/brew-preinstall, but that is a two-line trampoline
 # (`exec /usr/libexec/brew-preinstall`). Asserting only the trampoline still
 # passes when the payload it exec's is renamed or dropped upstream -- the unit
-# then fails at first login with status 127 and bluefinctl silently never
-# installs, which is exactly the symptom reported in #965. Assert the file that
+# then fails at first login with status 127 and tools silently never
+# install, which is exactly the symptom reported in #965. Assert the file that
 # actually does the work, not just the one systemd calls.
 test -x /usr/libexec/brew-preinstall
 test -f /usr/lib/systemd/user/brew-preinstall.service

--- a/tests/unit/20-tests_test.bats
+++ b/tests/unit/20-tests_test.bats
@@ -33,9 +33,8 @@ setup() {
         "${TEST_ROOT}/usr/share/ublue-os/just/update.just"
     echo 'options cros_charge_control probe_with_fwk_charge_control=1' \
         > "${TEST_ROOT}/usr/lib/modprobe.d/fw-charge-control.conf"
-    # brew-preinstall delivery path (bluefinctl + default CLI set) — see #965
-    touch "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile" \
-        "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile" \
+    # brew-preinstall delivery path (default CLI set) — see #965
+    touch "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile" \
         "${TEST_ROOT}/usr/lib/systemd/user/brew-preinstall.service"
     touch "${TEST_ROOT}/usr/bin/brew-preinstall" \
         "${TEST_ROOT}/usr/libexec/brew-preinstall"
@@ -212,11 +211,11 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "20-tests: rejects an image missing the bluefinctl Brewfile" {
-    # #965: bluefinctl reaches users only through preinstall.d. If `common`
-    # renames or drops this file, the build must fail rather than ship an
-    # image where bluefinctl silently never installs.
-    rm -f "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile"
+@test "20-tests: rejects an image missing the system-cli Brewfile" {
+    # The default CLI set reaches users through preinstall.d/system-cli.Brewfile.
+    # If `common` renames or drops this file, the build must fail rather than ship
+    # an image where default CLI tools silently never install.
+    rm -f "${TEST_ROOT}/usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile"
 
     run bash "${PATCHED_SCRIPT}"
     [ "$status" -ne 0 ]


### PR DESCRIPTION
## Summary

- remove the obsolete `bluefinctl.Brewfile` image assertion
- retain validation for Common’s supported `system-cli.Brewfile` brew-preinstall contract
- cover the missing contract file in focused BATS tests

## Validation

- `bats tests/unit/20-tests_test.bats`
- `bats tests/unit/`
- `just check`
- `pre-commit run --all-files`