### PR TITLE
fix(security): pin and verify secureboot signing keys (#1173)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -549,9 +549,12 @@ secureboot $image="bluefin" $tag="testing" $flavor="main":
     ${PODMAN} cp "$TMP":/usr/lib/modules/"${kernel_release}"/vmlinuz /tmp/vmlinuz
     ${PODMAN} rm "$TMP"
 
-    # Get the Public Certificates
-    curl --retry 3 -Lo /tmp/kernel-sign.der https://github.com/ublue-os/akmods/raw/main/certs/public_key.der
-    curl --retry 3 -Lo /tmp/akmods.der https://github.com/ublue-os/akmods/raw/main/certs/public_key_2.der
+    # Get the Public Certificates (pinned to akmods commit + SHA-256) — fail closed on mismatch.
+    AKMODS_COMMIT="c30e9467fe158dcf82c5176dec76d4373871ffda"
+    curl --retry 3 -Lo /tmp/kernel-sign.der "https://raw.githubusercontent.com/ublue-os/akmods/${AKMODS_COMMIT}/certs/public_key.der"
+    curl --retry 3 -Lo /tmp/akmods.der "https://raw.githubusercontent.com/ublue-os/akmods/${AKMODS_COMMIT}/certs/public_key_2.der"
+    echo "4e5c68474cb133fd8984d9599762cece9100c3e6cd8a9709aeaabd85dd9e70d1  /tmp/kernel-sign.der" | sha256sum -c -
+    echo "c01ef5e7fb9f6108fc58735f7eeb4dec084764a8aac404831e0ce3f9da63757d  /tmp/akmods.der" | sha256sum -c -
     openssl x509 -in /tmp/kernel-sign.der -out /tmp/kernel-sign.crt
     openssl x509 -in /tmp/akmods.der -out /tmp/akmods.crt
 

--- a/tests/test_justfile_secureboot.py
+++ b/tests/test_justfile_secureboot.py
@@ -1,0 +1,63 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+JUSTFILE = ROOT / "Justfile"
+
+EXPECTED_AKMODS_COMMIT = "c30e9467fe158dcf82c5176dec76d4373871ffda"
+EXPECTED_KERNEL_SIGN_SHA256 = (
+    "4e5c68474cb133fd8984d9599762cece9100c3e6cd8a9709aeaabd85dd9e70d1"
+)
+EXPECTED_AKMODS_KEY2_SHA256 = (
+    "c01ef5e7fb9f6108fc58735f7eeb4dec084764a8aac404831e0ce3f9da63757d"
+)
+
+
+class JustfileSecurebootTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = JUSTFILE.read_text(encoding="utf-8")
+        self.assertIn("secureboot", self.content)
+        # Extract the secureboot recipe section
+        self.recipe = self.content.split("secureboot $image=")[1].split("fedora_version", 1)[0]
+
+    def test_secureboot_uses_pinned_akmods_commit(self) -> None:
+        """secureboot recipe must pin the akmods commit."""
+        match = re.search(r'AKMODS_COMMIT="([0-9a-f]{40})"', self.recipe)
+        self.assertIsNotNone(match, "AKMODS_COMMIT not found in secureboot recipe")
+        assert match is not None
+        self.assertEqual(match.group(1), EXPECTED_AKMODS_COMMIT)
+
+    def test_no_mutable_main_cert_urls(self) -> None:
+        """secureboot recipe must not fetch certs from mutable main branch."""
+        self.assertNotIn(
+            "akmods/raw/main/certs/public_key.der",
+            self.recipe,
+            "Found unpinned public_key.der URL tracking main",
+        )
+        self.assertNotIn(
+            "akmods/raw/main/certs/public_key_2.der",
+            self.recipe,
+            "Found unpinned public_key_2.der URL tracking main",
+        )
+
+    def test_cert_checksums_verified_before_openssl(self) -> None:
+        """Both certs must be verified with sha256sum before openssl conversion."""
+        self.assertIn(EXPECTED_KERNEL_SIGN_SHA256, self.recipe)
+        self.assertIn(EXPECTED_AKMODS_KEY2_SHA256, self.recipe)
+
+        kernel_sha_pos = self.recipe.find(EXPECTED_KERNEL_SIGN_SHA256)
+        akmods_sha_pos = self.recipe.find(EXPECTED_AKMODS_KEY2_SHA256)
+        openssl_pos = self.recipe.find("openssl x509")
+
+        self.assertNotEqual(kernel_sha_pos, -1)
+        self.assertNotEqual(akmods_sha_pos, -1)
+        self.assertNotEqual(openssl_pos, -1)
+
+        self.assertLess(kernel_sha_pos, openssl_pos)
+        self.assertLess(akmods_sha_pos, openssl_pos)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses #1173 by pinning the public signing certificates downloaded in the `secureboot` recipe in `Justfile` to an immutable upstream commit on `ublue-os/akmods` and verifying their SHA-256 checksums before conversion and use.

## Problem

The `secureboot` recipe previously downloaded `certs/public_key.der` and `certs/public_key_2.der` from the floating `main` branch of `ublue-os/akmods` without an integrity guarantee. Because these certificates serve as the trust anchors for verifying kernel and module signatures with `sbverify`, fetching unverified keys from a mutable branch introduces a supply-chain vulnerability where a compromised or unexpectedly rotated key could lead to false verification.

## Solution

1. Pinned both URLs to immutable upstream commit `c30e9467fe158dcf82c5176dec76d4373871ffda`.
2. Verified both certificates against their independently confirmed SHA-256 hashes before conversion with `openssl x509`:
   - `certs/public_key.der`: `4e5c68474cb133fd8984d9599762cece9100c3e6cd8a9709aeaabd85dd9e70d1`
   - `certs/public_key_2.der`: `c01ef5e7fb9f6108fc58735f7eeb4dec084764a8aac404831e0ce3f9da63757d`
3. Fails closed immediately under `set -eou pipefail` if either checksum check fails, preventing conversion or mounting of unverified certificates.
4. Added unit test in `tests/test_justfile_secureboot.py` ensuring the commit pin, hash checks, and execution ordering remain enforced.

Note on #1174: PR #1174 combined #1172 and #1173 but was branched from `main` instead of `testing`, resulting in merge conflicts and 157 unrelated commits. This PR cleanly addresses #1173 in a single focused commit on `upstream/testing`.

## Validation

- Verified real upstream assets at commit `c30e9467fe158dcf82c5176dec76d4373871ffda` match the expected hashes byte-for-byte.
- Tested failure behavior: modified hash causes `sha256sum -c -` to exit with code 1 and halts execution before `openssl x509`.
- Tested success behavior: authentic downloads match hashes, convert cleanly with `openssl x509`, and exit with code 0.
- `just check`: syntax clean.
- `python3 -m unittest tests/test_justfile_secureboot.py`: 3 passed.
- `python3 -m unittest discover -s tests -p 'test_*.py'`: 65 passed.

Closes #1173

---
Gemini 3.7 flash high reasoning
