### PR TITLE
fix(security): consolidate Justfile supply-chain hardening (#1172, #1173)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -552,9 +552,12 @@ secureboot $image="bluefin" $tag="testing" $flavor="main":
     ${PODMAN} cp "$TMP":/usr/lib/modules/"${kernel_release}"/vmlinuz /tmp/vmlinuz
     ${PODMAN} rm "$TMP"
 
-    # Get the Public Certificates
-    curl --retry 3 -Lo /tmp/kernel-sign.der https://github.com/ublue-os/akmods/raw/main/certs/public_key.der
-    curl --retry 3 -Lo /tmp/akmods.der https://github.com/ublue-os/akmods/raw/main/certs/public_key_2.der
+    # Get the Public Certificates (pinned to akmods commit + SHA-256) — fail closed on mismatch.
+    AKMODS_COMMIT="c30e9467fe158dcf82c5176dec76d4373871ffda"
+    curl --retry 3 -Lo /tmp/kernel-sign.der "https://raw.githubusercontent.com/ublue-os/akmods/${AKMODS_COMMIT}/certs/public_key.der"
+    curl --retry 3 -Lo /tmp/akmods.der "https://raw.githubusercontent.com/ublue-os/akmods/${AKMODS_COMMIT}/certs/public_key_2.der"
+    echo "4e5c68474cb133fd8984d9599762cece9100c3e6cd8a9709aeaabd85dd9e70d1  /tmp/kernel-sign.der" | sha256sum -c -
+    echo "c01ef5e7fb9f6108fc58735f7eeb4dec084764a8aac404831e0ce3f9da63757d  /tmp/akmods.der" | sha256sum -c -
     openssl x509 -in /tmp/kernel-sign.der -out /tmp/kernel-sign.crt
     openssl x509 -in /tmp/akmods.der -out /tmp/akmods.crt
 

--- a/Justfile
+++ b/Justfile
@@ -484,6 +484,9 @@ verify-container container="" registry="ghcr.io/ublue-os" key="":
         trap 'rm -f "${COSIGN_INSTALL_PATH}"' EXIT
         curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
             -o "${COSIGN_INSTALL_PATH}"
+        # SHA-256 pinned from upstream cosign_checksums.txt for v3.1.1 — fail closed on mismatch.
+        COSIGN_SHA256="ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"
+        echo "${COSIGN_SHA256}  ${COSIGN_INSTALL_PATH}" | sha256sum -c -
         chmod +x "${COSIGN_INSTALL_PATH}"
         ${SUDOIF} install -m 0755 "${COSIGN_INSTALL_PATH}" /usr/local/bin/cosign
         echo "cosign installed: $(cosign version 2>/dev/null | awk '/GitVersion:/{print $2}')"

--- a/tests/test_justfile.py
+++ b/tests/test_justfile.py
@@ -1,0 +1,53 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+JUSTFILE = ROOT / "Justfile"
+
+EXPECTED_COSIGN_SHA256 = (
+    "ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc"
+)
+
+
+class JustfileCosignVerificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = JUSTFILE.read_text(encoding="utf-8")
+
+    def test_cosign_download_has_pinned_sha256(self) -> None:
+        """verify-container must pin the expected cosign v3.1.1 SHA-256."""
+        match = re.search(r'COSIGN_SHA256="([0-9a-f]{64})"', self.content)
+        self.assertIsNotNone(match, "COSIGN_SHA256 definition not found in Justfile")
+        assert match is not None
+        self.assertEqual(
+            match.group(1),
+            EXPECTED_COSIGN_SHA256,
+            "COSIGN_SHA256 does not match official cosign v3.1.1 linux-amd64 checksum",
+        )
+
+    def test_cosign_checksum_verified_before_install(self) -> None:
+        """sha256sum verification must occur before install -m 0755."""
+        self.assertIn("verify-container", self.content)
+        recipe_part = self.content.split("verify-container container=")[1].split(
+            "secureboot", 1
+        )[0]
+
+        sha_pos = recipe_part.find("sha256sum -c -")
+        install_pos = recipe_part.find("install -m 0755")
+
+        self.assertNotEqual(
+            sha_pos, -1, "sha256sum check not found in verify-container"
+        )
+        self.assertNotEqual(
+            install_pos, -1, "install command not found in verify-container"
+        )
+        self.assertLess(
+            sha_pos,
+            install_pos,
+            "sha256sum check must execute before install command",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_justfile_secureboot.py
+++ b/tests/test_justfile_secureboot.py
@@ -1,0 +1,63 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+JUSTFILE = ROOT / "Justfile"
+
+EXPECTED_AKMODS_COMMIT = "c30e9467fe158dcf82c5176dec76d4373871ffda"
+EXPECTED_KERNEL_SIGN_SHA256 = (
+    "4e5c68474cb133fd8984d9599762cece9100c3e6cd8a9709aeaabd85dd9e70d1"
+)
+EXPECTED_AKMODS_KEY2_SHA256 = (
+    "c01ef5e7fb9f6108fc58735f7eeb4dec084764a8aac404831e0ce3f9da63757d"
+)
+
+
+class JustfileSecurebootTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = JUSTFILE.read_text(encoding="utf-8")
+        self.assertIn("secureboot", self.content)
+        # Extract the secureboot recipe section
+        self.recipe = self.content.split("secureboot $image=")[1].split("fedora_version", 1)[0]
+
+    def test_secureboot_uses_pinned_akmods_commit(self) -> None:
+        """secureboot recipe must pin the akmods commit."""
+        match = re.search(r'AKMODS_COMMIT="([0-9a-f]{40})"', self.recipe)
+        self.assertIsNotNone(match, "AKMODS_COMMIT not found in secureboot recipe")
+        assert match is not None
+        self.assertEqual(match.group(1), EXPECTED_AKMODS_COMMIT)
+
+    def test_no_mutable_main_cert_urls(self) -> None:
+        """secureboot recipe must not fetch certs from mutable main branch."""
+        self.assertNotIn(
+            "akmods/raw/main/certs/public_key.der",
+            self.recipe,
+            "Found unpinned public_key.der URL tracking main",
+        )
+        self.assertNotIn(
+            "akmods/raw/main/certs/public_key_2.der",
+            self.recipe,
+            "Found unpinned public_key_2.der URL tracking main",
+        )
+
+    def test_cert_checksums_verified_before_openssl(self) -> None:
+        """Both certs must be verified with sha256sum before openssl conversion."""
+        self.assertIn(EXPECTED_KERNEL_SIGN_SHA256, self.recipe)
+        self.assertIn(EXPECTED_AKMODS_KEY2_SHA256, self.recipe)
+
+        kernel_sha_pos = self.recipe.find(EXPECTED_KERNEL_SIGN_SHA256)
+        akmods_sha_pos = self.recipe.find(EXPECTED_AKMODS_KEY2_SHA256)
+        openssl_pos = self.recipe.find("openssl x509")
+
+        self.assertNotEqual(kernel_sha_pos, -1)
+        self.assertNotEqual(akmods_sha_pos, -1)
+        self.assertNotEqual(openssl_pos, -1)
+
+        self.assertLess(kernel_sha_pos, openssl_pos)
+        self.assertLess(akmods_sha_pos, openssl_pos)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Consolidated landing of the security-hardening batch onto `testing`. Two reviewed, non-conflicting Justfile supply-chain fixes land together; the third item in the batch (PR #1229, libgda packages) is superseded by #1228 (commit 6195baa) already merged on `testing`.

### Included

- **fix(security): verify cosign binary checksum before install (#1172)** — `verify-container` downloaded the cosign v3.1.1 binary and installed it to `/usr/local/bin` with no integrity check. Now verifies the pinned SHA-256 (`ae1ecd…63fc`, from upstream `cosign_checksums.txt` for v3.1.1) before `chmod`/`install`. Fails closed under `set -eou pipefail`. Adds `tests/test_justfile.py`.
- **fix(security): pin and verify secureboot signing keys (#1173)** — `secureboot` fetched trust-anchor certificates (`certs/public_key.der`, `certs/public_key_2.der`) from the floating `ublue-os/akmods` main branch. Now pins to immutable commit `c30e9467fe158dcf82c5176dec76d4373871ffda` and verifies each cert's SHA-256 before `openssl x509` conversion. Adds `tests/test_justfile_secureboot.py`.

### Superseded

- **PR #1229** (libgda/libgda-sqlite): content fully contained in merged #1228 (6195baa) — same packages in `build_files/packages/base.toml` (lines 74–75) with stronger test coverage in `tests/unit/03-packages_test.bats`. Nothing further to land.

## Verification (consolidated state)

- `python3 tests/test_justfile.py` — 2 tests OK
- `python3 tests/test_justfile_secureboot.py` — 3 tests OK
- `python3 -m unittest discover -s tests -p 'test_*.py'` (CI `Unit tests` step) — 67 tests OK
- `bats tests/unit/03-packages_test.bats` — 12/12 OK
- `just --list` parses; `git diff --check` clean
- Pinned values re-verified against upstream: cosign v3.1.1 checksum matches sigstore release `cosign_checksums.txt`; both akmods cert SHA-256s match the pinned commit's blobs.

Closes #1172
Closes #1173

Refs #1210 (libgda portion landed via #1228; podman-compose request remains open)