### PR TITLE
fix(security): verify cosign binary checksum before install (#1172)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -484,6 +484,9 @@ verify-container container="" registry="ghcr.io/ublue-os" key="":
         trap 'rm -f "${COSIGN_INSTALL_PATH}"' EXIT
         curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
             -o "${COSIGN_INSTALL_PATH}"
+        # SHA-256 pinned from upstream cosign_checksums.txt for v3.1.1 — fail closed on mismatch.
+        COSIGN_SHA256="ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"
+        echo "${COSIGN_SHA256}  ${COSIGN_INSTALL_PATH}" | sha256sum -c -
         chmod +x "${COSIGN_INSTALL_PATH}"
         ${SUDOIF} install -m 0755 "${COSIGN_INSTALL_PATH}" /usr/local/bin/cosign
         echo "cosign installed: $(cosign version 2>/dev/null | awk '/GitVersion:/{print $2}')"

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -1,0 +1,53 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+JUSTFILE = ROOT / "Justfile"
+
+EXPECTED_COSIGN_SHA256 = (
+    "ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"
+)
+
+
+class JustfileCosignVerificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = JUSTFILE.read_text(encoding="utf-8")
+
+    def test_cosign_download_has_pinned_sha256(self) -> None:
+        """verify-container must pin the expected cosign v3.1.1 SHA-256."""
+        match = re.search(r'COSIGN_SHA256="([0-9a-f]{64})"', self.content)
+        self.assertIsNotNone(match, "COSIGN_SHA256 definition not found in Justfile")
+        assert match is not None
+        self.assertEqual(
+            match.group(1),
+            EXPECTED_COSIGN_SHA256,
+            "COSIGN_SHA256 does not match official cosign v3.1.1 linux-amd64 checksum",
+        )
+
+    def test_cosign_checksum_verified_before_install(self) -> None:
+        """sha256sum verification must occur before install -m 0755."""
+        self.assertIn("verify-container", self.content)
+        recipe_part = self.content.split("verify-container container=")[1].split(
+            "secureboot", 1
+        )[0]
+
+        sha_pos = recipe_part.find("sha256sum -c -")
+        install_pos = recipe_part.find("install -m 0755")
+
+        self.assertNotEqual(
+            sha_pos, -1, "sha256sum check not found in verify-container"
+        )
+        self.assertNotEqual(
+            install_pos, -1, "install command not found in verify-container"
+        )
+        self.assertLess(
+            sha_pos,
+            install_pos,
+            "sha256sum check must execute before install command",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses #1172 by verifying the SHA-256 checksum of the downloaded Cosign release binary (`v3.1.1`) before installing or executing it in the `verify-container` recipe in `Justfile`.

## Problem

The `verify-container` recipe downloaded `https://github.com/sigstore/cosign/releases/download/v3.1.1/cosign-linux-amd64` and installed it directly to `/usr/local/bin/cosign` without verifying its integrity. Because Cosign is itself the tool used to verify container image signatures, executing an unverified binary undermines the entire container verification chain.

## Solution

1. Pinned `COSIGN_SHA256="ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"`, matching the official upstream `cosign_checksums.txt` for `cosign-linux-amd64` in release `v3.1.1`.
2. Verified the downloaded binary with `echo "${COSIGN_SHA256}  ${COSIGN_INSTALL_PATH}" | sha256sum -c -` before `chmod` or `install`.
3. Fails closed immediately on checksum mismatch under `set -eou pipefail`, triggering the `trap` to remove the unverified download without installing it.
4. Added unit test in `tests/test_justfile.py` asserting that the pinned checksum matches official `v3.1.1` and runs before the installation command.

Note on #1174: PR #1174 previously attempted to address #1172 and #1173 together, but branched from an older commit on `main` instead of `testing`, resulting in 157 diverged commits and merge conflicts. This PR isolates #1172 with a clean, single-commit fix branched directly off `upstream/testing`.

## Validation

- Tested failed verification: modified checksum causes `sha256sum -c -` to exit with status 1, and the trap cleans up the binary without installation.
- Tested successful verification: authentic release download matches pinned SHA-256 and exits with status 0.
- `just check`: syntax clean.
- `python3 -m unittest tests/test_justfile.py`: 2 passed.
- `python3 -m unittest discover -s tests -p 'test_*.py'`: 64 passed.

Closes #1172

---
Gemini 3.7 flash high reasoning
