### PR TITLE
fix(sec): pin secureboot enrollment key fetch to akmods commit + SHA-256

### DIFF
--- a/build_files/base/21-container-native-iso.sh
+++ b/build_files/base/21-container-native-iso.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 ROOT="${FAKE_ROOT:-}"
 IMAGE_INFO="${ROOT}/usr/share/ublue-os/image-info.json"
 ISO_CONFIG="${ROOT}/usr/lib/bootc-image-builder/iso.yaml"
-SBKEY_URL="https://github.com/ublue-os/akmods/raw/main/certs/public_key.der"
+# Pinned to a full commit SHA with a checked-in digest so a compromised or
+# rotated akmods main branch fails the build instead of enrolling a bad key.
+SBKEY_URL="https://github.com/ublue-os/akmods/raw/c30e9467fe158dcf82c5176dec76d4373871ffda/certs/public_key.der"
+SBKEY_SHA256="4e5c68474cb133fd8984d9599762cece9100c3e6cd8a9709aeaabd85dd9e70d1"
 
 IMAGE_REF="$(jq -r '."image-ref"' "${IMAGE_INFO}")"
 IMAGE_REF="${IMAGE_REF##*://}"
@@ -152,6 +155,7 @@ rsync -aAXUHKP --filter='-x security.selinux' /var/lib/flatpak "$target"
 EOF
 
 ghcurl "${SBKEY_URL}" --retry 15 -o "${ROOT}/etc/sb_pubkey.der"
+echo "${SBKEY_SHA256}  ${ROOT}/etc/sb_pubkey.der" | sha256sum -c -
 cat >"${ROOT}/usr/share/anaconda/post-scripts/secureboot-enroll-key.ks" <<'EOF'
 %post --erroronfail --nochroot
 set -oue pipefail

--- a/tests/unit/21-container-native-iso_test.bats
+++ b/tests/unit/21-container-native-iso_test.bats
@@ -90,6 +90,46 @@ case "$url" in
     https://ghcr.io/token*)
         echo '{"token":"test-registry-token"}'
         ;;
+    *certs/public_key.der)
+        if [[ -n "${STUB_SBKEY_TAMPER:-}" ]]; then
+            mkdir -p "$(dirname "$destination")"
+            printf 'tampered-key' >"$destination"
+            exit 0
+        fi
+        # The real ublue-os/akmods Secure Boot signing certificate, pinned at
+        # commit c30e9467fe158dcf82c5176dec76d4373871ffda. 21-container-native-iso.sh
+        # verifies this against a checked-in SHA-256, so the stub has to serve the
+        # genuine bytes rather than a placeholder.
+        mkdir -p "$(dirname "$destination")"
+        base64 -d >"$destination" <<'AKMODS_SBKEY'
+MIIFtjCCA56gAwIBAgIUffh69d7nONn6wvijghk3S+ChgKcwDQYJKoZIhvcNAQELBQAwdTEXMBUG
+A1UECgwOVW5pdmVyc2FsIEJsdWUxFzAVBgNVBAsMDmtlcm5lbCBzaWduaW5nMRUwEwYDVQQDDAx1
+Ymx1ZSBrZXJuZWwxKjAoBgkqhkiG9w0BCQEWG3NlY3VyaXR5QHVuaXZlcnNhbC1ibHVlLm9yZzAg
+Fw0yNDA3MTEwMzA3MDlaGA8yMTI0MDYxNzAzMDcwOVowdTEXMBUGA1UECgwOVW5pdmVyc2FsIEJs
+dWUxFzAVBgNVBAsMDmtlcm5lbCBzaWduaW5nMRUwEwYDVQQDDAx1Ymx1ZSBrZXJuZWwxKjAoBgkq
+hkiG9w0BCQEWG3NlY3VyaXR5QHVuaXZlcnNhbC1ibHVlLm9yZzCCAiIwDQYJKoZIhvcNAQEBBQAD
+ggIPADCCAgoCggIBAJrjC/NmzXRnUWisoRu8vUKr8jq7QqlYWVSdT2jvsuA9qyQ/GKBg5A7kBV+X
+pKJCV1M7QkiUvQ7nn2pAYZAjWbRABBcoHlN1eFg7wTVP1C+wV5mdsXO/fBs896GCRcI2Na+HJQ3o
+2m8PdCWGzgOYJCe9zHIwdbm6mPjgw56pIc50c7OHqU3qFsFZTXrJkq/cvyyr+Ue6j4JcJERm1IVM
+ktRJ6nZ7NmmWjYTGSlBQl9YIT2DktSzihxM9f23R1RujdFmy6I6pMwSB3F4ehhFWlgvZa1/AGaXg
+7dE06RwT8A5U+fb3iV/V66JaisiL8rISvmY7a5LMRMGRNlVF54JeF08N/w/ylOQb6cSE6H6Ug60h
+n2sbFy0S7rHQKXb8ZA5Y59na4EfLRnGGJQDWT+znsBTkJ730GvrbWzA1HfzwazeHQXSzyWf3h+d7
+tRM9DwjGz3RZ4YNQuttD3NcBBo/x8QZtOjbJGmPNg3k1OQ6m0nSBCf7lbtD9KMoGfAf2hF0y+Pw4
+3AARhJyhrzzIvhUYXtj/jPn+qQa7x+h/LBqdRVXqYRTnDddqM8OW8/m2oNRWAAqfrCxfNZjD5x1/
+1trzuw4flLM4xMxEele8x0d1rLoAfUIWU0FjWIJF1mCtrpXKNtfSpAyXylxzGTADGPAW+JrALu5/
+nVZGq8aBtQJOSlp7AgMBAAGjPDA6MAwGA1UdEwEB/wQCMAAwCwYDVR0PBAQDAgeAMB0GA1UdDgQW
+BBQsJQYVWLUCDEsNnKVgYuAMbNsEajANBgkqhkiG9w0BAQsFAAOCAgEAUp+arzHK6qsFtCL++BSJ
+CManvz9tb5IwiqQXyQgh2XmOcALh/JN63evdc2/ECdBBD9qO/0H+a8u59A9C4EqghKFtTsb50vbM
+gJe/naAxuWU98oT9eqnAMnHJnr4FWY5rGP3hbxbt51h5nUmcX5dpgOfFmu3bPpPYii9Ky/wN/KGA
+QBB7eOErbwRZHVFBtlKdN9Vz1UH0LVa1LyPyz8F60Yfjz0waQxm7T0Idx74yCJbb1PX/1s71FHSO
+qSlFFycYsN5bBbS8DPTThxjcQjMpRHR+hhW6vPVflphRExGtBY3FP/rOZbWS+LlEJlWmkBD8WPMb
+t71fDSpf3R9St7NJu6KtuiCAbrGpkGmhKYQOVVNNO5Uz127UlC7Llt7KUh+ftfIVPGuFyBAhV5jW
+2T+5FbT9fARITlD33TaAXgzALkchz1+koiYhxW3SPVdjbkzowae5V+D9yp7kemY3yBT269D7BOwl
+PAzr2ncSbm6v54s59Wx60rOKq087FakK33YDPdd7guqwm5lQWiEMWIS5MHsNDcqeaisz3KPe5KEa
+P2BEkBuVdZGBLwelO8SCJDoQH3ULK3mhL0nu7LfehYBEdj0ZaBIO6V2ej+Cx1uR7Cf4PKlLja/IA
+ymEj6a8OJMN6+0pfX3u8DaO51gzKIn1Aumx5L76B64rp7LVWRpnwGPs=
+AKMODS_SBKEY
+        ;;
     *)
         mkdir -p "$(dirname "$destination")"
         printf 'test-key' >"$destination"
@@ -263,4 +303,17 @@ print("\n".join(lines[start:end + 1]))
 
     run grep -F 'nonempty-boot' "${CONTAINERFILE}"
     [ "$status" -ne 0 ]
+}
+
+@test "Secure Boot enrollment key failing its SHA-256 aborts the build" {
+    # The pinned digest is the only thing standing between a rotated or
+    # compromised akmods key and Secure Boot enrollment on first boot, so a
+    # mismatch must fail the build rather than enroll the key.
+    STUB_SBKEY_TAMPER=1 run bash "${ISO_SCRIPT}"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'sha256sum'* || "$output" == *'FAILED'* ]]
+
+    # ...and the bad key must not be left staged for enrollment.
+    run grep -Fq 'tampered-key' "${TEST_ROOT}/etc/sb_pubkey.der"
+    [ "$status" -ne 0 ] || [ ! -s "${TEST_ROOT}/usr/share/anaconda/post-scripts/secureboot-enroll-key.ks" ]
 }


### PR DESCRIPTION
## What problem are you solving?

`build_files/base/21-container-native-iso.sh` fetched the Secure Boot MOK enrollment key from `ublue-os/akmods` main-branch HEAD with no integrity check, so a rotated or compromised key would be baked into every ISO and enrolled into users' Secure Boot trust on first boot with nothing to catch it. This is the change from #1160, replayed onto `testing` so it is reviewable and can actually run CI.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

Two commits, two files:

1. **`21-container-native-iso.sh`** (+5/−1, original commit by `sec-check[bot]`, authorship preserved) — pins `SBKEY_URL` to commit `c30e9467fe158dcf82c5176dec76d4373871ffda` and verifies the download against a checked-in `SBKEY_SHA256`, failing closed on mismatch.

2. **`tests/unit/21-container-native-iso_test.bats`** (+53) — new, added here. The fix alone turned 4 of the 6 existing tests red: the `ghcurl` stub served a `test-key` placeholder, so `sha256sum -c` failed and took the script down under `set -euo pipefail`. The stub now serves the genuine akmods certificate, so the verification runs for real instead of being bypassed, plus a negative test that a mismatched key aborts the build.

I rejected the smaller fix of making `SBKEY_SHA256` env-overridable (`${SBKEY_SHA256:-...}`) — that would let anything controlling the build environment neuter the exact control being added.

### Why a new PR rather than pushing to #1160

#1160 targets `testing` but was branched from `main`, so its diff carries the whole `main`↔`testing` drift: **162 changed files, 157 commits, +7494/−4998**, for a change that is genuinely +5/−1. It is `mergeable_state: dirty` and GitHub's "Update branch" cannot resolve it. Per the cherry-pick recipe in the #1063 review, replaying the single real commit onto current `testing` reduces it to the actual change. #1160 should be closed in favour of this once reviewed.

The same drift affects #1148, #1165 and #1168, which still need the same treatment. Separately, **#1174 is already fully present on `testing`** — both the cosign SHA-256 check and this same akmods pin — and can simply be closed.

## Testing

- [ ] `just check` passes — `just` is not available in this environment; not run
- [ ] `pre-commit run --all-files` passes — `pre-commit` is not available in this environment; not run
- [x] Documentation updated when a reusable procedure or source-of-truth fact changed — n/a, no procedure or source-of-truth change
- [ ] Build tested locally — not run

Run locally against this branch:

- `bats tests/unit/` — **231/231 pass, 0 failures**
- `python3 -m unittest discover -s tests -p 'test_*.py'` — **67 pass**
- `python3 scripts/check-testsuite-workflow-ref.py` — pass
- `python3 scripts/check-renovate-automerge-auth.py` — pass
- Baseline check: `origin/testing` alone is 6/6 on this test file, so the 4 failures were caused by the fix and are resolved here.
- The pinned digest `4e5c6847…9e70d1` was re-verified by fetching the file from the pinned commit and hashing it — matches byte-for-byte. It also matches the digest already pinned for the same certificate in `Justfile` on `testing`.
- The negative test was confirmed non-vacuous: deleting the `sha256sum -c -` line turns it red.

## Checklist

- [x] Conventional commit message (`fix:`, `test:`)
- [x] No hardcoded secrets or credentials — the embedded blob is `ublue-os/akmods`' **public** signing certificate, already fetched by this script at build time
- [x] Package additions follow COPR isolation rules — n/a, no package changes

## Community verification (bug-fix PRs)

After the next build ships, `just secureboot` and the ISO build path both fetch the enrollment key from a pinned commit and abort on digest mismatch. To verify the gate is live, change a byte of the expected digest locally and confirm the build fails at `sha256sum -c -` rather than proceeding to enroll the key.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q73RnSt6xLbvh7T6ETCdcg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q73RnSt6xLbvh7T6ETCdcg)_